### PR TITLE
chore: .gitignore에 *.stackdump 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ out/
 ### VS Code ###
 .vscode/
 
+### OS generated files ###
+*.stackdump
+
 ### Claude Code ###
 .claude/
 


### PR DESCRIPTION
## Summary
- Windows Git Bash 크래시 로그 파일(*.stackdump)을 .gitignore에 추가

## Test plan
- [x] 불필요한 파일이 git status에 표시되지 않음 확인

🤖 Generated with [Claude Code](https://claude.ai/code)