### PR TITLE
feat(android): 네트워크 설정 및 API 클라이언트 구성

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -21,12 +22,16 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080\"")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            buildConfigField("String", "BASE_URL", "\"https://api.echo.com\"")
         }
     }
     compileOptions {
@@ -38,6 +43,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -50,6 +56,14 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+
+    // Network
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.kotlinx.serialization)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
+    implementation(libs.kotlinx.serialization.json)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
@@ -1,0 +1,52 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.BuildConfig
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
+
+object ApiClient {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+        encodeDefaults = true
+    }
+
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = if (BuildConfig.DEBUG) {
+            HttpLoggingInterceptor.Level.BODY
+        } else {
+            HttpLoggingInterceptor.Level.NONE
+        }
+    }
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .build()
+
+    val conversationApi: ConversationApi by lazy {
+        retrofit.create(ConversationApi::class.java)
+    }
+
+    val diaryApi: DiaryApi by lazy {
+        retrofit.create(DiaryApi::class.java)
+    }
+
+    val userApi: UserApi by lazy {
+        retrofit.create(UserApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiResult.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiResult.kt
@@ -1,0 +1,74 @@
+package com.example.graduation_project.data.api
+
+import retrofit2.HttpException
+import java.io.IOException
+
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class Error(val exception: ApiException) : ApiResult<Nothing>()
+}
+
+sealed class ApiException(
+    override val message: String,
+    override val cause: Throwable? = null
+) : Exception(message, cause) {
+
+    data class NetworkError(
+        override val message: String = "네트워크 연결을 확인해주세요",
+        override val cause: Throwable? = null
+    ) : ApiException(message, cause)
+
+    data class ServerError(
+        val code: Int,
+        override val message: String = "서버 오류가 발생했습니다",
+        override val cause: Throwable? = null
+    ) : ApiException(message, cause)
+
+    data class ClientError(
+        val code: Int,
+        override val message: String = "요청 오류가 발생했습니다",
+        override val cause: Throwable? = null
+    ) : ApiException(message, cause)
+
+    data class UnknownError(
+        override val message: String = "알 수 없는 오류가 발생했습니다",
+        override val cause: Throwable? = null
+    ) : ApiException(message, cause)
+}
+
+suspend fun <T> safeApiCall(apiCall: suspend () -> T): ApiResult<T> {
+    return try {
+        ApiResult.Success(apiCall())
+    } catch (e: IOException) {
+        ApiResult.Error(ApiException.NetworkError(cause = e))
+    } catch (e: HttpException) {
+        val code = e.code()
+        val error = when {
+            code in 400..499 -> ApiException.ClientError(
+                code = code,
+                message = getClientErrorMessage(code),
+                cause = e
+            )
+            code in 500..599 -> ApiException.ServerError(
+                code = code,
+                message = "서버 오류가 발생했습니다 ($code)",
+                cause = e
+            )
+            else -> ApiException.UnknownError(cause = e)
+        }
+        ApiResult.Error(error)
+    } catch (e: Exception) {
+        ApiResult.Error(ApiException.UnknownError(cause = e))
+    }
+}
+
+private fun getClientErrorMessage(code: Int): String = when (code) {
+    400 -> "잘못된 요청입니다"
+    401 -> "인증이 필요합니다"
+    403 -> "접근 권한이 없습니다"
+    404 -> "요청한 리소스를 찾을 수 없습니다"
+    409 -> "요청 충돌이 발생했습니다"
+    422 -> "처리할 수 없는 요청입니다"
+    429 -> "요청이 너무 많습니다. 잠시 후 다시 시도해주세요"
+    else -> "요청 오류가 발생했습니다 ($code)"
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ConversationApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ConversationApi.kt
@@ -1,0 +1,27 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.model.ConversationResponse
+import com.example.graduation_project.data.model.HealthData
+import com.example.graduation_project.data.model.MessageRequest
+import okhttp3.MultipartBody
+import retrofit2.http.Body
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface ConversationApi {
+
+    @POST("/api/conversations/start")
+    suspend fun startConversation(
+        @Body healthData: HealthData
+    ): ConversationResponse
+
+    @Multipart
+    @POST("/api/conversations/message")
+    suspend fun sendMessage(
+        @Part audio: MultipartBody.Part
+    ): ConversationResponse
+
+    @POST("/api/conversations/end")
+    suspend fun endConversation(): ConversationResponse
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/DiaryApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/DiaryApi.kt
@@ -1,0 +1,14 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.model.Diary
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface DiaryApi {
+
+    @GET("/api/diaries")
+    suspend fun getDiaries(): List<Diary>
+
+    @GET("/api/diaries/{id}")
+    suspend fun getDiary(@Path("id") id: Long): Diary
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
@@ -1,0 +1,22 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.model.User
+import com.example.graduation_project.data.model.UserPreferences
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+
+interface UserApi {
+
+    @GET("/api/users/me")
+    suspend fun getUser(): User
+
+    @PUT("/api/users/me")
+    suspend fun updateUser(@Body user: User): User
+
+    @GET("/api/users/me/preferences")
+    suspend fun getPreferences(): UserPreferences
+
+    @PUT("/api/users/me/preferences")
+    suspend fun updatePreferences(@Body preferences: UserPreferences): UserPreferences
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
@@ -1,0 +1,23 @@
+package com.example.graduation_project.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConversationResponse(
+    val sessionId: String? = null,
+    val message: String? = null,
+    val audioUrl: String? = null
+)
+
+@Serializable
+data class MessageRequest(
+    val text: String
+)
+
+@Serializable
+data class HealthData(
+    val sleepDuration: Int? = null,
+    val steps: Int? = null,
+    val exerciseDistance: Double? = null,
+    val exerciseActivity: String? = null
+)

--- a/android/app/src/main/java/com/example/graduation_project/data/model/DiaryModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/DiaryModels.kt
@@ -1,0 +1,13 @@
+package com.example.graduation_project.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Diary(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val createdAt: String,
+    val weather: String? = null,
+    val mood: String? = null
+)

--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -1,0 +1,19 @@
+package com.example.graduation_project.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class User(
+    val id: Long,
+    val name: String,
+    val age: Int? = null,
+    val birthday: String? = null
+)
+
+@Serializable
+data class UserPreferences(
+    val hobby: String? = null,
+    val occupation: String? = null,
+    val familyRelation: String? = null,
+    val preferredTopics: List<String> = emptyList()
+)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.3"
 composeBom = "2024.09.00"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+kotlinxSerializationJson = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,8 +28,16 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+# Network
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- Retrofit 2.11 + OkHttp 4.12 의존성 추가
- kotlinx-serialization을 JSON 컨버터로 사용
- BuildConfig로 BASE_URL 환경 분리 (debug: `http://10.0.2.2:8080`, release: production)
- API 인터페이스 정의 (ConversationApi, DiaryApi, UserApi)
- 공통 에러 핸들링 (`ApiResult`, `ApiException`)

## 구조
```
data/
├─ api/
│   ├─ ApiClient.kt          # Retrofit 설정
│   ├─ ApiResult.kt          # 공통 에러 핸들링
│   ├─ ConversationApi.kt    # 대화 API
│   ├─ DiaryApi.kt           # 일기 API
│   └─ UserApi.kt            # 사용자 API
└─ model/
    ├─ ConversationModels.kt
    ├─ DiaryModels.kt
    └─ UserModels.kt
```

## Test plan
- [x] `./gradlew assembleDebug` 빌드 성공 확인
- [ ] 에뮬레이터에서 로컬 서버 연동 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)