### PR TITLE
feat(android): ConversationRepository 추가 및 ViewModel API 연동 개선  

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/repository/ConversationRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/ConversationRepository.kt
@@ -1,0 +1,32 @@
+package com.example.graduation_project.data.repository
+
+import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.model.ConversationResponse
+import com.example.graduation_project.data.api.ConversationApi
+import com.example.graduation_project.data.model.HealthData
+import okhttp3.MultipartBody
+
+class ConversationRepository(
+    private val conversationApi: ConversationApi = ApiClient.conversationApi
+) {
+
+    suspend fun startConversation(healthData: HealthData): ApiResult<ConversationResponse> {
+        return safeApiCall {
+            conversationApi.startConversation(healthData)
+        }
+    }
+
+    suspend fun sendMessage(audio: MultipartBody.Part): ApiResult<ConversationResponse> {
+        return safeApiCall {
+            conversationApi.sendMessage(audio)
+        }
+    }
+
+    suspend fun endConversation(): ApiResult<ConversationResponse> {
+        return safeApiCall {
+            conversationApi.endConversation()
+        }
+    }
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                     
  - ConversationRepository 생성하여 API 호출을 Repository 레이어로 분리 (Clean Architecture)
  - ConversationViewModel에서 API 직접 호출 → Repository 경유로 변경
  - 에러 타입별 사용자 친화적 메시지 처리 추가
  - 대화 시작 재시도 기능 추가 (retryStartConversation)

  ## 완료 태스크

  ### T1-4: ConversationRepository 구현
  - startConversation() API 호출
  - 응답 파싱 (conversationId, 첫 인사 텍스트, 음성 Base64)

  ### T1-5: ConversationViewModel 구현
  - 대화 시작 로직
  - StateFlow로 UI 상태 관리

  ### T1-6: 에러 처리 및 재시도
  - 네트워크 에러 핸들링
  - 재시도 UI 연동

  ## 변경 파일
  - `data/repository/ConversationRepository.kt` (신규) - API 호출 래퍼
  - `presentation/conversation/ConversationViewModel.kt` (수정) - Repository 연동 + 에러 처리 개선

  ## Test plan
  - [x] assembleDebug 빌드 성공 확인
  - [ ] 서버 연동 통합 테스트 (T7-3에서 진행 예정)