### PR TITLE
fix: KSP 및 Room 버전 호환성 수정

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 kotlin = "2.2.0"
-ksp = "2.2.0-2.0.0"
+ksp = "2.2.0-2.0.2"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -15,7 +15,7 @@ okhttp = "4.12.0"
 kotlinxSerializationJson = "1.7.3"
 coroutines = "1.8.1"
 androidVad = "2.0.10"
-room = "2.6.1"
+room = "2.8.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                     
  - KSP `2.2.0-2.0.0` → `2.2.0-2.0.2`: Maven 저장소에 존재하지 않는 버전 수정                                                                                                    
  - Room `2.6.1` → `2.8.4`: KSP2 (Kotlin 2.2.0) 호환성 확보

  ## 원인
  T4-1 (Room DB 설정) 머지 후 빌드 실패 발생
  1. KSP 플러그인 `2.2.0-2.0.0`이 Maven에 없어 resolve 실패
  2. Room 2.6.1이 KSP2와 호환되지 않아 `unexpected jvm signature V` 오류

  ## 변경 파일
  - `gradle/libs.versions.toml` (2줄 변경)

  ## Test plan
  - [x] `./gradlew assembleDebug` 빌드 성공 확인