### PR TITLE
feat(android): 음성 설정 모델 및 UserRepository 추가 (US 2.3)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -15,5 +15,12 @@ data class UserPreferences(
     val hobby: String? = null,
     val occupation: String? = null,
     val familyRelation: String? = null,
-    val preferredTopics: List<String> = emptyList()
+    val preferredTopics: List<String> = emptyList(),
+    val voiceSettings: VoiceSettings? = null
+)
+
+@Serializable
+data class VoiceSettings(
+    val voiceSpeed: Double = 1.0,
+    val voiceTone: String = "warm"
 )

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
@@ -1,0 +1,24 @@
+package com.example.graduation_project.data.repository
+
+import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.api.UserApi
+import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.model.UserPreferences
+
+class UserRepository(
+    private val userApi: UserApi = ApiClient.userApi
+) {
+
+    suspend fun getPreferences(): ApiResult<UserPreferences> {
+        return safeApiCall {
+            userApi.getPreferences()
+        }
+    }
+
+    suspend fun updatePreferences(preferences: UserPreferences): ApiResult<UserPreferences> {
+        return safeApiCall {
+            userApi.updatePreferences(preferences)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
  - T2-7: VoiceSettings 모델 추가 (voiceSpeed, voiceTone) — 서버 VoiceSettings.java와 1:1 매핑
  - UserPreferences에 voiceSettings 필드 추가
  - UserRepository 추가 (사용자 설정 조회/수정 API 호출 준비)

  ## 참고
  - 서버에 PUT /api/users/me/preferences 엔드포인트가 아직 없어 실제 전송 로직은 미구현
  - 서버 API 완성 후 ViewModel에서 UserRepository 연동 예정

  ## 변경 파일
  - `UserModels.kt` — VoiceSettings 모델 추가, UserPreferences에 필드 추가
  - `UserRepository.kt` — 신규 파일 (사용자 설정 API 호출)

  ## Test plan
  - [x] `./gradlew assembleDebug` 빌드 성공 확인