### PR TITLE
feat(android): 음성 속도 설정 다이얼로그 구현 (T9-1)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -4,19 +4,30 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.presentation.settings.VoiceSettingsDialog
 import com.example.graduation_project.presentation.conversation.components.ActiveConversationView
 import com.example.graduation_project.presentation.conversation.components.ConversationControls
 import com.example.graduation_project.presentation.conversation.components.EmptyConversationView
@@ -62,13 +73,22 @@ fun ConversationScreen(
         }
     }
 
+    // 설정 다이얼로그 상태
+    var showSettingsDialog by remember { mutableStateOf(false) }
+
     // 화면 구성
     ConversationScreenContent(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         onStartClick = viewModel::startConversation,
-        onEndClick = viewModel::endConversation
+        onEndClick = viewModel::endConversation,
+        onSettingsClick = { showSettingsDialog = true }
     )
+
+    // 음성 설정 다이얼로그
+    if (showSettingsDialog) {
+        VoiceSettingsDialog(onDismiss = { showSettingsDialog = false })
+    }
 }
 
 /**
@@ -80,7 +100,8 @@ private fun ConversationScreenContent(
     uiState: ConversationUiState,
     snackbarHostState: SnackbarHostState,
     onStartClick: () -> Unit,
-    onEndClick: () -> Unit
+    onEndClick: () -> Unit,
+    onSettingsClick: () -> Unit = {}
 ) {
     // 따뜻한 느낌 + 고대비 색상 (어르신 접근성 고려)
     val backgroundColor = Color(0xFFFFFDF9)  // 아주 연한 아이보리
@@ -99,6 +120,25 @@ private fun ConversationScreenContent(
             Box(
                 modifier = Modifier.weight(1f)
             ) {
+                // 대화 시작 전: 설정 버튼 (우측 상단)
+                if (!uiState.isConversationActive) {
+                    IconButton(
+                        onClick = onSettingsClick,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(16.dp)
+                            .height(48.dp),
+                        colors = IconButtonDefaults.iconButtonColors(
+                            contentColor = Color(0xFF666666)
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = "음성 설정"
+                        )
+                    }
+                }
+
                 if (uiState.isConversationActive) {
                     // 대화 중: 상태 + AI 응답 + 사용자 음성 + 동심원 애니메이션
                     val currentAiMessage = uiState.messages

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsDialog.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsDialog.kt
@@ -1,0 +1,150 @@
+package com.example.graduation_project.presentation.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun VoiceSettingsDialog(
+    onDismiss: () -> Unit,
+    viewModel: VoiceSettingsViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "음성 속도 설정",
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "${String.format("%.1f", uiState.voiceSpeed)}x",
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = when {
+                        uiState.voiceSpeed < 1.0f -> "느리게"
+                        uiState.voiceSpeed > 1.0f -> "빠르게"
+                        else -> "보통"
+                    },
+                    fontSize = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Slider(
+                    value = uiState.voiceSpeed,
+                    onValueChange = viewModel::onSpeedChange,
+                    valueRange = 0.8f..1.2f,
+                    steps = 3,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = SliderDefaults.colors(
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+
+                // 느리게 / 빠르게 라벨
+                Spacer(modifier = Modifier.height(4.dp))
+
+                androidx.compose.foundation.layout.Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "느리게",
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = "빠르게",
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 저장 상태 표시
+                if (uiState.isSaved) {
+                    Text(
+                        text = "저장되었습니다",
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+
+                if (uiState.errorMessage != null) {
+                    Text(
+                        text = uiState.errorMessage!!,
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text(
+                        text = "닫기",
+                        fontSize = 18.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsViewModel.kt
@@ -1,0 +1,91 @@
+package com.example.graduation_project.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.model.VoiceSettings
+import com.example.graduation_project.data.repository.UserRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class VoiceSettingsUiState(
+    val voiceSpeed: Float = 1.0f,
+    val isLoading: Boolean = false,
+    val isSaved: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class VoiceSettingsViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(VoiceSettingsUiState())
+    val uiState: StateFlow<VoiceSettingsUiState> = _uiState.asStateFlow()
+
+    private val repository = UserRepository()
+    private var debounceJob: Job? = null
+
+    init {
+        loadSettings()
+    }
+
+    private fun loadSettings() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            when (val result = repository.getPreferences()) {
+                is ApiResult.Success -> {
+                    val speed = result.data.voiceSettings?.voiceSpeed?.toFloat() ?: 1.0f
+                    _uiState.update {
+                        it.copy(
+                            voiceSpeed = speed,
+                            isLoading = false
+                        )
+                    }
+                }
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = "설정을 불러올 수 없습니다"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun onSpeedChange(speed: Float) {
+        // 0.1 단위로 반올림
+        val rounded = (Math.round(speed * 10.0f) / 10.0f)
+        _uiState.update { it.copy(voiceSpeed = rounded, isSaved = false) }
+
+        // 기존 debounce 취소 후 0.5초 대기
+        debounceJob?.cancel()
+        debounceJob = viewModelScope.launch {
+            delay(500L)
+            saveSpeed(rounded)
+        }
+    }
+
+    private suspend fun saveSpeed(speed: Float) {
+        val preferences = UserPreferences(
+            voiceSettings = VoiceSettings(voiceSpeed = speed.toDouble())
+        )
+
+        when (repository.updatePreferences(preferences)) {
+            is ApiResult.Success -> {
+                _uiState.update { it.copy(isSaved = true) }
+            }
+            is ApiResult.Error -> {
+                _uiState.update {
+                    it.copy(errorMessage = "저장에 실패했습니다")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 ---                                                                                                                                                                            
  Summary         
                                                                                                                                                                                 
  - 경도인지장애 어르신이 AI 음성의 말하기 속도를 직접 조절할 수 있는 설정 다이얼로그를 구현했습니다.
  - 대화 화면(ConversationScreen)에서 대화 시작 전 우측 상단 설정 아이콘을 통해 진입합니다.
  - Material3 Slider로 0.8x(느리게) ~ 1.2x(빠르게) 범위를 0.1 단위로 조절할 수 있으며, 슬라이더를 멈춘 후 0.5초 뒤 서버에 자동 저장됩니다.
  - 서버에 TTS 속도 적용 로직이 이미 존재하므로, 저장 후 다음 메시지부터 변경된 속도가 반영됩니다.

  변경 파일

  신규
  파일: VoiceSettingsViewModel.kt
  설명: 음성 속도 상태 관리. loadSettings()로 서버에서 현재 속도 조회, onSpeedChange()에서 0.5초 debounce 후 UserRepository.updatePreferences() 호출
  ────────────────────────────────────────
  파일: VoiceSettingsDialog.kt
  설명: 음성 속도 설정 다이얼로그 UI. PermissionDialog 패턴(Dialog + Card) 재사용. 현재 속도값(36sp), 느리게/보통/빠르게 라벨, 저장 완료/에러 상태 표시 포함

 수정
ConversationScreen.kt :  대화 시작 전 화면 우측 상단에 Settings 아이콘 버튼 추가. 클릭 시 VoiceSettingsDialog 표시, 대화 중에는 아이콘 숨김

  기존 재사용 코드

  - UserRepository — getPreferences(), updatePreferences()
  - UserApi — GET/PUT /api/users/me/preferences
  - UserModels — VoiceSettings(voiceSpeed, voiceTone), UserPreferences
  - PermissionDialog — Dialog + Card 레이아웃 패턴, 어르신 접근성 스타일(24sp 제목, 56dp 버튼)

  Test plan

  - 대화 시작 전 화면에서 우측 상단 설정 아이콘 노출 확인
  - 대화 중에는 설정 아이콘이 숨겨지는지 확인
  - 설정 아이콘 클릭 시 음성 속도 다이얼로그 표시 확인
  - 다이얼로그 진입 시 서버에서 현재 속도를 불러오는지 확인
  - Slider로 0.8x ~ 1.2x 범위를 0.1 단위로 조절 가능한지 확인
  - 슬라이더 변경 후 0.5초 뒤 "저장되었습니다" 텍스트 표시 확인
  - 닫기 버튼으로 다이얼로그 정상 종료 확인
  - ./gradlew assembleDebug 빌드 성공 확인 ✅
