### PR TITLE
feat(health): Health Connect 실제 데이터 수집/정제 구현

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
@@ -5,11 +5,19 @@ import android.content.Intent
 import android.net.Uri
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
 import com.example.graduation_project.domain.health.HealthConnectAvailability
+import com.example.graduation_project.domain.health.SleepSummary
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 
 /**
  * Health Connect SDK 초기화 및 가용성 확인 담당.
@@ -28,7 +36,8 @@ class HealthConnectManager(private val context: Context) {
             HealthPermission.getReadPermission(HeartRateRecord::class),
             HealthPermission.getReadPermission(SleepSessionRecord::class),
             HealthPermission.getReadPermission(StepsRecord::class),
-            HealthPermission.getReadPermission(ExerciseSessionRecord::class)
+            HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+            HealthPermission.getReadPermission(DistanceRecord::class)
         )
     }
 
@@ -53,6 +62,114 @@ class HealthConnectManager(private val context: Context) {
         val client = HealthConnectClient.getOrCreate(context)
         val granted = client.permissionController.getGrantedPermissions()
         return granted.containsAll(REQUIRED_PERMISSIONS)
+    }
+
+    /**
+     * 어제 정오(12:00) → 오늘 정오(12:00) 범위의 수면 데이터 읽기.
+     * - minutes: 전체 세션 합산 수면 시간(분)
+     * - startTime: 가장 긴 세션(주 수면)의 시작 시각 "HH:mm" → 서버 낮잠 분류용
+     */
+    suspend fun readYesterdaySleep(): SleepSummary {
+        val client = HealthConnectClient.getOrCreate(context)
+        val zone = ZoneId.systemDefault()
+        val today = LocalDate.now(zone)
+        val rangeStart = today.minusDays(1).atTime(LocalTime.NOON).atZone(zone).toInstant()
+        val rangeEnd = today.atTime(LocalTime.NOON).atZone(zone).toInstant()
+
+        val response = client.readRecords(
+            ReadRecordsRequest(SleepSessionRecord::class, TimeRangeFilter.between(rangeStart, rangeEnd))
+        )
+        if (response.records.isEmpty()) return SleepSummary(null, null)
+
+        val totalMinutes = response.records.sumOf { record ->
+            (record.endTime.toEpochMilli() - record.startTime.toEpochMilli()) / 60_000L
+        }.toInt()
+
+        val mainSession = response.records.maxByOrNull { record ->
+            record.endTime.toEpochMilli() - record.startTime.toEpochMilli()
+        }
+        val startTimeStr = mainSession?.let {
+            val localTime = it.startTime.atZone(zone).toLocalTime()
+            String.format("%02d:%02d", localTime.hour, localTime.minute)
+        }
+
+        return SleepSummary(minutes = totalMinutes, startTime = startTimeStr)
+    }
+
+    /**
+     * 오늘 자정(00:00) → 현재 범위의 걸음 수 합산.
+     */
+    suspend fun readTodaySteps(): Int? {
+        val client = HealthConnectClient.getOrCreate(context)
+        val zone = ZoneId.systemDefault()
+        val startTime = LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val endTime = Instant.now()
+
+        val response = client.readRecords(
+            ReadRecordsRequest(StepsRecord::class, TimeRangeFilter.between(startTime, endTime))
+        )
+        if (response.records.isEmpty()) return null
+
+        return response.records.sumOf { it.count }.toInt()
+    }
+
+    /**
+     * 최근 24시간 내 가장 최근 ExerciseSessionRecord 읽기.
+     * 거리는 DistanceRecord 우선, 없으면 laps 폴백.
+     */
+    suspend fun readLatestExercise(): Pair<Double?, String?> {
+        val client = HealthConnectClient.getOrCreate(context)
+        val endTime = Instant.now()
+        val startTime = endTime.minusSeconds(24 * 60 * 60L)
+
+        val exerciseResponse = client.readRecords(
+            ReadRecordsRequest(ExerciseSessionRecord::class, TimeRangeFilter.between(startTime, endTime))
+        )
+        if (exerciseResponse.records.isEmpty()) return Pair(null, null)
+
+        val latest = exerciseResponse.records.maxByOrNull { it.endTime }
+            ?: return Pair(null, null)
+
+        val distanceKm = readExerciseDistanceKm(client, latest.startTime, latest.endTime)
+            ?: run {
+                val meters = latest.laps.mapNotNull { it.length?.inMeters }.sum()
+                if (meters > 0.0) meters / 1000.0 else null
+            }
+
+        return Pair(distanceKm, exerciseTypeToKorean(latest.exerciseType))
+    }
+
+    private suspend fun readExerciseDistanceKm(
+        client: HealthConnectClient,
+        startTime: Instant,
+        endTime: Instant
+    ): Double? {
+        val response = client.readRecords(
+            ReadRecordsRequest(DistanceRecord::class, TimeRangeFilter.between(startTime, endTime))
+        )
+        if (response.records.isEmpty()) return null
+        val totalKm = response.records.sumOf { it.distance.inKilometers }
+        return if (totalKm > 0.0) totalKm else null
+    }
+
+    private fun exerciseTypeToKorean(type: Int): String = when (type) {
+        ExerciseSessionRecord.EXERCISE_TYPE_WALKING -> "걷기"
+        ExerciseSessionRecord.EXERCISE_TYPE_RUNNING -> "달리기"
+        ExerciseSessionRecord.EXERCISE_TYPE_RUNNING_TREADMILL -> "런닝머신"
+        ExerciseSessionRecord.EXERCISE_TYPE_BIKING -> "자전거"
+        ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY -> "실내 자전거"
+        ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_POOL -> "수영"
+        ExerciseSessionRecord.EXERCISE_TYPE_HIKING -> "등산"
+        ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING -> "근력 운동"
+        ExerciseSessionRecord.EXERCISE_TYPE_YOGA -> "요가"
+        ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING -> "HIIT"
+        ExerciseSessionRecord.EXERCISE_TYPE_ELLIPTICAL -> "일립티컬"
+        ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING -> "계단 오르기"
+        ExerciseSessionRecord.EXERCISE_TYPE_DANCING -> "댄스"
+        ExerciseSessionRecord.EXERCISE_TYPE_GOLF -> "골프"
+        ExerciseSessionRecord.EXERCISE_TYPE_TENNIS -> "테니스"
+        ExerciseSessionRecord.EXERCISE_TYPE_BADMINTON -> "배드민턴"
+        else -> "운동"
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectRepositoryImpl.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.example.graduation_project.data.health
+
+import com.example.graduation_project.domain.health.HealthConnectAvailability
+import com.example.graduation_project.domain.health.IHealthRepository
+import com.example.graduation_project.domain.health.SleepSummary
+
+/**
+ * IHealthRepository 구현체.
+ * HealthConnectManager에 실제 데이터 접근을 위임.
+ */
+class HealthConnectRepositoryImpl(
+    private val manager: HealthConnectManager
+) : IHealthRepository {
+
+    override fun getAvailability(): HealthConnectAvailability = manager.checkAvailability()
+
+    override suspend fun hasPermissions(): Boolean = manager.checkGrantedPermissions()
+
+    override suspend fun readYesterdaySleep(): SleepSummary = manager.readYesterdaySleep()
+
+    override suspend fun readTodaySteps(): Int? = manager.readTodaySteps()
+
+    override suspend fun readLatestExercise(): Pair<Double?, String?> = manager.readLatestExercise()
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
@@ -35,6 +35,7 @@ data class TtsRetryResponse(
 @Serializable
 data class HealthData(
     val sleepDuration: Int? = null,
+    val sleepStartTime: String? = null,   // "HH:mm" 형식, 서버 낮잠/야간 수면 분류용
     val steps: Int? = null,
     val exerciseDistance: Double? = null,
     val exerciseActivity: String? = null

--- a/android/app/src/main/java/com/example/graduation_project/domain/health/IHealthRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/health/IHealthRepository.kt
@@ -1,0 +1,32 @@
+package com.example.graduation_project.domain.health
+
+/**
+ * Health Connect 데이터 접근 추상화 인터페이스.
+ * domain 레이어가 data 레이어를 직접 참조하지 않도록 의존성 역전.
+ */
+interface IHealthRepository {
+
+    /** Health Connect SDK 가용성 확인 (동기, 비suspend) */
+    fun getAvailability(): HealthConnectAvailability
+
+    /** 모든 필수 권한이 부여되었는지 확인 */
+    suspend fun hasPermissions(): Boolean
+
+    /**
+     * 어제 정오(12:00) → 오늘 정오(12:00) 범위의 수면 데이터 읽기.
+     * @return SleepSummary(minutes, startTime), 데이터 없으면 SleepSummary(null, null)
+     */
+    suspend fun readYesterdaySleep(): SleepSummary
+
+    /**
+     * 오늘 자정(00:00) → 현재 범위의 걸음 수 합산.
+     * @return 걸음 수, 데이터 없으면 null
+     */
+    suspend fun readTodaySteps(): Int?
+
+    /**
+     * 최근 24시간 내 가장 최근 운동 세션 읽기.
+     * @return Pair(거리km, 운동종류한국어), 데이터 없으면 Pair(null, null)
+     */
+    suspend fun readLatestExercise(): Pair<Double?, String?>
+}

--- a/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
@@ -1,0 +1,14 @@
+package com.example.graduation_project.domain.health
+
+/**
+ * 수면 요약 도메인 모델.
+ * 서버 낮잠/야간 수면 분류를 위해 수면 시작 시각을 함께 전달.
+ *
+ * @param minutes    총 수면 시간 (분), 데이터 없으면 null
+ * @param startTime  주 수면 세션 시작 시각 "HH:mm" (로컬 타임존), 데이터 없으면 null
+ *                   서버: startTime < "18:00" → 낮잠, ≥ "18:00" → 야간 수면
+ */
+data class SleepSummary(
+    val minutes: Int?,
+    val startTime: String?
+)

--- a/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
@@ -1,0 +1,39 @@
+package com.example.graduation_project.domain.usecase
+
+import com.example.graduation_project.data.model.HealthData
+import com.example.graduation_project.domain.health.HealthConnectAvailability
+import com.example.graduation_project.domain.health.IHealthRepository
+import com.example.graduation_project.domain.health.SleepSummary
+
+/**
+ * Health Connect에서 건강 데이터를 읽어 HealthData DTO로 반환하는 UseCase.
+ *
+ * - 가용성/권한 미충족 시 HealthData(all null) 반환 (graceful degradation)
+ * - 각 데이터는 독립적으로 읽기 — 하나 실패해도 나머지는 계속 시도
+ * - 이상치 제거(sanitize): 앱에서 전처리 후 서버에 정제된 값만 전달
+ */
+class GetHealthDataUseCase(
+    private val repository: IHealthRepository
+) {
+    suspend operator fun invoke(): HealthData {
+        if (repository.getAvailability() !is HealthConnectAvailability.Available) return HealthData()
+        if (!runCatching { repository.hasPermissions() }.getOrDefault(false)) return HealthData()
+
+        val sleep = runCatching { repository.readYesterdaySleep() }.getOrDefault(SleepSummary(null, null))
+        val steps = runCatching { repository.readTodaySteps() }.getOrNull().sanitizeSteps()
+        val exercise = runCatching { repository.readLatestExercise() }.getOrDefault(Pair(null, null))
+
+        return HealthData(
+            sleepDuration = sleep.minutes.sanitizeSleep(),
+            sleepStartTime = sleep.startTime,
+            steps = steps,
+            exerciseDistance = exercise.first.sanitizeDistance(),
+            exerciseActivity = exercise.second
+        )
+    }
+
+    // 이상치 제거: 유효 범위 벗어나면 null (서버에서 "데이터 없음"으로 평가)
+    private fun Int?.sanitizeSleep(): Int? = this?.takeIf { it in 30..720 }       // 30분 ~ 12시간
+    private fun Int?.sanitizeSteps(): Int? = this?.takeIf { it in 1..50_000 }     // 최대 5만보
+    private fun Double?.sanitizeDistance(): Double? = this?.takeIf { it in 0.01..100.0 } // 최대 100km
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -6,11 +6,13 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.health.HealthConnectManager
+import com.example.graduation_project.data.health.HealthConnectRepositoryImpl
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.dao.MessageDao
 import com.example.graduation_project.data.local.entity.MessageEntity
-import com.example.graduation_project.data.model.HealthData
 import com.example.graduation_project.data.repository.ConversationRepository
+import com.example.graduation_project.domain.usecase.GetHealthDataUseCase
 import com.example.graduation_project.data.voice.AudioPlayerManager
 import com.example.graduation_project.data.voice.AudioRecordManager
 import com.example.graduation_project.domain.voice.AudioPlayException
@@ -61,7 +63,10 @@ class ConversationViewModel(
     application: Application,
     private val repository: ConversationRepository = ConversationRepository(),
     private val messageDao: MessageDao = AppDatabase.getInstance(application).messageDao(),
-    private val audioRecordManager: AudioRecordManager = AudioRecordManager(application)
+    private val audioRecordManager: AudioRecordManager = AudioRecordManager(application),
+    private val getHealthDataUseCase: GetHealthDataUseCase = GetHealthDataUseCase(
+        HealthConnectRepositoryImpl(HealthConnectManager(application))
+    )
 ) : AndroidViewModel(application) {
 
     // 내부에서만 수정 가능한 상태
@@ -296,7 +301,8 @@ class ConversationViewModel(
             // PROCESSING 타이머 시작
             startProcessingTimer()
 
-            val result = repository.startConversation(getDummyHealthData())
+            val healthData = getHealthDataUseCase()
+            val result = repository.startConversation(healthData)
 
             // PROCESSING 타이머 중지
             stopProcessingTimer()
@@ -677,14 +683,6 @@ class ConversationViewModel(
         audioRecordManager.stop()
         _uiState.update { it.copy(isSpeechDetected = false) }
     }
-
-    // 임시 건강 데이터 (추후 Health Connect 연동)
-    private fun getDummyHealthData() = HealthData(
-        sleepDuration = 420,      // 7시간 (분 단위)
-        steps = 5000,             // 5000보
-        exerciseDistance = 3.5,   // 3.5km
-        exerciseActivity = "걷기"
-    )
 
     // ═══════════════════════════════════════════════════════════════════
     // PROCESSING 타이머

--- a/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
@@ -8,8 +8,10 @@ import com.example.graduation_project.data.local.dao.MessageDao
 import com.example.graduation_project.data.model.ConversationEndResponse
 import com.example.graduation_project.data.model.ConversationMessageResponse
 import com.example.graduation_project.data.model.ConversationStartResponse
+import com.example.graduation_project.data.model.HealthData
 import com.example.graduation_project.data.repository.ConversationRepository
 import com.example.graduation_project.data.voice.AudioRecordManager
+import com.example.graduation_project.domain.usecase.GetHealthDataUseCase
 import com.example.graduation_project.domain.voice.AudioRecordState
 import com.example.graduation_project.presentation.model.ConversationState
 import io.mockk.coEvery
@@ -60,6 +62,7 @@ class ConversationViewModelTest {
     private val mockApplication = mockk<Application>(relaxed = true)
     private val mockAudioRecordState = MutableStateFlow<AudioRecordState>(AudioRecordState.Idle)
     private val mockAudioRecordManager = mockk<AudioRecordManager>(relaxed = true)
+    private val mockGetHealthDataUseCase = mockk<GetHealthDataUseCase>()
 
     private lateinit var viewModel: ConversationViewModel
 
@@ -72,12 +75,14 @@ class ConversationViewModelTest {
         every { Log.e(any(), any<String>()) } returns 0
         every { Log.e(any(), any<String>(), any()) } returns 0
         every { mockAudioRecordManager.state } returns mockAudioRecordState
+        coEvery { mockGetHealthDataUseCase() } returns HealthData()
 
         viewModel = ConversationViewModel(
             application = mockApplication,
             repository = mockRepository,
             messageDao = mockMessageDao,
-            audioRecordManager = mockAudioRecordManager
+            audioRecordManager = mockAudioRecordManager,
+            getHealthDataUseCase = mockGetHealthDataUseCase
         )
     }
 


### PR DESCRIPTION
## Summary

- `IHealthRepository` 인터페이스 + `SleepSummary` 도메인 모델 추가 (Clean Architecture)
- `HealthConnectManager`에 실제 데이터 읽기 3종 구현 (수면/걸음수/운동)
- `HealthConnectRepositoryImpl`로 data 레이어 구현체 분리
- `GetHealthDataUseCase`에서 이상치 제거 후 `HealthData` 반환
- `ConversationViewModel`에서 `getDummyHealthData()` 제거 → 실제 데이터 사용

## 이상치 기준 (앱 전처리)

| 데이터 | 유효 범위 | 벗어나면 |
|--------|----------|----------|
| 수면 | 30분 ~ 720분(12h) | null |
| 걸음 수 | 1 ~ 50,000보 | null |
| 운동 거리 | 0.01 ~ 100km | null |

## 데이터 수집 범위

- 수면: 어제 정오(12:00) → 오늘 정오(12:00) — 야간 수면 전체 포착
- 걸음 수: 오늘 자정(00:00) → 현재
- 운동: 최근 24시간 내 가장 최근 세션, 거리는 DistanceRecord 우선 (Galaxy Watch 호환)

## 서버 협업 필요

`sleepStartTime` ("HH:mm") 필드가 추가됨.
`HealthDataService`에서 파싱하여 18:00 미만 → 낮잠, 이상 → 야간 수면 분류 필요.

## 의존성

> ⚠️ 이 PR은 `feature/US4.1-health-connect-permission` 머지 후 develop으로 retarget 예정.

## Test plan

- [ ] `./gradlew assembleDebug` 빌드 통과
- [ ] `ConversationViewModelTest` 전체 통과
- [ ] Health Connect 권한 Granted 상태 → 실제 데이터 로그 확인
- [ ] 권한 Denied 상태 → `HealthData(all null)`으로 대화 시작 확인
- [ ] Health Connect 미설치 → `HealthData(all null)`으로 대화 시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)