### PR TITLE
fix: Android-server API contract 불일치 수정 (HealthData, UserPreferences)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
@@ -79,7 +79,7 @@ class HealthConnectManager(private val context: Context) {
         val response = client.readRecords(
             ReadRecordsRequest(SleepSessionRecord::class, TimeRangeFilter.between(rangeStart, rangeEnd))
         )
-        if (response.records.isEmpty()) return SleepSummary(null, null)
+        if (response.records.isEmpty()) return SleepSummary(null, null, null)
 
         val totalMinutes = response.records.sumOf { record ->
             (record.endTime.toEpochMilli() - record.startTime.toEpochMilli()) / 60_000L
@@ -92,8 +92,12 @@ class HealthConnectManager(private val context: Context) {
             val localTime = it.startTime.atZone(zone).toLocalTime()
             String.format("%02d:%02d", localTime.hour, localTime.minute)
         }
+        val wakeUpTimeStr = mainSession?.let {
+            val localTime = it.endTime.atZone(zone).toLocalTime()
+            String.format("%02d:%02d", localTime.hour, localTime.minute)
+        }
 
-        return SleepSummary(minutes = totalMinutes, startTime = startTimeStr)
+        return SleepSummary(minutes = totalMinutes, startTime = startTimeStr, wakeUpTime = wakeUpTimeStr)
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
@@ -34,9 +34,11 @@ data class TtsRetryResponse(
 // 요청 Model(DTO) -> /start에 대한 DTO
 @Serializable
 data class HealthData(
-    val sleepDuration: Int? = null,
-    val sleepStartTime: String? = null,   // "HH:mm" 형식, 서버 낮잠/야간 수면 분류용
+    val sleepDurationMinutes: Int? = null,   // renamed: sleepDuration → sleepDurationMinutes
+    val sleepStartTime: String? = null,      // "HH:mm" 형식, 서버 낮잠/야간 수면 분류용
+    val wakeUpTime: String? = null,          // "HH:mm" 형식, 기상 시각
     val steps: Int? = null,
-    val exerciseDistance: Double? = null,
-    val exerciseActivity: String? = null
+    val exerciseDistanceKm: Double? = null,  // renamed: exerciseDistance → exerciseDistanceKm
+    val exerciseActivity: String? = null,
+    val activityList: String? = null         // 활동 목록 (추후 구현)
 )

--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -12,11 +12,18 @@ data class User(
 
 @Serializable
 data class UserPreferences(
-    val hobby: String? = null,
+    val userId: Long? = null,
+    val name: String? = null,
+    val age: Int? = null,
+    val birthday: String? = null,               // 서버: LocalDate → "yyyy-MM-dd"
+    val location: String? = null,
+    val familyInfo: String? = null,             // renamed: familyRelation → familyInfo
     val occupation: String? = null,
-    val familyRelation: String? = null,
-    val preferredTopics: List<String> = emptyList(),
-    val voiceSettings: VoiceSettings? = null
+    val hobbies: String? = null,                // renamed: hobby → hobbies
+    val preferredTopics: String? = null,        // type changed: List<String> → String
+    val voiceSettings: VoiceSettings? = null,
+    val conversationTime: String? = null,       // 서버: LocalTime → "HH:mm"
+    val preferredSleepHours: Int? = null
 )
 
 @Serializable

--- a/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
@@ -7,8 +7,10 @@ package com.example.graduation_project.domain.health
  * @param minutes    총 수면 시간 (분), 데이터 없으면 null
  * @param startTime  주 수면 세션 시작 시각 "HH:mm" (로컬 타임존), 데이터 없으면 null
  *                   서버: startTime < "18:00" → 낮잠, ≥ "18:00" → 야간 수면
+ * @param wakeUpTime 주 수면 세션 종료 시각 "HH:mm" (로컬 타임존), 데이터 없으면 null
  */
 data class SleepSummary(
     val minutes: Int?,
-    val startTime: String?
+    val startTime: String?,
+    val wakeUpTime: String?
 )

--- a/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
@@ -19,15 +19,16 @@ class GetHealthDataUseCase(
         if (repository.getAvailability() !is HealthConnectAvailability.Available) return HealthData()
         if (!runCatching { repository.hasPermissions() }.getOrDefault(false)) return HealthData()
 
-        val sleep = runCatching { repository.readYesterdaySleep() }.getOrDefault(SleepSummary(null, null))
+        val sleep = runCatching { repository.readYesterdaySleep() }.getOrDefault(SleepSummary(null, null, null))
         val steps = runCatching { repository.readTodaySteps() }.getOrNull().sanitizeSteps()
         val exercise = runCatching { repository.readLatestExercise() }.getOrDefault(Pair(null, null))
 
         return HealthData(
-            sleepDuration = sleep.minutes.sanitizeSleep(),
+            sleepDurationMinutes = sleep.minutes.sanitizeSleep(),
             sleepStartTime = sleep.startTime,
+            wakeUpTime = sleep.wakeUpTime,
             steps = steps,
-            exerciseDistance = exercise.first.sanitizeDistance(),
+            exerciseDistanceKm = exercise.first.sanitizeDistance(),
             exerciseActivity = exercise.second
         )
     }

--- a/server/src/main/java/com/example/echo/conversation/controller/ConversationController.java
+++ b/server/src/main/java/com/example/echo/conversation/controller/ConversationController.java
@@ -6,6 +6,7 @@ import com.example.echo.conversation.dto.ConversationResponse;
 import com.example.echo.conversation.dto.ConversationStartResponse;
 import com.example.echo.conversation.dto.TtsRetryResponse;
 import com.example.echo.conversation.service.ConversationService;
+import com.example.echo.health.dto.HealthData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,9 +33,10 @@ public class ConversationController {
      */
     @PostMapping("/start")
     public ResponseEntity<ConversationStartResponse> startConversation(
-            @CurrentUser Long userId
+            @CurrentUser Long userId,
+            @RequestBody(required = false) HealthData healthData
     ) {
-        ConversationStartResponse response = conversationService.startConversation(userId);
+        ConversationStartResponse response = conversationService.startConversation(userId, healthData);
         return ResponseEntity.ok(response);
     }
 

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -9,6 +9,8 @@ import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.conversation.dto.TtsRetryResponse;
 import com.example.echo.conversation.exception.ConversationNotFoundException;
 import com.example.echo.diary.service.DiaryService;
+import com.example.echo.health.dto.HealthData;
+import com.example.echo.health.service.HealthDataService;
 import com.example.echo.prompt.service.PromptService;
 import com.example.echo.voice.service.VoiceService;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +32,15 @@ public class ConversationService {
     private final AIService aiService;
     private final ContextService contextService;
     private final DiaryService diaryService;
+    private final HealthDataService healthDataService;
 
     @Transactional
-    public ConversationStartResponse startConversation(Long userId) {
+    public ConversationStartResponse startConversation(Long userId, HealthData healthData) {
+        // 0. 건강 데이터 저장 (Android에서 수신한 경우)
+        if (healthData != null) {
+            healthDataService.saveHealthData(userId, healthData);
+        }
+
         // 1. 컨텍스트 초기화
         UserContext context = contextService.initializeContext(userId);
 

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
@@ -7,6 +7,7 @@ import com.example.echo.context.service.ContextService;
 import com.example.echo.conversation.dto.ConversationStartResponse;
 import com.example.echo.diary.service.DiaryService;
 import com.example.echo.health.dto.HealthData;
+import com.example.echo.health.service.HealthDataService;
 import com.example.echo.prompt.service.PromptService;
 import com.example.echo.user.dto.UserPreferences;
 import com.example.echo.user.dto.VoiceSettings;
@@ -43,6 +44,9 @@ class ConversationServiceTest {
     @Mock
     private DiaryService diaryService;
 
+    @Mock
+    private HealthDataService healthDataService;
+
     //@InjectMocks-제거
     private ConversationService conversationService;
 
@@ -57,7 +61,8 @@ class ConversationServiceTest {
                 promptService,
                 aiService,
                 contextService,
-                diaryService
+                diaryService,
+                healthDataService
         );
         mockContext = createMockContext();
     }
@@ -76,7 +81,7 @@ class ConversationServiceTest {
         when(voiceService.textToSpeech(eq(greeting), any(VoiceSettings.class))).thenReturn(audioData);
 
         // When
-        ConversationStartResponse response = conversationService.startConversation(TEST_USER_ID);
+        ConversationStartResponse response = conversationService.startConversation(TEST_USER_ID, null);
 
         // Then
         assertThat(response).isNotNull();
@@ -98,7 +103,7 @@ class ConversationServiceTest {
         when(voiceService.textToSpeech(eq(greeting), any(VoiceSettings.class))).thenReturn(audioData);
 
         // When
-        conversationService.startConversation(TEST_USER_ID);
+        conversationService.startConversation(TEST_USER_ID, null);
 
         // Then - 순서 검증
         InOrder inOrder = inOrder(contextService, promptService, aiService, voiceService);
@@ -118,7 +123,7 @@ class ConversationServiceTest {
         when(voiceService.textToSpeech(any(), any())).thenReturn("audio".getBytes());
 
         // When
-        conversationService.startConversation(TEST_USER_ID);
+        conversationService.startConversation(TEST_USER_ID, null);
 
         // Then
         verify(contextService, times(1)).initializeContext(TEST_USER_ID);

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -7,6 +7,7 @@ import com.example.echo.context.service.ContextService;
 import com.example.echo.conversation.dto.ConversationResponse;
 import com.example.echo.conversation.dto.ConversationStartResponse;
 import com.example.echo.diary.service.DiaryService;
+import com.example.echo.health.service.HealthDataService;
 import com.example.echo.prompt.service.PromptService;
 import com.example.echo.user.dto.UserPreferences;
 import com.example.echo.user.dto.VoiceSettings;
@@ -52,6 +53,9 @@ class ConversationServiceTest2 {
 
     @Mock
     private DiaryService diaryService;
+
+    @Mock
+    private HealthDataService healthDataService;
 
     private Long userId;
     private UserContext mockContext;
@@ -101,7 +105,7 @@ class ConversationServiceTest2 {
             given(voiceService.textToSpeech(greeting, mockVoiceSettings)).willReturn(audioData);
 
             // when
-            ConversationStartResponse result = conversationService.startConversation(userId);
+            ConversationStartResponse result = conversationService.startConversation(userId, null);
 
             // then
             assertThat(result).isNotNull();
@@ -123,7 +127,7 @@ class ConversationServiceTest2 {
             given(voiceService.textToSpeech(greeting, mockVoiceSettings)).willReturn(audioData);
 
             // when
-            conversationService.startConversation(userId);
+            conversationService.startConversation(userId, null);
 
             // then (순서대로 호출 검증)
             var inOrder = inOrder(contextService, promptService, aiService, voiceService);


### PR DESCRIPTION
## Summary

- **HealthData DTO 필드명 수정**: `sleepDuration→sleepDurationMinutes`, `exerciseDistance→exerciseDistanceKm`, `wakeUpTime`/`activityList` 신규 추가 (Android → Server 일치)
- **UserPreferences DTO 수정**: `hobby→hobbies`, `familyRelation→familyInfo`, `preferredTopics: List<String>→String`, 누락 필드 7개 추가
- **`/start` endpoint 수정**: `ConversationController`에 `@RequestBody(required=false) HealthData` 추가, `ConversationService`에서 건강 데이터 저장 후 컨텍스트 초기화

## Test plan

- [x] Android unit tests: `./gradlew test` — BUILD SUCCESSFUL
- [x] Server ConversationServiceTest(1,2): `./gradlew test --tests "com.example.echo.conversation.service.*"` — BUILD SUCCESSFUL
- [ ] 통합 테스트 (Voice/E2E): 외부 API(Clova TTS, Whisper) 의존으로 로컬 환경에서 실패 (기존 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)