### PR TITLE
bugfix: health_logs 중복 저장으로 인한 대화 시작 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Build and Deploy to EC2
 
 on:
   push:
-    branches: [main]
+    branches: [bugfix/health-log-duplicate-upsert]
     paths: ['server/**']
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Build and Deploy to EC2
 
 on:
   push:
-    branches: [bugfix/health-log-duplicate-upsert]
+    branches: [main]
     paths: ['server/**']
 
 env:

--- a/server/src/main/java/com/example/echo/health/entity/HealthLog.java
+++ b/server/src/main/java/com/example/echo/health/entity/HealthLog.java
@@ -19,9 +19,14 @@ import java.time.LocalTime;
  * - 7일 평균 계산 및 대화용 건강 정보 조회에 사용
  */
 @Entity
-@Table(name = "health_logs", indexes = {
-        @Index(name = "idx_health_logs_user_date", columnList = "user_id, recorded_date")
-})
+@Table(name = "health_logs",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_health_logs_user_date",
+                columnNames = {"user_id", "recorded_date"}
+        ),
+        indexes = {
+                @Index(name = "idx_health_logs_user_date", columnList = "user_id, recorded_date")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HealthLog {

--- a/server/src/main/java/com/example/echo/health/service/HealthDataService.java
+++ b/server/src/main/java/com/example/echo/health/service/HealthDataService.java
@@ -103,7 +103,8 @@ public class HealthDataService {
     }
 
     /**
-     * 건강 데이터 저장
+     * 건강 데이터 저장 (upsert)
+     * - 오늘 날짜 데이터가 이미 있으면 삭제 후 재저장
      */
     @Transactional
     public HealthLog saveHealthData(Long userId, HealthData data) {
@@ -111,10 +112,14 @@ public class HealthDataService {
     }
 
     /**
-     * 특정 날짜의 건강 데이터 저장
+     * 특정 날짜의 건강 데이터 저장 (upsert)
+     * - 동일 (userId, date) 데이터가 이미 있으면 삭제 후 재저장
      */
     @Transactional
     public HealthLog saveHealthData(Long userId, LocalDate date, HealthData data) {
+        healthLogRepository.findByUserIdAndRecordedDate(userId, date)
+                .ifPresent(healthLogRepository::delete);
+
         HealthLog healthLog = HealthLog.fromHealthData(userId, date, data);
         return healthLogRepository.save(healthLog);
     }

--- a/server/src/main/java/com/example/echo/health/service/HealthDataService.java
+++ b/server/src/main/java/com/example/echo/health/service/HealthDataService.java
@@ -118,7 +118,10 @@ public class HealthDataService {
     @Transactional
     public HealthLog saveHealthData(Long userId, LocalDate date, HealthData data) {
         healthLogRepository.findByUserIdAndRecordedDate(userId, date)
-                .ifPresent(healthLogRepository::delete);
+                .ifPresent(existing -> {
+                    healthLogRepository.delete(existing);
+                    healthLogRepository.flush(); // DELETE SQL을 즉시 DB에 반영 후 INSERT
+                });
 
         HealthLog healthLog = HealthLog.fromHealthData(userId, date, data);
         return healthLogRepository.save(healthLog);


### PR DESCRIPTION
## 문제
대화 시작 버튼을 여러 번 누르면 health_logs 테이블에 동일한                                                                                                                                                                                     (user_id, recorded_date) 데이터가 중복 저장됨.                                                                                                                                                                                                  이후 조회 시 결과가 2개 이상 반환되어 NonUniqueResultException 발생.                                                                                                                                                                                                                                                                                                                                                                                                                            ## 원인                                                                                                                                                                                                                                         saveHealthData()가 기존 데이터 존재 여부와 관계없이                                                                                                                                                                                           
  항상 새 행을 INSERT하는 구조.

  ## 수정 내용
  - HealthDataService.saveHealthData()
    동일 (userId, date) 데이터가 있으면 delete → flush → insert (upsert)
    flush()로 DELETE SQL이 INSERT 전에 DB에 반영되도록 순서 보장

  - HealthLog Entity @Table에 uniqueConstraints 추가
    (user_id, recorded_date) 조합에 DB 레벨 unique constraint 적용
    (RDS에 ALTER TABLE로 직접 적용 완료)

  ## 참고
  RDS에 직접 실행한 SQL:
  ALTER TABLE health_logs ADD UNIQUE KEY uq_health_logs_user_date (user_id, recorded_date);
