### PR TITLE
refactor: UPSERT 로직 통합 (delete+save → update 방식)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// Caffeine Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	// OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-micrometer'

--- a/server/src/main/java/com/example/echo/health/service/HealthDataService.java
+++ b/server/src/main/java/com/example/echo/health/service/HealthDataService.java
@@ -114,36 +114,6 @@ public class HealthDataService {
                 .build();
     }
 
-    /**
-     * 건강 데이터 저장 또는 업데이트 (UPSERT)
-     *
-     * 같은 날짜에 데이터가 이미 존재하면 업데이트, 없으면 새로 생성
-     * 대화 시작 시 즉시 호출하여 건강 데이터 손실 방지
-     *
-     * @param userId 사용자 ID
-     * @param data 건강 데이터
-     */
-    @Transactional
-    public void saveOrUpdateHealthData(Long userId, HealthData data) {
-        if (data == null) {
-            log.debug("건강 데이터가 null이므로 저장 생략 - userId: {}", userId);
-            return;
-        }
-
-        LocalDate today = LocalDate.now();
-        healthLogRepository.findByUserIdAndRecordedDate(userId, today)
-                .ifPresentOrElse(
-                        existing -> {
-                            log.debug("기존 건강 데이터 업데이트 - userId: {}, date: {}", userId, today);
-                            existing.update(data);
-                        },
-                        () -> {
-                            log.debug("새 건강 데이터 생성 - userId: {}, date: {}", userId, today);
-                            healthLogRepository.save(HealthLog.fromHealthData(userId, today, data));
-                        }
-                );
-    }
-
     // ========== 서버 측 평균 계산 메서드 ==========
 
     /**
@@ -200,8 +170,8 @@ public class HealthDataService {
     }
 
     /**
-     * 건강 데이터 저장 (upsert)
-     * - 오늘 날짜 데이터가 이미 있으면 삭제 후 재저장
+     * 건강 데이터 저장 또는 업데이트 (UPSERT)
+     * - 오늘 날짜 데이터가 이미 있으면 업데이트, 없으면 새로 생성
      */
     @Transactional
     public HealthLog saveHealthData(Long userId, HealthData data) {
@@ -209,19 +179,27 @@ public class HealthDataService {
     }
 
     /**
-     * 특정 날짜의 건강 데이터 저장 (upsert)
-     * - 동일 (userId, date) 데이터가 이미 있으면 삭제 후 재저장
+     * 특정 날짜의 건강 데이터 저장 또는 업데이트 (UPSERT)
+     * - 동일 (userId, date) 데이터가 이미 있으면 업데이트, 없으면 새로 생성
+     * - 기존 delete + save 방식 대신 update 방식으로 효율성 개선
      */
     @Transactional
     public HealthLog saveHealthData(Long userId, LocalDate date, HealthData data) {
-        healthLogRepository.findByUserIdAndRecordedDate(userId, date)
-                .ifPresent(existing -> {
-                    healthLogRepository.delete(existing);
-                    healthLogRepository.flush(); // DELETE SQL을 즉시 DB에 반영 후 INSERT
-                });
+        if (data == null) {
+            log.debug("건강 데이터가 null이므로 저장 생략 - userId: {}", userId);
+            return null;
+        }
 
-        HealthLog healthLog = HealthLog.fromHealthData(userId, date, data);
-        return healthLogRepository.save(healthLog);
+        return healthLogRepository.findByUserIdAndRecordedDate(userId, date)
+                .map(existing -> {
+                    log.debug("기존 건강 데이터 업데이트 - userId: {}, date: {}", userId, date);
+                    existing.update(data);
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    log.debug("새 건강 데이터 생성 - userId: {}, date: {}", userId, date);
+                    return healthLogRepository.save(HealthLog.fromHealthData(userId, date, data));
+                });
     }
 
     /**

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
@@ -6,6 +6,7 @@ import com.example.echo.context.domain.UserContext;
 import com.example.echo.context.service.ContextService;
 import com.example.echo.conversation.dto.ConversationStartResponse;
 import com.example.echo.diary.service.DiaryService;
+import com.example.echo.health.dto.EnrichedHealthData;
 import com.example.echo.health.dto.HealthData;
 import com.example.echo.health.service.HealthDataService;
 import com.example.echo.prompt.service.PromptService;
@@ -159,7 +160,7 @@ class ConversationServiceTest {
         return UserContext.builder()
                 .userId(TEST_USER_ID)
                 .preferences(preferences)
-                .todayHealthData(healthData)
+                .enrichedHealthData(EnrichedHealthData.fromHealthData(healthData))
                 .todayWeather(weatherData)
                 .build();
     }

--- a/server/src/test/java/com/example/echo/health/service/HealthDataServiceTest.java
+++ b/server/src/test/java/com/example/echo/health/service/HealthDataServiceTest.java
@@ -86,8 +86,8 @@ class HealthDataServiceTest {
     class SaveHealthDataTest {
 
         @Test
-        @DisplayName("건강 데이터 저장 성공")
-        void saveHealthData() {
+        @DisplayName("새 건강 데이터 저장 성공")
+        void saveHealthData_new() {
             // Given
             HealthData healthData = HealthData.builder()
                     .steps(6000)
@@ -96,6 +96,8 @@ class HealthDataServiceTest {
                     .exerciseActivity("조깅")
                     .build();
 
+            when(healthLogRepository.findByUserIdAndRecordedDate(eq(TEST_USER_ID), any(LocalDate.class)))
+                    .thenReturn(Optional.empty());
             when(healthLogRepository.save(any(HealthLog.class)))
                     .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -106,6 +108,47 @@ class HealthDataServiceTest {
             verify(healthLogRepository).save(any(HealthLog.class));
             assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
             assertThat(result.getSteps()).isEqualTo(6000);
+        }
+
+        @Test
+        @DisplayName("기존 건강 데이터 업데이트 성공 (UPSERT)")
+        void saveHealthData_update() {
+            // Given
+            HealthLog existingLog = HealthLog.builder()
+                    .userId(TEST_USER_ID)
+                    .recordedDate(LocalDate.now())
+                    .steps(5000)
+                    .sleepDurationMinutes(420)
+                    .build();
+
+            HealthData newHealthData = HealthData.builder()
+                    .steps(8000)
+                    .sleepDurationMinutes(540)
+                    .exerciseDistanceKm(5.0)
+                    .exerciseActivity("달리기")
+                    .build();
+
+            when(healthLogRepository.findByUserIdAndRecordedDate(eq(TEST_USER_ID), any(LocalDate.class)))
+                    .thenReturn(Optional.of(existingLog));
+
+            // When
+            HealthLog result = healthDataService.saveHealthData(TEST_USER_ID, newHealthData);
+
+            // Then
+            assertThat(result).isSameAs(existingLog);
+            assertThat(result.getSteps()).isEqualTo(8000);
+            assertThat(result.getSleepDurationMinutes()).isEqualTo(540);
+            assertThat(result.getExerciseActivity()).isEqualTo("달리기");
+        }
+
+        @Test
+        @DisplayName("null 데이터 저장 시 null 반환")
+        void saveHealthData_null() {
+            // When
+            HealthLog result = healthDataService.saveHealthData(TEST_USER_ID, null);
+
+            // Then
+            assertThat(result).isNull();
         }
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                          
  - `saveOrUpdateHealthData()` 제거, `saveHealthData()`로 UPSERT 로직 통합                                                                                                            
  - 기존 delete+flush+save 방식을 update 방식으로 변경하여 DB 효율성 개선                                                                                                             
  - PR #202와 PR #204에서 중복된 UPSERT 구현을 단일화                                                                                                                                 
                                                                                                                                                                                      
  ## Changes                                                                                                                                                                          
  | 파일 | 변경 내용 |                                                                                                                                                                
  |------|----------|                                                                                                                                                                 
  | `HealthDataService.java` | `saveOrUpdateHealthData()` 제거, `saveHealthData()`를 update 방식으로 통합, null 처리 추가 |                                                           
  | `HealthDataServiceTest.java` | UPSERT(업데이트), null 처리 테스트 케이스 추가 |                                                                                                   
  | `build.gradle` | Caffeine 캐시 의존성 추가 (PR #204에서 누락) |                                                                                                                   
  | `ConversationServiceTest.java` | 필드명 수정 `todayHealthData` → `enrichedHealthData` (PR #204에서 누락) |                                                                        
                                                                                                                                                                                      
  ## Why update is better than delete+save                                                                                                                                            
  | 관점 | DELETE + INSERT | UPDATE |                                                                                                                                                 
  |------|-----------------|--------|                                                                                                                                                 
  | DB 쿼리 수 | 3회 (SELECT → DELETE → INSERT) | 2회 (SELECT → UPDATE) |                                                                                                             
  | ID 유지 | ID 변경됨 | ID 유지됨 |                                                                                                                                                 
  | 트랜잭션 | flush() 필요 | 불필요 |                                                                                                                                                
                                                                                                                                                                                      
  ## Test plan                                                                                                                                                                        
  - [x] `HealthDataServiceTest` 전체 통과                                                                                                                                             
  - [x] `ConversationServiceTest` 전체 통과