### PR TITLE
fix: Health Connect 권한 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthPermissionDialogs.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthPermissionDialogs.kt
@@ -324,6 +324,7 @@ fun openHealthConnectSettings(context: Context) {
     val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         Intent("android.intent.action.MANAGE_HEALTH_PERMISSIONS")
             .setPackage("com.google.android.apps.healthdata")
+            .putExtra(Intent.EXTRA_PACKAGE_NAME, context.packageName)
     } else {
         Intent("androidx.health.ACTION_HEALTH_CONNECT_SETTINGS")
             .setPackage("com.google.android.apps.healthdata")

--- a/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
@@ -48,9 +48,25 @@ class HealthViewModel(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             val availability = healthConnectManager.checkAvailability()
-            _uiState.update { it.copy(availability = availability) }
             if (availability is HealthConnectAvailability.Available) {
-                checkPermissions()
+                try {
+                    val allGranted = healthConnectManager.checkGrantedPermissions()
+                    _uiState.update {
+                        it.copy(
+                            availability = availability,
+                            permissionState = if (allGranted) PermissionState.Granted else PermissionState.NotRequested
+                        )
+                    }
+                } catch (e: Exception) {
+                    _uiState.update {
+                        it.copy(
+                            availability = availability,
+                            errorMessage = "건강 데이터 권한을 확인할 수 없습니다"
+                        )
+                    }
+                }
+            } else {
+                _uiState.update { it.copy(availability = availability) }
             }
             _uiState.update { it.copy(isLoading = false) }
         }
@@ -59,8 +75,8 @@ class HealthViewModel(
     private suspend fun checkPermissions() {
         try {
             val allGranted = healthConnectManager.checkGrantedPermissions()
-            if (allGranted) {
-                _uiState.update { it.copy(permissionState = PermissionState.Granted) }
+            _uiState.update {
+                it.copy(permissionState = if (allGranted) PermissionState.Granted else PermissionState.NotRequested)
             }
         } catch (e: Exception) {
             _uiState.update { it.copy(errorMessage = "건강 데이터 권한을 확인할 수 없습니다") }


### PR DESCRIPTION
## Summary

- `checkInitialState()`에서 `availability`와 `permissionState`를 별도 업데이트하던 race condition 수정 → 단일 원자적 업데이트로 변경, 권한이 허용되어 있어도 다이얼로그가 뜨던 버그 해결
- `openHealthConnectSettings()`에 `Intent.EXTRA_PACKAGE_NAME` 추가 (Android 14+), "설정으로 이동" 버튼 무반응 버그 해결

## Test plan

- [ ] 권한 허용 상태: 앱 재시작 → 다이얼로그가 뜨지 않아야 함
- [ ] 권한 미허용 상태: 앱 재시작 → Rationale 다이얼로그 정상 표시
- [ ] 권한 거부 상태: "설정으로 이동" 버튼 → Health Connect 앱의 에코 권한 페이지로 이동
- [ ] onResume 재확인: 설정에서 돌아왔을 때 권한 상태 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)