### PR TITLE
test: HealthDataService 및 PromptService 단위 테스트 추가 (#191)

### DIFF
--- a/server/src/main/java/com/example/echo/health/repository/HealthLogRepository.java
+++ b/server/src/main/java/com/example/echo/health/repository/HealthLogRepository.java
@@ -2,8 +2,6 @@ package com.example.echo.health.repository;
 
 import com.example.echo.health.entity.HealthLog;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -30,43 +28,7 @@ public interface HealthLogRepository extends JpaRepository<HealthLog, Long> {
             Long userId, LocalDate startDate, LocalDate endDate);
 
     /**
-     * 특정 사용자의 기간별 평균 걸음 수 계산
-     */
-    @Query("SELECT AVG(h.steps) FROM HealthLog h " +
-            "WHERE h.userId = :userId " +
-            "AND h.recordedDate BETWEEN :startDate AND :endDate " +
-            "AND h.steps IS NOT NULL")
-    Double findAverageStepsByUserIdAndDateRange(
-            @Param("userId") Long userId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
-
-    /**
-     * 특정 사용자의 기간별 평균 수면 시간(분) 계산
-     */
-    @Query("SELECT AVG(h.sleepDurationMinutes) FROM HealthLog h " +
-            "WHERE h.userId = :userId " +
-            "AND h.recordedDate BETWEEN :startDate AND :endDate " +
-            "AND h.sleepDurationMinutes IS NOT NULL")
-    Double findAverageSleepMinutesByUserIdAndDateRange(
-            @Param("userId") Long userId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
-
-    /**
      * 특정 사용자의 특정 날짜에 데이터 존재 여부 확인
      */
     boolean existsByUserIdAndRecordedDate(Long userId, LocalDate recordedDate);
-
-    /**
-     * 특정 사용자의 기간별 기상 시간 목록 조회 (평균 계산용)
-     */
-    @Query("SELECT h.wakeUpTime FROM HealthLog h " +
-            "WHERE h.userId = :userId " +
-            "AND h.recordedDate BETWEEN :startDate AND :endDate " +
-            "AND h.wakeUpTime IS NOT NULL")
-    List<java.time.LocalTime> findWakeUpTimesByUserIdAndDateRange(
-            @Param("userId") Long userId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
 }

--- a/server/src/main/java/com/example/echo/health/service/HealthDataService.java
+++ b/server/src/main/java/com/example/echo/health/service/HealthDataService.java
@@ -203,26 +203,6 @@ public class HealthDataService {
     }
 
     /**
-     * 7일 평균 걸음 수 조회
-     */
-    public Double getWeeklyAverageSteps(Long userId) {
-        LocalDate endDate = LocalDate.now().minusDays(1);
-        LocalDate startDate = endDate.minusDays(6);
-        Double avg = healthLogRepository.findAverageStepsByUserIdAndDateRange(userId, startDate, endDate);
-        return avg != null ? avg : 0.0;
-    }
-
-    /**
-     * 7일 평균 수면 시간(시간) 조회
-     */
-    public Double getWeeklyAverageSleepHours(Long userId) {
-        LocalDate endDate = LocalDate.now().minusDays(1);
-        LocalDate startDate = endDate.minusDays(6);
-        Double avgMinutes = healthLogRepository.findAverageSleepMinutesByUserIdAndDateRange(userId, startDate, endDate);
-        return avgMinutes != null ? avgMinutes / 60.0 : 0.0;
-    }
-
-    /**
      * 수면 평가: 오늘 수면 vs 선호 수면 시간
      *
      * @param totalMinutes   오늘 수면 시간(분)
@@ -270,32 +250,6 @@ public class HealthDataService {
         if (diffMinutes < -15) return "평소보다 일찍";
         if (diffMinutes > 15) return "평소보다 늦게";
         return "평소와 비슷";
-    }
-
-    /**
-     * 7일 평균 기상 시간 조회
-     *
-     * @param userId 사용자 ID
-     * @return 평균 기상 시간 (데이터가 없으면 null)
-     */
-    public LocalTime getWeeklyAverageWakeTime(Long userId) {
-        LocalDate endDate = LocalDate.now().minusDays(1);
-        LocalDate startDate = endDate.minusDays(6);
-
-        java.util.List<LocalTime> wakeTimes = healthLogRepository
-                .findWakeUpTimesByUserIdAndDateRange(userId, startDate, endDate);
-
-        if (wakeTimes == null || wakeTimes.isEmpty()) {
-            return null;
-        }
-
-        // LocalTime을 초로 변환하여 평균 계산 후 다시 LocalTime으로 변환
-        long totalSeconds = wakeTimes.stream()
-                .mapToLong(LocalTime::toSecondOfDay)
-                .sum();
-        long avgSeconds = totalSeconds / wakeTimes.size();
-
-        return LocalTime.ofSecondOfDay(avgSeconds);
     }
 
     /**

--- a/server/src/main/java/com/example/echo/prompt/service/PromptService.java
+++ b/server/src/main/java/com/example/echo/prompt/service/PromptService.java
@@ -141,11 +141,12 @@ public class PromptService {
      * 대화 프롬프트 생성
      *
      * 사용자 발화에 대한 AI 응답 생성을 위한 프롬프트
-     * 시스템 프롬프트 + 오늘의 컨텍스트 + 대화 히스토리 + 사용자 메시지 조합
+     * 시스템 프롬프트 + 대화 히스토리 + 사용자 메시지 조합
      *
      * [최적화] 시스템 프롬프트는 Context에서 캐싱된 것 사용 (재생성 X)
+     * [리팩토링] todayContext 제거 - 시스템 프롬프트에 건강/날씨 데이터 포함되어 중복
      *
-     * 템플릿 변수: {{systemPrompt}}, {{todayContext}}, {{conversationHistory}}, {{userMessage}}
+     * 템플릿 변수: {{systemPrompt}}, {{conversationHistory}}, {{userMessage}}
      *
      * @param context ContextService에서 전달받은 UserContext
      * @param userMessage 현재 사용자 발화 (STT 변환 결과)
@@ -159,84 +160,17 @@ public class PromptService {
         // 2. 시스템 프롬프트는 Context에서 캐싱된 것 사용 (재생성 X)
         String systemPrompt = context.getSystemPrompt();
 
-        // 3. 나머지 구성 요소 빌드
-        String todayContext = buildTodayContext(context);
+        // 3. 대화 히스토리 빌드
         String conversationHistory = buildHistory(context);
 
         // 4. 템플릿 변수 매핑
         Map<String, Object> variables = new HashMap<>();
         variables.put("systemPrompt", systemPrompt);
-        variables.put("todayContext", todayContext);
         variables.put("conversationHistory", conversationHistory);
         variables.put("userMessage", userMessage);
 
         // 5. 템플릿 컴파일 (변수 치환) 후 반환
         return template.compile(variables);
-    }
-
-    /**
-     * 오늘의 컨텍스트 빌드 (건강 데이터 + 날씨)
-     *
-     * 사용자의 오늘 건강 데이터와 날씨 정보를 자연어 문장으로 포맷팅
-     * AI가 맥락을 이해하고 관련 대화를 할 수 있도록 정보 제공
-     *
-     * [최적화] Context의 EnrichedHealthData 사용 - DB 재조회 없음
-     *
-     * @param context UserContext
-     * @return 포맷팅된 오늘의 컨텍스트 문자열
-     */
-    String buildTodayContext(UserContext context) {
-        StringBuilder sb = new StringBuilder();
-
-        // 사용자 이름 추출
-        UserPreferences preferences = context.getPreferences();
-        String userName = (preferences != null && preferences.getName() != null)
-                ? preferences.getName() : "사용자";
-
-        // 1. 건강 데이터 포맷팅 (EnrichedHealthData 사용)
-        EnrichedHealthData healthData = context.getEnrichedHealthData();
-        if (healthData != null) {
-            Integer steps = healthData.getSteps();
-            // sleepDurationMinutes를 시간으로 변환
-            Integer sleepMinutes = healthData.getSleepDurationMinutes();
-            Double sleepHours = (sleepMinutes != null) ? sleepMinutes / 60.0 : null;
-
-            if (steps != null || sleepHours != null) {
-                sb.append(String.format("오늘 %s님은 ", userName));
-
-                if (steps != null) {
-                    sb.append(String.format("%,d보 걸으셨고", steps));
-                }
-
-                if (sleepHours != null) {
-                    if (steps != null) {
-                        sb.append(", ");
-                    }
-                    sb.append(String.format("%.1f시간 주무셨습니다.", sleepHours));
-                } else if (steps != null) {
-                    sb.append(".");
-                }
-            }
-        }
-
-        // 2. 날씨 데이터 포맷팅
-        WeatherData weatherData = context.getTodayWeather();
-        if (weatherData != null && weatherData.getDescription() != null) {
-            if (sb.length() > 0) {
-                sb.append(" ");
-            }
-
-            String weatherDesc = weatherData.getDescription();
-            Integer temperature = weatherData.getTemperature();
-
-            if (temperature != null) {
-                sb.append(String.format("오늘 날씨는 %s이고 기온은 %d도입니다.", weatherDesc, temperature));
-            } else {
-                sb.append(String.format("오늘 날씨는 %s입니다.", weatherDesc));
-            }
-        }
-
-        return sb.toString();
     }
 
     /**

--- a/server/src/test/java/com/example/echo/health/repository/HealthLogRepositoryTest.java
+++ b/server/src/test/java/com/example/echo/health/repository/HealthLogRepositoryTest.java
@@ -97,51 +97,6 @@ class HealthLogRepositoryTest {
     }
 
     @Test
-    @DisplayName("findAverageStepsByUserIdAndDateRange - 평균 걸음 수 계산")
-    void findAverageStepsByUserIdAndDateRange() {
-        // Given
-        LocalDate startDate = TODAY.minusDays(6);
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate, 4000, 400));
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate.plusDays(1), 6000, 420));
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate.plusDays(2), 5000, 440));
-
-        // When
-        Double avgSteps = healthLogRepository.findAverageStepsByUserIdAndDateRange(
-                TEST_USER_ID, startDate, TODAY);
-
-        // Then
-        assertThat(avgSteps).isEqualTo(5000.0);
-    }
-
-    @Test
-    @DisplayName("findAverageStepsByUserIdAndDateRange - 데이터 없으면 null 반환")
-    void findAverageStepsByUserIdAndDateRange_noData() {
-        // When
-        Double avgSteps = healthLogRepository.findAverageStepsByUserIdAndDateRange(
-                TEST_USER_ID, TODAY.minusDays(7), TODAY);
-
-        // Then
-        assertThat(avgSteps).isNull();
-    }
-
-    @Test
-    @DisplayName("findAverageSleepMinutesByUserIdAndDateRange - 평균 수면 시간 계산")
-    void findAverageSleepMinutesByUserIdAndDateRange() {
-        // Given
-        LocalDate startDate = TODAY.minusDays(6);
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate, 4000, 360));
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate.plusDays(1), 5000, 420));
-        healthLogRepository.save(createHealthLog(TEST_USER_ID, startDate.plusDays(2), 6000, 480));
-
-        // When
-        Double avgSleepMinutes = healthLogRepository.findAverageSleepMinutesByUserIdAndDateRange(
-                TEST_USER_ID, startDate, TODAY);
-
-        // Then
-        assertThat(avgSleepMinutes).isEqualTo(420.0);
-    }
-
-    @Test
     @DisplayName("existsByUserIdAndRecordedDate - 데이터 존재 확인")
     void existsByUserIdAndRecordedDate() {
         // Given

--- a/server/src/test/java/com/example/echo/health/service/HealthDataServiceTest.java
+++ b/server/src/test/java/com/example/echo/health/service/HealthDataServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.echo.health.service;
 
+import com.example.echo.health.dto.EnrichedHealthData;
 import com.example.echo.health.dto.HealthData;
 import com.example.echo.health.entity.HealthLog;
 import com.example.echo.health.repository.HealthLogRepository;
@@ -13,6 +14,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,76 +152,6 @@ class HealthDataServiceTest {
 
             // Then
             assertThat(result).isNull();
-        }
-    }
-
-    @Nested
-    @DisplayName("getWeeklyAverageSteps 테스트")
-    class GetWeeklyAverageStepsTest {
-
-        @Test
-        @DisplayName("7일 평균 걸음 수 반환")
-        void getWeeklyAverageSteps() {
-            // Given
-            when(healthLogRepository.findAverageStepsByUserIdAndDateRange(
-                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
-                    .thenReturn(5000.0);
-
-            // When
-            Double result = healthDataService.getWeeklyAverageSteps(TEST_USER_ID);
-
-            // Then
-            assertThat(result).isEqualTo(5000.0);
-        }
-
-        @Test
-        @DisplayName("데이터 없으면 0.0 반환")
-        void getWeeklyAverageSteps_noData() {
-            // Given
-            when(healthLogRepository.findAverageStepsByUserIdAndDateRange(
-                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
-                    .thenReturn(null);
-
-            // When
-            Double result = healthDataService.getWeeklyAverageSteps(TEST_USER_ID);
-
-            // Then
-            assertThat(result).isEqualTo(0.0);
-        }
-    }
-
-    @Nested
-    @DisplayName("getWeeklyAverageSleepHours 테스트")
-    class GetWeeklyAverageSleepHoursTest {
-
-        @Test
-        @DisplayName("7일 평균 수면 시간(시간) 반환")
-        void getWeeklyAverageSleepHours() {
-            // Given
-            when(healthLogRepository.findAverageSleepMinutesByUserIdAndDateRange(
-                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
-                    .thenReturn(420.0);
-
-            // When
-            Double result = healthDataService.getWeeklyAverageSleepHours(TEST_USER_ID);
-
-            // Then
-            assertThat(result).isEqualTo(7.0);
-        }
-
-        @Test
-        @DisplayName("데이터 없으면 0.0 반환")
-        void getWeeklyAverageSleepHours_noData() {
-            // Given
-            when(healthLogRepository.findAverageSleepMinutesByUserIdAndDateRange(
-                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
-                    .thenReturn(null);
-
-            // When
-            Double result = healthDataService.getWeeklyAverageSleepHours(TEST_USER_ID);
-
-            // Then
-            assertThat(result).isEqualTo(0.0);
         }
     }
 
@@ -364,4 +297,182 @@ class HealthDataServiceTest {
                     .isEqualTo("평소보다 늦게");
         }
     }
+
+    @Nested
+    @DisplayName("getHealthDataByDate 테스트")
+    class GetHealthDataByDateTest {
+
+        @Test
+        @DisplayName("특정 날짜 데이터 존재 시 HealthData 반환")
+        void getHealthDataByDate_found() {
+            // Given
+            LocalDate targetDate = LocalDate.of(2026, 3, 1);
+            HealthLog healthLog = HealthLog.builder()
+                    .userId(TEST_USER_ID)
+                    .recordedDate(targetDate)
+                    .steps(8000)
+                    .sleepDurationMinutes(480)
+                    .wakeUpTime(LocalTime.of(6, 30))
+                    .exerciseActivity("등산")
+                    .build();
+
+            when(healthLogRepository.findByUserIdAndRecordedDate(TEST_USER_ID, targetDate))
+                    .thenReturn(Optional.of(healthLog));
+
+            // When
+            HealthData result = healthDataService.getHealthDataByDate(TEST_USER_ID, targetDate);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getSteps()).isEqualTo(8000);
+            assertThat(result.getSleepDurationMinutes()).isEqualTo(480);
+            assertThat(result.getExerciseActivity()).isEqualTo("등산");
+        }
+
+        @Test
+        @DisplayName("특정 날짜 데이터 없으면 null 반환")
+        void getHealthDataByDate_notFound() {
+            // Given
+            LocalDate targetDate = LocalDate.of(2026, 3, 1);
+            when(healthLogRepository.findByUserIdAndRecordedDate(TEST_USER_ID, targetDate))
+                    .thenReturn(Optional.empty());
+
+            // When
+            HealthData result = healthDataService.getHealthDataByDate(TEST_USER_ID, targetDate);
+
+            // Then
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("buildEnrichedHealthData 테스트")
+    class BuildEnrichedHealthDataTest {
+
+        @Test
+        @DisplayName("정상 케이스: 7일 평균과 평가 결과 포함")
+        void buildEnrichedHealthData_success() {
+            // Given
+            HealthData todayData = HealthData.builder()
+                    .steps(6500) // 5000 * 1.3 = 6500 (130%, "평소보다 많음" 조건: > 120%)
+                    .sleepDurationMinutes(420)
+                    .wakeUpTime(LocalTime.of(7, 0))
+                    .sleepStartTime(LocalTime.of(23, 0))
+                    .exerciseDistanceKm(2.5)
+                    .exerciseActivity("산책")
+                    .build();
+
+            List<HealthLog> weeklyLogs = List.of(
+                    createHealthLog(5000, 400, LocalTime.of(7, 10)),
+                    createHealthLog(5500, 420, LocalTime.of(7, 0)),
+                    createHealthLog(4500, 380, LocalTime.of(6, 50))
+            );
+
+            when(healthLogRepository.findByUserIdAndRecordedDateBetweenOrderByRecordedDateAsc(
+                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(weeklyLogs);
+
+            // When
+            EnrichedHealthData result = healthDataService.buildEnrichedHealthData(
+                    todayData, TEST_USER_ID, 7);
+
+            // Then
+            // 원시 데이터 확인
+            assertThat(result.getSteps()).isEqualTo(6500);
+            assertThat(result.getSleepDurationMinutes()).isEqualTo(420);
+            assertThat(result.getWakeUpTime()).isEqualTo(LocalTime.of(7, 0));
+            assertThat(result.getExerciseActivity()).isEqualTo("산책");
+
+            // 7일 평균 확인
+            assertThat(result.getAvgSteps()).isEqualTo(5000.0);
+            assertThat(result.getAvgSleepHours()).isCloseTo(6.67, org.assertj.core.api.Assertions.within(0.01));
+            assertThat(result.getAvgWakeUpTime()).isNotNull();
+
+            // 평가 결과 확인
+            assertThat(result.getStepsEvaluation()).isEqualTo("평소보다 많음"); // 6500/5000 = 1.3 > 1.2
+            assertThat(result.getSleepEvaluation()).isEqualTo("적당"); // 420분 vs 7시간(420분)
+            assertThat(result.getWakeTimeEvaluation()).isNotEmpty();
+
+            // 포맷팅 확인
+            assertThat(result.getStepsFormatted()).isEqualTo("6,500보");
+            assertThat(result.getSleepDurationFormatted()).isEqualTo("7시간");
+            assertThat(result.getExerciseDistanceFormatted()).isEqualTo("2.5km");
+        }
+
+        @Test
+        @DisplayName("todayData가 null: 빈 EnrichedHealthData 반환")
+        void buildEnrichedHealthData_nullTodayData() {
+            // Given
+            when(healthLogRepository.findByUserIdAndRecordedDateBetweenOrderByRecordedDateAsc(
+                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            EnrichedHealthData result = healthDataService.buildEnrichedHealthData(
+                    null, TEST_USER_ID, 7);
+
+            // Then
+            assertThat(result.getSteps()).isNull();
+            assertThat(result.getSleepDurationMinutes()).isNull();
+            assertThat(result.getStepsEvaluation()).isEmpty();
+            assertThat(result.getSleepEvaluation()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("7일 데이터 없음: 평균 0.0, 평가는 '데이터 없음'")
+        void buildEnrichedHealthData_noWeeklyData() {
+            // Given
+            HealthData todayData = HealthData.builder()
+                    .steps(5000)
+                    .wakeUpTime(LocalTime.of(7, 0))
+                    .build();
+
+            when(healthLogRepository.findByUserIdAndRecordedDateBetweenOrderByRecordedDateAsc(
+                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            EnrichedHealthData result = healthDataService.buildEnrichedHealthData(
+                    todayData, TEST_USER_ID, null);
+
+            // Then
+            assertThat(result.getAvgSteps()).isEqualTo(0.0);
+            assertThat(result.getAvgSleepHours()).isEqualTo(0.0);
+            assertThat(result.getAvgWakeUpTime()).isNull();
+            assertThat(result.getStepsEvaluation()).isEqualTo("데이터 없음");
+            assertThat(result.getWakeTimeEvaluation()).isEqualTo("데이터 없음");
+        }
+
+        @Test
+        @DisplayName("preferredSleepHours가 null: 수면 평가 생략")
+        void buildEnrichedHealthData_nullPreferredSleepHours() {
+            // Given
+            HealthData todayData = HealthData.builder()
+                    .sleepDurationMinutes(420)
+                    .build();
+
+            when(healthLogRepository.findByUserIdAndRecordedDateBetweenOrderByRecordedDateAsc(
+                    eq(TEST_USER_ID), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            EnrichedHealthData result = healthDataService.buildEnrichedHealthData(
+                    todayData, TEST_USER_ID, null);
+
+            // Then
+            assertThat(result.getSleepEvaluation()).isEmpty();
+            assertThat(result.getPreferredSleepHours()).isNull();
+        }
+
+        private HealthLog createHealthLog(Integer steps, Integer sleepMinutes, LocalTime wakeUpTime) {
+            return HealthLog.builder()
+                    .userId(TEST_USER_ID)
+                    .recordedDate(LocalDate.now().minusDays(1))
+                    .steps(steps)
+                    .sleepDurationMinutes(sleepMinutes)
+                    .wakeUpTime(wakeUpTime)
+                    .build();
+        }
+    }
+
 }

--- a/server/src/test/java/com/example/echo/prompt/service/PromptServiceTest.java
+++ b/server/src/test/java/com/example/echo/prompt/service/PromptServiceTest.java
@@ -137,12 +137,12 @@ class PromptServiceTest {
     // ===== buildConversationPrompt 테스트 =====
 
     @Test
-    @DisplayName("buildConversationPrompt - 정상 케이스: 4개 변수가 모두 치환됨")
+    @DisplayName("buildConversationPrompt - 정상 케이스: 3개 변수가 모두 치환됨")
     void buildConversationPrompt_success() {
         // Given
         PromptTemplate conversationTemplate = PromptTemplate.builder()
                 .type(PromptType.CONVERSATION)
-                .content("[시스템]{{systemPrompt}}\n[컨텍스트]{{todayContext}}\n[히스토리]{{conversationHistory}}\n[메시지]{{userMessage}}")
+                .content("[시스템]{{systemPrompt}}\n[히스토리]{{conversationHistory}}\n[메시지]{{userMessage}}")
                 .build();
 
         when(promptTemplateRepository.findFirstByTypeAndIsActiveTrueOrderByCreatedAtDesc(PromptType.CONVERSATION))
@@ -151,68 +151,12 @@ class PromptServiceTest {
         // Context에 시스템 프롬프트 캐싱 (실제 흐름과 동일)
         context.setSystemPrompt("시스템: 홍길동");
 
-        // When (EnrichedHealthData는 이미 Context에 있으므로 DB 조회 없음)
+        // When
         String result = promptService.buildConversationPrompt(context, "오늘 날씨 어때요?");
 
         // Then
         assertThat(result).contains("시스템: 홍길동");
-        assertThat(result).contains("5,000보 걸으셨고");
         assertThat(result).contains("오늘 날씨 어때요?");
-    }
-
-    // ===== buildTodayContext 테스트 =====
-
-    @Test
-    @DisplayName("buildTodayContext - 건강+날씨 모두 있음: 건강 정보와 날씨 정보가 함께 포맷팅")
-    void buildTodayContext_healthAndWeather() {
-        // When
-        String result = promptService.buildTodayContext(context);
-
-        // Then
-        assertThat(result).contains("홍길동님은");
-        assertThat(result).contains("5,000보 걸으셨고");
-        assertThat(result).contains("7.0시간 주무셨습니다.");
-        assertThat(result).contains("오늘 날씨는 맑음이고 기온은 20도입니다.");
-    }
-
-    @Test
-    @DisplayName("buildTodayContext - 건강 데이터만 있음: 날씨 없이 건강 정보만 출력")
-    void buildTodayContext_healthOnly() {
-        // Given
-        UserContext healthOnlyContext = UserContext.builder()
-                .userId(TEST_USER_ID)
-                .preferences(context.getPreferences())
-                .enrichedHealthData(context.getEnrichedHealthData())
-                .todayWeather(null)
-                .build();
-
-        // When
-        String result = promptService.buildTodayContext(healthOnlyContext);
-
-        // Then
-        assertThat(result).contains("5,000보 걸으셨고");
-        assertThat(result).contains("7.0시간 주무셨습니다.");
-        assertThat(result).doesNotContain("날씨");
-    }
-
-    @Test
-    @DisplayName("buildTodayContext - 날씨만 있음: 건강 없이 날씨 정보만 출력")
-    void buildTodayContext_weatherOnly() {
-        // Given
-        UserContext weatherOnlyContext = UserContext.builder()
-                .userId(TEST_USER_ID)
-                .preferences(context.getPreferences())
-                .enrichedHealthData(null)
-                .todayWeather(context.getTodayWeather())
-                .build();
-
-        // When
-        String result = promptService.buildTodayContext(weatherOnlyContext);
-
-        // Then
-        assertThat(result).doesNotContain("걸으셨고");
-        assertThat(result).doesNotContain("주무셨습니다");
-        assertThat(result).contains("오늘 날씨는 맑음이고 기온은 20도입니다.");
     }
 
     // ===== buildHistory 테스트 =====
@@ -261,6 +205,72 @@ class PromptServiceTest {
 
         // When
         String result = promptService.buildHistory(emptyHistoryContext);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // ===== buildSystemPrompt 건강 데이터 테스트 =====
+
+    @Test
+    @DisplayName("buildSystemPrompt - 건강 데이터 변수 치환 확인")
+    void buildSystemPrompt_healthDataVariables() {
+        // Given
+        PromptTemplate template = PromptTemplate.builder()
+                .type(PromptType.SYSTEM)
+                .content("걸음: {{steps}}, 수면: {{sleepInfo}}, 걸음평가: {{stepsEvaluation}}, 수면평가: {{sleepEvaluation}}")
+                .build();
+
+        when(promptTemplateRepository.findFirstByTypeAndIsActiveTrueOrderByCreatedAtDesc(PromptType.SYSTEM))
+                .thenReturn(Optional.of(template));
+
+        // When
+        String result = promptService.buildSystemPrompt(context);
+
+        // Then
+        assertThat(result).contains("걸음: 5,000보");
+        assertThat(result).contains("수면: 7시간");
+        assertThat(result).contains("걸음평가: 평소와 비슷");
+        assertThat(result).contains("수면평가: 적당");
+    }
+
+    @Test
+    @DisplayName("buildSystemPrompt - 건강 데이터 null: 빈 문자열로 치환")
+    void buildSystemPrompt_nullHealthData() {
+        // Given
+        UserContext noHealthContext = UserContext.builder()
+                .userId(TEST_USER_ID)
+                .preferences(context.getPreferences())
+                .enrichedHealthData(null)
+                .todayWeather(null)
+                .build();
+
+        PromptTemplate template = PromptTemplate.builder()
+                .type(PromptType.SYSTEM)
+                .content("걸음: [{{steps}}], 수면평가: [{{sleepEvaluation}}]")
+                .build();
+
+        when(promptTemplateRepository.findFirstByTypeAndIsActiveTrueOrderByCreatedAtDesc(PromptType.SYSTEM))
+                .thenReturn(Optional.of(template));
+
+        // When
+        String result = promptService.buildSystemPrompt(noHealthContext);
+
+        // Then
+        assertThat(result).isEqualTo("걸음: [], 수면평가: []");
+    }
+
+    @Test
+    @DisplayName("buildHistory - null 히스토리: 빈 문자열 반환")
+    void buildHistory_nullHistory() {
+        // Given
+        UserContext nullHistoryContext = UserContext.builder()
+                .userId(TEST_USER_ID)
+                .conversationHistory(null)
+                .build();
+
+        // When
+        String result = promptService.buildHistory(nullHistoryContext);
 
         // Then
         assertThat(result).isEmpty();


### PR DESCRIPTION
## 테스트 추가
- HealthDataServiceTest: buildEnrichedHealthData, getHealthDataByDate 테스트
- PromptServiceTest: buildSystemPrompt 건강 데이터 변수 치환 테스트

## 리팩토링 (미사용 코드 제거)
- HealthLogRepository: DB 평균 계산 쿼리 제거 (서버 계산 방식으로 통일)
- HealthDataService: getWeeklyAverageSteps/SleepHours/WakeTime 제거
- PromptService: buildTodayContext 제거 (시스템 프롬프트와 중복)

## 변경 근거
- 7일 평균 계산은 buildEnrichedHealthData에서 서버 측 계산으로 통일
- todayContext는 시스템 프롬프트에 이미 건강/날씨 데이터 포함되어 중복