### PR TITLE
refactor: OpenAI messages 배열 role 분리 방식 적용

### DIFF
--- a/server/src/main/java/com/example/echo/ai/service/AIService.java
+++ b/server/src/main/java/com/example/echo/ai/service/AIService.java
@@ -21,6 +21,7 @@ import com.example.echo.ai.client.OpenAIClient;
 import com.example.echo.ai.dto.ChatCompletionRequest;
 import com.example.echo.ai.dto.ChatCompletionResponse;
 import com.example.echo.ai.exception.AIException;
+import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
@@ -94,19 +95,51 @@ public class AIService {
     /**
      * 대화 응답 생성
      *
-     * @param conversationPrompt 시스템프롬프트 + 컨텍스트 + 히스토리 + 사용자메시지
+     * OpenAI 권장 방식: messages 배열에 role별로 분리하여 전송
+     * - system: 시스템 프롬프트 (AI 페르소나, 규칙)
+     * - user/assistant: 대화 히스토리
+     * - user: 현재 사용자 메시지
+     *
+     * @param systemPrompt 시스템 프롬프트 (캐싱된 것 사용)
+     * @param history 대화 히스토리 (ConversationTurn 리스트)
+     * @param userMessage 현재 사용자 메시지
      * @return AI가 생성한 응답 메시지
      * @throws AIException API 호출 실패 시
      */
-    public String generateResponse(String conversationPrompt) {
-        log.debug("Generating response with conversation prompt");
+    public String generateResponse(String systemPrompt, List<ConversationTurn> history, String userMessage) {
+        log.debug("Generating response - history size: {}, userMessage: {}",
+                history != null ? history.size() : 0, userMessage);
 
         List<ChatCompletionRequest.Message> messages = new ArrayList<>();
 
-        // 대화 프롬프트를 시스템 메시지로 전달 (컨텍스트 + 대화 히스토리 포함)
+        // 1. 시스템 프롬프트
         messages.add(ChatCompletionRequest.Message.builder()
                 .role("system")
-                .content(conversationPrompt)
+                .content(systemPrompt)
+                .build());
+
+        // 2. 대화 히스토리 (user/assistant role로 분리)
+        if (history != null) {
+            for (ConversationTurn turn : history) {
+                // 사용자 메시지가 있으면 추가 (첫 인사는 userMessage가 null일 수 있음)
+                if (turn.getUserMessage() != null) {
+                    messages.add(ChatCompletionRequest.Message.builder()
+                            .role("user")
+                            .content(turn.getUserMessage())
+                            .build());
+                }
+                // AI 응답 추가
+                messages.add(ChatCompletionRequest.Message.builder()
+                        .role("assistant")
+                        .content(turn.getAiResponse())
+                        .build());
+            }
+        }
+
+        // 3. 현재 사용자 메시지
+        messages.add(ChatCompletionRequest.Message.builder()
+                .role("user")
+                .content(userMessage)
                 .build());
 
         ChatCompletionRequest request = ChatCompletionRequest.builder()

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -43,14 +43,17 @@ public class ConversationService {
         // 1. 컨텍스트 초기화 (healthData 전달하여 DB 재조회 방지)
         UserContext context = contextService.initializeContext(userId, healthData);
 
-        // 2. 첫 인사 생성
+        // 2. 시스템 프롬프트 생성 및 컨텍스트에 캐싱 (processUserMessage에서 재사용)
         String systemPrompt = promptService.buildSystemPrompt(context);
+        context.setSystemPrompt(systemPrompt);
+
+        // 3. 첫 인사 생성
         String firstMessage = aiService.generateGreeting(systemPrompt, context);
 
-        // 3. TTS 변환
+        // 4. TTS 변환
         byte[] audioData = voiceService.textToSpeech(firstMessage, context.getPreferences().getVoiceSettings());
 
-        // 4. 히스토리 추가 (동기 - tts-retry에서 히스토리 조회 보장)
+        // 5. 히스토리 추가 (동기 - tts-retry에서 히스토리 조회 보장)
         contextService.addConversationTurn(userId, null, firstMessage);
 
         return ConversationStartResponse.builder()
@@ -68,16 +71,15 @@ public class ConversationService {
         // 2. STT 변환
         String userMessage = voiceService.speechToText(audioFile);
 
-        // 3. 프롬프트 생성
-        String conversationPrompt = promptService.buildConversationPrompt(context, userMessage);
+        // 3. AI 응답 생성 (OpenAI 권장 방식: messages 배열)
+        String systemPrompt = context.getSystemPrompt();
+        List<ConversationTurn> history = context.getConversationHistory();
+        String aiResponse = aiService.generateResponse(systemPrompt, history, userMessage);
 
-        // 4. AI 응답 생성
-        String aiResponse = aiService.generateResponse(conversationPrompt);
-
-        // 5. TTS 변환
+        // 4. TTS 변환
         byte[] audioData = voiceService.textToSpeech(aiResponse, context.getPreferences().getVoiceSettings());
 
-        // 6. 히스토리 업데이트 (동기)
+        // 5. 히스토리 업데이트 (동기)
         contextService.addConversationTurn(userId, userMessage, aiResponse);
 
         return ConversationResponse.builder()

--- a/server/src/main/java/com/example/echo/prompt/service/PromptService.java
+++ b/server/src/main/java/com/example/echo/prompt/service/PromptService.java
@@ -4,9 +4,12 @@ package com.example.echo.prompt.service;
  * [2024-02 최적화] DB 접근 최소화
  *    - EnrichedHealthData를 Context에서 직접 사용 (DB 재조회 X)
  *    - 프롬프트 템플릿에 @Cacheable 적용
+ *
+ * [2026-03 리팩토링] OpenAI 권장 방식 적용
+ *    - buildConversationPrompt, buildHistory 제거
+ *    - AIService에서 messages 배열로 직접 대화 히스토리 전송
  */
 import com.example.echo.common.dto.WeatherData;
-import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import com.example.echo.health.dto.EnrichedHealthData;
 import com.example.echo.prompt.entity.PromptTemplate;
@@ -19,7 +22,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -137,82 +139,4 @@ public class PromptService {
         // 캐시 삭제만 수행
     }
 
-    /**
-     * 대화 프롬프트 생성
-     *
-     * 사용자 발화에 대한 AI 응답 생성을 위한 프롬프트
-     * 시스템 프롬프트 + 대화 히스토리 + 사용자 메시지 조합
-     *
-     * [최적화] 시스템 프롬프트는 Context에서 캐싱된 것 사용 (재생성 X)
-     * [리팩토링] todayContext 제거 - 시스템 프롬프트에 건강/날씨 데이터 포함되어 중복
-     *
-     * 템플릿 변수: {{systemPrompt}}, {{conversationHistory}}, {{userMessage}}
-     *
-     * @param context ContextService에서 전달받은 UserContext
-     * @param userMessage 현재 사용자 발화 (STT 변환 결과)
-     * @return 컴파일된 대화 프롬프트 문자열
-     * @throws IllegalStateException 활성화된 CONVERSATION 템플릿이 없을 경우
-     */
-    public String buildConversationPrompt(UserContext context, String userMessage) {
-        // 1. 템플릿 조회 (캐싱 적용)
-        PromptTemplate template = getActiveTemplate(PromptType.CONVERSATION);
-
-        // 2. 시스템 프롬프트는 Context에서 캐싱된 것 사용 (재생성 X)
-        String systemPrompt = context.getSystemPrompt();
-
-        // 3. 대화 히스토리 빌드
-        String conversationHistory = buildHistory(context);
-
-        // 4. 템플릿 변수 매핑
-        Map<String, Object> variables = new HashMap<>();
-        variables.put("systemPrompt", systemPrompt);
-        variables.put("conversationHistory", conversationHistory);
-        variables.put("userMessage", userMessage);
-
-        // 5. 템플릿 컴파일 (변수 치환) 후 반환
-        return template.compile(variables);
-    }
-
-    /**
-     * 대화 히스토리 빌드
-     *
-     * 오늘의 대화 히스토리를 턴별로 포맷팅
-     * AI가 이전 대화 맥락을 유지할 수 있도록 정보 제공
-     *
-     * 출력 형식:
-     * [턴 1]
-     * 사용자: (사용자 발화)
-     * AI: (AI 응답)
-     *
-     * [턴 2]
-     * ...
-     *
-     * @param context UserContext
-     * @return 포맷팅된 대화 히스토리 문자열 (히스토리가 없으면 빈 문자열)
-     */
-    String buildHistory(UserContext context) {
-        List<ConversationTurn> history = context.getConversationHistory();
-
-        // 히스토리가 없거나 비어있으면 빈 문자열 반환
-        if (history == null || history.isEmpty()) {
-            return "";
-        }
-
-        // 각 턴을 포맷팅하여 문자열로 조합
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < history.size(); i++) {
-            ConversationTurn turn = history.get(i);
-
-            sb.append(String.format("[턴 %d]\n", i + 1));
-            sb.append(String.format("사용자: %s\n", turn.getUserMessage()));
-            sb.append(String.format("AI: %s", turn.getAiResponse()));
-
-            // 마지막 턴이 아니면 구분선 추가
-            if (i < history.size() - 1) {
-                sb.append("\n\n");
-            }
-        }
-
-        return sb.toString();
-    }
 }

--- a/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
@@ -4,6 +4,7 @@ import com.example.echo.ai.client.OpenAIClient;
 import com.example.echo.ai.dto.ChatCompletionRequest;
 import com.example.echo.ai.dto.ChatCompletionResponse;
 import com.example.echo.ai.exception.AIException;
+import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -99,37 +102,52 @@ class AIServiceTest {
     // ===== generateResponse 테스트 =====
 
     @Test
-    @DisplayName("generateResponse - 정상 케이스: conversationPrompt가 system 메시지로 전달")
+    @DisplayName("generateResponse - 정상 케이스: system/user/assistant role로 messages 배열 구성")
     void generateResponse_success() {
         // Given
-        String conversationPrompt = "시스템 프롬프트 + 컨텍스트 + 히스토리 + 사용자 메시지";
+        String systemPrompt = "당신은 친근한 대화 상대입니다.";
+        List<ConversationTurn> history = new ArrayList<>();
+        history.add(ConversationTurn.builder()
+                .userMessage("안녕하세요")
+                .aiResponse("안녕하세요! 오늘 기분이 어떠세요?")
+                .timestamp(LocalDateTime.now())
+                .build());
+        String userMessage = "오늘 날씨가 좋네요";
+
         ChatCompletionResponse response = createMockResponse("좋은 질문이네요!");
 
         when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenReturn(response);
 
         // When
-        String result = aiService.generateResponse(conversationPrompt);
+        String result = aiService.generateResponse(systemPrompt, history, userMessage);
 
         // Then
         assertThat(result).isEqualTo("좋은 질문이네요!");
 
-        // 메시지 구조 검증
+        // 메시지 구조 검증: system(1) + history(user+assistant)(2) + current user(1) = 4
         ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);
         when(openAIClient.createChatCompletion(captor.capture())).thenReturn(response);
-        aiService.generateResponse(conversationPrompt);
+        aiService.generateResponse(systemPrompt, history, userMessage);
 
         ChatCompletionRequest capturedRequest = captor.getValue();
-        assertThat(capturedRequest.getMessages()).hasSize(1);
+        assertThat(capturedRequest.getMessages()).hasSize(4);
         assertThat(capturedRequest.getMessages().get(0).getRole()).isEqualTo("system");
-        assertThat(capturedRequest.getMessages().get(0).getContent()).isEqualTo(conversationPrompt);
+        assertThat(capturedRequest.getMessages().get(0).getContent()).isEqualTo(systemPrompt);
+        assertThat(capturedRequest.getMessages().get(1).getRole()).isEqualTo("user");
+        assertThat(capturedRequest.getMessages().get(2).getRole()).isEqualTo("assistant");
+        assertThat(capturedRequest.getMessages().get(3).getRole()).isEqualTo("user");
+        assertThat(capturedRequest.getMessages().get(3).getContent()).isEqualTo(userMessage);
     }
 
     @Test
     @DisplayName("generateResponse - API 실패: FeignException → AIException 변환")
     void generateResponse_apiFailure() {
         // Given
-        String conversationPrompt = "대화 프롬프트";
+        String systemPrompt = "시스템 프롬프트";
+        List<ConversationTurn> history = new ArrayList<>();
+        String userMessage = "오늘 날씨 어때요?";
+
         FeignException feignException = mock(FeignException.class);
         when(feignException.status()).thenReturn(429);
         when(feignException.getMessage()).thenReturn("Rate Limit Exceeded");
@@ -138,7 +156,7 @@ class AIServiceTest {
                 .thenThrow(feignException);
 
         // When & Then
-        assertThatThrownBy(() -> aiService.generateResponse(conversationPrompt))
+        assertThatThrownBy(() -> aiService.generateResponse(systemPrompt, history, userMessage))
                 .isInstanceOf(AIException.class)
                 .hasMessageContaining("AI 응답 생성 실패")
                 .hasCause(feignException);
@@ -150,6 +168,10 @@ class AIServiceTest {
     @DisplayName("extractContent - 빈 응답: response가 null이거나 choices가 비어있을 때 빈 문자열 반환")
     void extractContent_emptyResponse() {
         // Given - null choices
+        String systemPrompt = "시스템 프롬프트";
+        List<ConversationTurn> history = new ArrayList<>();
+        String userMessage = "테스트 메시지";
+
         ChatCompletionResponse nullChoicesResponse = mock(ChatCompletionResponse.class);
         when(nullChoicesResponse.getChoices()).thenReturn(null);
 
@@ -157,7 +179,7 @@ class AIServiceTest {
                 .thenReturn(nullChoicesResponse);
 
         // When
-        String result1 = aiService.generateResponse("프롬프트");
+        String result1 = aiService.generateResponse(systemPrompt, history, userMessage);
 
         // Then
         assertThat(result1).isEmpty();
@@ -170,7 +192,7 @@ class AIServiceTest {
                 .thenReturn(emptyChoicesResponse);
 
         // When
-        String result2 = aiService.generateResponse("프롬프트");
+        String result2 = aiService.generateResponse(systemPrompt, history, userMessage);
 
         // Then
         assertThat(result2).isEmpty();

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -154,14 +154,17 @@ class ConversationServiceTest2 {
             );
 
             String userMessage = "오늘 날씨가 좋아서 산책했어요";
-            String conversationPrompt = "대화 프롬프트";
+            String systemPrompt = "시스템 프롬프트";
             String aiResponse = "산책하셨군요! 어디를 다녀오셨나요?";
             byte[] responseAudio = "response audio".getBytes();
 
+            // Context에 systemPrompt 설정
+            mockContext.setSystemPrompt(systemPrompt);
+
             given(contextService.getContext(userId)).willReturn(mockContext);
             given(voiceService.speechToText(audioFile)).willReturn(userMessage);
-            given(promptService.buildConversationPrompt(mockContext, userMessage)).willReturn(conversationPrompt);
-            given(aiService.generateResponse(conversationPrompt)).willReturn(aiResponse);
+            // OpenAI 권장 방식: messages 배열로 직접 전달
+            given(aiService.generateResponse(eq(systemPrompt), any(), eq(userMessage))).willReturn(aiResponse);
             given(voiceService.textToSpeech(aiResponse, mockVoiceSettings)).willReturn(responseAudio);
 
             // when
@@ -175,7 +178,7 @@ class ConversationServiceTest2 {
         }
 
         @Test
-        @DisplayName("성공: STT → AI → TTS 순서로 처리된다")
+        @DisplayName("성공: STT → AI → TTS 순서로 처리된다 (messages 배열 방식)")
         void success_processesInCorrectOrder() {
             // given
             MultipartFile audioFile = new MockMultipartFile(
@@ -183,25 +186,25 @@ class ConversationServiceTest2 {
             );
 
             String userMessage = "테스트 메시지";
-            String prompt = "프롬프트";
+            String systemPrompt = "시스템 프롬프트";
             String aiResponse = "AI 응답";
             byte[] audio = "audio".getBytes();
 
+            mockContext.setSystemPrompt(systemPrompt);
+
             given(contextService.getContext(userId)).willReturn(mockContext);
             given(voiceService.speechToText(audioFile)).willReturn(userMessage);
-            given(promptService.buildConversationPrompt(mockContext, userMessage)).willReturn(prompt);
-            given(aiService.generateResponse(prompt)).willReturn(aiResponse);
+            given(aiService.generateResponse(eq(systemPrompt), any(), eq(userMessage))).willReturn(aiResponse);
             given(voiceService.textToSpeech(aiResponse, mockVoiceSettings)).willReturn(audio);
 
             // when
             conversationService.processUserMessage(userId, audioFile);
 
-            // then
-            var inOrder = inOrder(contextService, voiceService, promptService, aiService);
+            // then (PromptService.buildConversationPrompt 호출 제거됨)
+            var inOrder = inOrder(contextService, voiceService, aiService);
             inOrder.verify(contextService).getContext(userId);
             inOrder.verify(voiceService).speechToText(audioFile);
-            inOrder.verify(promptService).buildConversationPrompt(mockContext, userMessage);
-            inOrder.verify(aiService).generateResponse(prompt);
+            inOrder.verify(aiService).generateResponse(eq(systemPrompt), any(), eq(userMessage));
             inOrder.verify(voiceService).textToSpeech(aiResponse, mockVoiceSettings);
         }
 

--- a/server/src/test/java/com/example/echo/prompt/service/PromptServiceTest.java
+++ b/server/src/test/java/com/example/echo/prompt/service/PromptServiceTest.java
@@ -1,7 +1,6 @@
 package com.example.echo.prompt.service;
 
 import com.example.echo.common.dto.WeatherData;
-import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import com.example.echo.health.dto.EnrichedHealthData;
 import com.example.echo.prompt.entity.PromptTemplate;
@@ -16,9 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -134,82 +130,6 @@ class PromptServiceTest {
         assertThat(result).isEqualTo("안녕하세요 사용자님");
     }
 
-    // ===== buildConversationPrompt 테스트 =====
-
-    @Test
-    @DisplayName("buildConversationPrompt - 정상 케이스: 3개 변수가 모두 치환됨")
-    void buildConversationPrompt_success() {
-        // Given
-        PromptTemplate conversationTemplate = PromptTemplate.builder()
-                .type(PromptType.CONVERSATION)
-                .content("[시스템]{{systemPrompt}}\n[히스토리]{{conversationHistory}}\n[메시지]{{userMessage}}")
-                .build();
-
-        when(promptTemplateRepository.findFirstByTypeAndIsActiveTrueOrderByCreatedAtDesc(PromptType.CONVERSATION))
-                .thenReturn(Optional.of(conversationTemplate));
-
-        // Context에 시스템 프롬프트 캐싱 (실제 흐름과 동일)
-        context.setSystemPrompt("시스템: 홍길동");
-
-        // When
-        String result = promptService.buildConversationPrompt(context, "오늘 날씨 어때요?");
-
-        // Then
-        assertThat(result).contains("시스템: 홍길동");
-        assertThat(result).contains("오늘 날씨 어때요?");
-    }
-
-    // ===== buildHistory 테스트 =====
-
-    @Test
-    @DisplayName("buildHistory - 대화 히스토리 존재: 턴별로 포맷팅")
-    void buildHistory_withHistory() {
-        // Given
-        List<ConversationTurn> history = new ArrayList<>();
-        history.add(ConversationTurn.builder()
-                .userMessage("안녕하세요")
-                .aiResponse("안녕하세요! 오늘 기분이 어떠세요?")
-                .timestamp(LocalDateTime.now())
-                .build());
-        history.add(ConversationTurn.builder()
-                .userMessage("좋아요")
-                .aiResponse("다행이네요!")
-                .timestamp(LocalDateTime.now())
-                .build());
-
-        UserContext contextWithHistory = UserContext.builder()
-                .userId(TEST_USER_ID)
-                .conversationHistory(history)
-                .build();
-
-        // When
-        String result = promptService.buildHistory(contextWithHistory);
-
-        // Then
-        assertThat(result).contains("[턴 1]");
-        assertThat(result).contains("사용자: 안녕하세요");
-        assertThat(result).contains("AI: 안녕하세요! 오늘 기분이 어떠세요?");
-        assertThat(result).contains("[턴 2]");
-        assertThat(result).contains("사용자: 좋아요");
-        assertThat(result).contains("AI: 다행이네요!");
-    }
-
-    @Test
-    @DisplayName("buildHistory - 히스토리 비어있음: 빈 문자열 반환")
-    void buildHistory_emptyHistory() {
-        // Given
-        UserContext emptyHistoryContext = UserContext.builder()
-                .userId(TEST_USER_ID)
-                .conversationHistory(new ArrayList<>())
-                .build();
-
-        // When
-        String result = promptService.buildHistory(emptyHistoryContext);
-
-        // Then
-        assertThat(result).isEmpty();
-    }
-
     // ===== buildSystemPrompt 건강 데이터 테스트 =====
 
     @Test
@@ -258,21 +178,5 @@ class PromptServiceTest {
 
         // Then
         assertThat(result).isEqualTo("걸음: [], 수면평가: []");
-    }
-
-    @Test
-    @DisplayName("buildHistory - null 히스토리: 빈 문자열 반환")
-    void buildHistory_nullHistory() {
-        // Given
-        UserContext nullHistoryContext = UserContext.builder()
-                .userId(TEST_USER_ID)
-                .conversationHistory(null)
-                .build();
-
-        // When
-        String result = promptService.buildHistory(nullHistoryContext);
-
-        // Then
-        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
- AIService.generateResponse 시그니처 변경 (conversationPrompt → systemPrompt, history, userMessage)
- PromptService에서 buildConversationPrompt, buildHistory 제거
- ConversationService에서 systemPrompt 캐싱 추가
- 관련 테스트 코드 수정