### PR TITLE
fix: Health Connect 권한 안내 재표시 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthConnectPermissionHandler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthConnectPermissionHandler.kt
@@ -45,7 +45,8 @@ fun HealthConnectPermissionHandler(
     }
 
     // 앱 시작 시 자동 다이얼로그 표시
-    LaunchedEffect(uiState.availability, uiState.permissionState) {
+    LaunchedEffect(uiState.availability, uiState.permissionState, uiState.isLoading) {
+        if (uiState.isLoading) return@LaunchedEffect
         when {
             uiState.availability is HealthConnectAvailability.NotInstalled ->
                 showNotInstalled = true

--- a/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
@@ -60,7 +60,6 @@ class HealthViewModel(
                 } catch (e: Exception) {
                     _uiState.update {
                         it.copy(
-                            availability = availability,
                             errorMessage = "건강 데이터 권한을 확인할 수 없습니다"
                         )
                     }


### PR DESCRIPTION
## Summary

- `HealthViewModel`: `checkInitialState()` catch 블록에서 `availability = availability` 제거 → 예외 발생 시 `NotSupported` 유지로 `Available && NotRequested` 조건 불일치, 다이얼로그 미발화
- `HealthConnectPermissionHandler`: `LaunchedEffect` key에 `uiState.isLoading` 추가 + `if (isLoading) return@LaunchedEffect` 가드 → 로딩 중 중간 state 전환으로 인한 Rationale 다이얼로그 오발화 차단

## 재현 조건

권한 허용 상태에서 앱 캐시/데이터 삭제 → 앱 재시작 시 "권한 허용하기" 다이얼로그가 불필요하게 재표시되는 버그

## Test plan

- [ ] 권한 허용 → 앱 데이터 삭제 → 앱 재시작 → 다이얼로그 미표시 확인
- [ ] 권한 미허용 상태 → 앱 시작 → Rationale 다이얼로그 정상 표시 확인
- [ ] `checkGrantedPermissions()` 예외 상황 → 에러 메시지만 표시, 권한 다이얼로그 미표시 확인
- [ ] onResume 시 권한 상태 정상 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)