### PR TITLE
fix: Health Connect READ_DISTANCE 권한 누락 및 checkPermissions 상태 전이 버그 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.READ_DISTANCE" />
 
     <uses-feature android:name="android.hardware.microphone" android:required="true" />
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/health/HealthViewModel.kt
@@ -74,8 +74,13 @@ class HealthViewModel(
     private suspend fun checkPermissions() {
         try {
             val allGranted = healthConnectManager.checkGrantedPermissions()
-            _uiState.update {
-                it.copy(permissionState = if (allGranted) PermissionState.Granted else PermissionState.NotRequested)
+            _uiState.update { current ->
+                val newState = when {
+                    allGranted -> PermissionState.Granted
+                    current.permissionState is PermissionState.Denied -> PermissionState.Denied
+                    else -> PermissionState.NotRequested
+                }
+                current.copy(permissionState = newState)
             }
         } catch (e: Exception) {
             _uiState.update { it.copy(errorMessage = "건강 데이터 권한을 확인할 수 없습니다") }

--- a/android/app/src/test/java/com/example/graduation_project/presentation/health/HealthViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/health/HealthViewModelTest.kt
@@ -1,0 +1,144 @@
+package com.example.graduation_project.presentation.health
+
+import android.app.Application
+import com.example.graduation_project.data.health.HealthConnectManager
+import com.example.graduation_project.domain.health.HealthConnectAvailability
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * HealthViewModel 단위 테스트
+ *
+ * ## 테스트 대상
+ * - checkPermissions() 상태 전이: Denied 상태가 NotRequested로 덮어씌워지는 버그 수정 검증
+ *
+ * ## 검증 시나리오
+ * | 현재 상태    | allGranted | 기대 상태      |
+ * |------------|------------|--------------|
+ * | Denied     | false      | Denied (유지) |
+ * | NotRequested | false    | NotRequested |
+ * | Denied     | true       | Granted      |
+ * | Granted    | false      | NotRequested |
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HealthViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = HealthMainDispatcherRule()
+
+    private val mockApplication = mockk<Application>(relaxed = true)
+    private val mockManager = mockk<HealthConnectManager>()
+
+    @Before
+    fun setUp() {
+        // checkInitialState()에서 Available 반환, 초기 권한은 미부여
+        every { mockManager.checkAvailability() } returns HealthConnectAvailability.Available
+        coEvery { mockManager.checkGrantedPermissions() } returns false
+    }
+
+    private fun createViewModel(): HealthViewModel =
+        HealthViewModel(mockApplication, mockManager)
+
+    // ===== checkPermissions 상태 전이 테스트 =====
+
+    @Test
+    fun `checkPermissions - Denied 상태에서 권한 미부여 시 Denied 유지`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val vm = createViewModel()
+            advanceUntilIdle()                  // checkInitialState() 완료 → NotRequested
+
+            vm.onPermissionsResult(emptySet())  // → Denied
+            assertEquals(PermissionState.Denied, vm.uiState.value.permissionState)
+
+            // onResume → refreshPermissions() 시뮬레이션 (allGranted=false)
+            vm.refreshPermissions()
+            advanceUntilIdle()
+
+            assertEquals(PermissionState.Denied, vm.uiState.value.permissionState)
+        }
+
+    @Test
+    fun `checkPermissions - NotRequested 상태에서 권한 미부여 시 NotRequested 유지`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val vm = createViewModel()
+            advanceUntilIdle()  // checkInitialState() 완료 → NotRequested
+
+            assertEquals(PermissionState.NotRequested, vm.uiState.value.permissionState)
+
+            vm.refreshPermissions()
+            advanceUntilIdle()
+
+            assertEquals(PermissionState.NotRequested, vm.uiState.value.permissionState)
+        }
+
+    @Test
+    fun `checkPermissions - Denied 상태에서 권한 부여 시 Granted 전환`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.onPermissionsResult(emptySet())  // → Denied
+            assertEquals(PermissionState.Denied, vm.uiState.value.permissionState)
+
+            coEvery { mockManager.checkGrantedPermissions() } returns true
+            vm.refreshPermissions()
+            advanceUntilIdle()
+
+            assertEquals(PermissionState.Granted, vm.uiState.value.permissionState)
+        }
+
+    @Test
+    fun `checkPermissions - Granted 상태에서 권한 취소 시 NotRequested 전환`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            coEvery { mockManager.checkGrantedPermissions() } returns true
+            val vm = createViewModel()
+            advanceUntilIdle()  // checkInitialState() 완료 → Granted
+
+            assertEquals(PermissionState.Granted, vm.uiState.value.permissionState)
+
+            coEvery { mockManager.checkGrantedPermissions() } returns false
+            vm.refreshPermissions()
+            advanceUntilIdle()
+
+            assertEquals(PermissionState.NotRequested, vm.uiState.value.permissionState)
+        }
+
+    // ===== Health Connect 미지원 환경 테스트 =====
+
+    @Test
+    fun `Health Connect 미지원 환경에서 refreshPermissions 호출 시 아무 변화 없음`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            every { mockManager.checkAvailability() } returns HealthConnectAvailability.NotSupported
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val stateBefore = vm.uiState.value.permissionState
+            vm.refreshPermissions()
+            advanceUntilIdle()
+
+            assertEquals(stateBefore, vm.uiState.value.permissionState)
+        }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HealthMainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description?) = Dispatchers.setMain(testDispatcher)
+    override fun finished(description: Description?) = Dispatchers.resetMain()
+}


### PR DESCRIPTION
## Summary

- `AndroidManifest.xml`에 `READ_DISTANCE` 권한 누락으로 `checkGrantedPermissions()`가 항상 `false`를 반환, Health Connect에 접근하지 못하고 빈 `HealthData()`가 서버로 전송되던 Root Cause 수정
- `HealthViewModel.checkPermissions()`에서 `Denied` 상태가 `NotRequested`로 덮어씌워져 권한 안내 다이얼로그가 무한 재표시되던 상태 전이 버그 수정
- `HealthViewModelTest` 추가로 4가지 상태 전이 시나리오 및 미지원 환경 케이스 검증 (5/5 통과)

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `AndroidManifest.xml` | `READ_DISTANCE` 권한 선언 추가 |
| `HealthViewModel.kt` | `checkPermissions()` 상태 전이 수정 — `Denied` 상태 유지 |
| `HealthViewModelTest.kt` | 신규 단위 테스트 5개 추가 |

## Test plan

- [x] `assembleDebug` 빌드 성공
- [x] `HealthViewModelTest` 5/5 통과
  - `Denied` + 권한 미부여 → `Denied` 유지 (무한 루프 방지)
  - `NotRequested` + 권한 미부여 → `NotRequested` 유지
  - `Denied` + 권한 부여 → `Granted` 전환
  - `Granted` + 권한 취소 → `NotRequested` 전환 (재요청 유도)
  - Health Connect 미지원 환경 → 상태 변화 없음
- [ ] 실기기: 권한 최초 부여 후 재진입 시 다이얼로그 재표시 없음 확인
- [ ] 실기기: 권한 거부 후 재진입 시 Denied 다이얼로그만 표시 확인
- [ ] 실기기: 대화 시작 후 서버로 non-null 건강 데이터 전송 확인 (로그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)