### PR TITLE
fix: activityList null 버그 수정 — 오늘 운동 활동 목록 수집 구현

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
@@ -156,6 +156,27 @@ class HealthConnectManager(private val context: Context) {
         return if (totalKm > 0.0) totalKm else null
     }
 
+    /**
+     * 오늘 자정(00:00) → 현재 범위의 모든 운동 활동 목록.
+     * 중복 제거 후 쉼표 구분 한국어 문자열 반환. 레코드 없으면 null.
+     */
+    suspend fun readTodayActivityList(): String? {
+        val client = HealthConnectClient.getOrCreate(context)
+        val zone = ZoneId.systemDefault()
+        val startTime = LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val endTime = Instant.now()
+
+        val response = client.readRecords(
+            ReadRecordsRequest(ExerciseSessionRecord::class, TimeRangeFilter.between(startTime, endTime))
+        )
+        if (response.records.isEmpty()) return null
+
+        return response.records
+            .map { exerciseTypeToKorean(it.exerciseType) }
+            .distinct()
+            .joinToString(",")
+    }
+
     private fun exerciseTypeToKorean(type: Int): String = when (type) {
         ExerciseSessionRecord.EXERCISE_TYPE_WALKING -> "걷기"
         ExerciseSessionRecord.EXERCISE_TYPE_RUNNING -> "달리기"

--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectRepositoryImpl.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectRepositoryImpl.kt
@@ -21,4 +21,6 @@ class HealthConnectRepositoryImpl(
     override suspend fun readTodaySteps(): Int? = manager.readTodaySteps()
 
     override suspend fun readLatestExercise(): Pair<Double?, String?> = manager.readLatestExercise()
+
+    override suspend fun readTodayActivityList(): String? = manager.readTodayActivityList()
 }

--- a/android/app/src/main/java/com/example/graduation_project/domain/health/IHealthRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/health/IHealthRepository.kt
@@ -29,4 +29,10 @@ interface IHealthRepository {
      * @return Pair(거리km, 운동종류한국어), 데이터 없으면 Pair(null, null)
      */
     suspend fun readLatestExercise(): Pair<Double?, String?>
+
+    /**
+     * 오늘 자정(00:00) → 현재 범위의 모든 운동 활동 목록.
+     * @return 쉼표 구분 한국어 활동명 (예: "걷기,달리기"), 데이터 없으면 null
+     */
+    suspend fun readTodayActivityList(): String?
 }

--- a/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/usecase/GetHealthDataUseCase.kt
@@ -22,6 +22,7 @@ class GetHealthDataUseCase(
         val sleep = runCatching { repository.readYesterdaySleep() }.getOrDefault(SleepSummary(null, null, null))
         val steps = runCatching { repository.readTodaySteps() }.getOrNull().sanitizeSteps()
         val exercise = runCatching { repository.readLatestExercise() }.getOrDefault(Pair(null, null))
+        val activityList = runCatching { repository.readTodayActivityList() }.getOrNull()
 
         return HealthData(
             sleepDurationMinutes = sleep.minutes.sanitizeSleep(),
@@ -29,7 +30,8 @@ class GetHealthDataUseCase(
             wakeUpTime = sleep.wakeUpTime,
             steps = steps,
             exerciseDistanceKm = exercise.first.sanitizeDistance(),
-            exerciseActivity = exercise.second
+            exerciseActivity = exercise.second,
+            activityList = activityList
         )
     }
 


### PR DESCRIPTION
## Summary
- `HealthConnectManager`에 `readTodayActivityList()` 추가 — 오늘 자정~현재의 모든 `ExerciseSessionRecord` 조회, 중복 제거 후 쉼표 구분 한국어 문자열 반환
- `IHealthRepository` 인터페이스에 `readTodayActivityList(): String?` 메서드 추가
- `HealthConnectRepositoryImpl`에 구현체 추가
- `GetHealthDataUseCase`에서 `activityList` 수집 후 `HealthData`에 설정 — 기존 `// 추후 구현` 미설정 버그 수정

## Root Cause
`GetHealthDataUseCase`가 `activityList` 필드를 설정하지 않아 `{{activityList}}` placeholder가 항상 null/빈 문자열로 치환되던 문제.

## Test plan
- [ ] `./gradlew assembleDebug` 빌드 통과 확인
- [ ] 운동 기록이 있는 기기에서 대화 시작 후 서버 로그에서 `activityList` 값 확인
- [ ] 운동 기록이 없는 경우 null 정상 처리 (graceful degradation) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)