### PR TITLE
feat: [US5.3] Kakao 역지오코딩 GeocodingClient 구현 (T5.3-1, #230)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ nul
 ### Local config (contains secrets) ###
 local.properties
 .env
+
+### Android build outputs ###
+android/app/prod/

--- a/server/src/main/java/com/example/echo/location/client/GeocodingClient.java
+++ b/server/src/main/java/com/example/echo/location/client/GeocodingClient.java
@@ -1,0 +1,29 @@
+package com.example.echo.location.client;
+
+import com.example.echo.location.dto.KakaoGeocodingResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Kakao 역지오코딩 Feign 클라이언트
+ *
+ * 좌표(위도/경도) → 주소명 변환
+ *
+ * 주의: Kakao API는 x=경도(lon), y=위도(lat) 순서
+ *       GPS의 lat/lon과 반대이므로 호출 시 반드시 확인
+ */
+@FeignClient(
+        name = "kakao-geocoding",
+        url = "${kakao.api.url}",
+        configuration = KakaoFeignConfig.class
+)
+public interface GeocodingClient {
+
+    @GetMapping("/v2/local/geo/coord2address.json")
+    KakaoGeocodingResponse reverseGeocode(
+            @RequestParam("x") double lon,
+            @RequestParam("y") double lat,
+            @RequestParam("input_coord") String inputCoord
+    );
+}

--- a/server/src/main/java/com/example/echo/location/client/KakaoFeignConfig.java
+++ b/server/src/main/java/com/example/echo/location/client/KakaoFeignConfig.java
@@ -1,0 +1,23 @@
+package com.example.echo.location.client;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Kakao API 인증 설정
+ * - Authorization: KakaoAK {key} 헤더 자동 추가
+ *
+ * @Configuration 없음 - @FeignClient의 configuration= 속성으로만 사용
+ * (컴포넌트 스캔 대상에서 제외하여 전역 Bean 등록 방지)
+ */
+public class KakaoFeignConfig {
+
+    @Value("${kakao.api.key}")
+    private String apiKey;
+
+    @Bean
+    public RequestInterceptor kakaoAuthInterceptor() {
+        return template -> template.header("Authorization", "KakaoAK " + apiKey);
+    }
+}

--- a/server/src/main/java/com/example/echo/location/dto/KakaoGeocodingResponse.java
+++ b/server/src/main/java/com/example/echo/location/dto/KakaoGeocodingResponse.java
@@ -1,0 +1,64 @@
+package com.example.echo.location.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Kakao 좌표 → 주소 변환 API 응답 DTO
+ *
+ * API: GET /v2/local/geo/coord2address.json
+ * 문서: https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-address
+ */
+@Data
+public class KakaoGeocodingResponse {
+
+    private List<Document> documents;
+
+    @Data
+    public static class Document {
+        private Address address;
+
+        @JsonProperty("road_address")
+        private RoadAddress roadAddress;
+    }
+
+    @Data
+    public static class Address {
+        @JsonProperty("address_name")
+        private String addressName;      // 예: "서울 강남구 역삼동 737"
+    }
+
+    @Data
+    public static class RoadAddress {
+        @JsonProperty("address_name")
+        private String addressName;      // 예: "서울 강남구 테헤란로 152"
+
+        @JsonProperty("building_name")
+        private String buildingName;     // 예: "강남파이낸스센터" (없으면 빈 문자열)
+    }
+
+    /**
+     * 빌딩명 > 도로명주소 > 지번주소 순으로 가장 의미 있는 장소명 반환
+     */
+    public String getBestPlaceName() {
+        if (documents == null || documents.isEmpty()) return null;
+
+        Document doc = documents.get(0);
+
+        if (doc.getRoadAddress() != null
+                && doc.getRoadAddress().getBuildingName() != null
+                && !doc.getRoadAddress().getBuildingName().isBlank()) {
+            return doc.getRoadAddress().getBuildingName();
+        }
+        if (doc.getRoadAddress() != null
+                && doc.getRoadAddress().getAddressName() != null) {
+            return doc.getRoadAddress().getAddressName();
+        }
+        if (doc.getAddress() != null) {
+            return doc.getAddress().getAddressName();
+        }
+        return null;
+    }
+}

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -21,6 +21,10 @@ openai:
   api:
     key: ${OPENAI_API_KEY}
 
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}
+
 azure:
   tts:
     endpoint: https://koreacentral.tts.speech.microsoft.com

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -34,6 +34,11 @@ openai:
     temperature: 0.7
     max-tokens: 1024
 
+kakao:
+  api:
+    url: https://dapi.kakao.com
+    # key는 application-local.yaml에서 설정
+
 # Azure Cognitive Services TTS 설정
 azure:
   tts:


### PR DESCRIPTION
## Summary

- `location/client/GeocodingClient`: Kakao 좌표→주소 변환 Feign 인터페이스
- `location/client/KakaoFeignConfig`: KakaoAK 인증 헤더 자동 주입
- `location/dto/KakaoGeocodingResponse`: 빌딩명 > 도로명 > 지번 우선순위 장소명 반환
- `application.yaml`: `kakao.api.url` 추가
- `application-prod.yaml`: `kakao.api.key: ${KAKAO_API_KEY}` 환경변수 설정
- `.gitignore`: `android/app/prod/` 빌드 아웃풋 제외

## 패키지 구조 결정

`geocoding/` 패키지 대신 `location/` 패키지로 구성 (DDD 도메인 중심)
→ `voice/client/STTClient` 패턴과 일관성 유지

## 주의사항

Kakao API는 `x=경도(lon)`, `y=위도(lat)` — GPS와 순서 반대

## Test plan

- [ ] `./gradlew compileJava` 빌드 성공 확인
- [ ] T5.3-2(캐싱) 완료 후 GeocodingService 통합 테스트

Closes #230