### PR TITLE
fix: Android 빌드 오류 수정 (중복 의존성, 단위 테스트)

### DIFF
--- a/android/app/src/test/java/com/example/graduation_project/data/location/LocationDataManagerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/location/LocationDataManagerTest.kt
@@ -5,14 +5,15 @@ import com.example.graduation_project.data.health.HealthConnectManager
 import com.example.graduation_project.domain.health.StayPointDetector
 import com.example.graduation_project.domain.model.LocationPoint
 import com.example.graduation_project.domain.model.StayPoint
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import java.time.Instant
 
 class LocationDataManagerTest {
@@ -24,41 +25,41 @@ class LocationDataManagerTest {
 
     @Before
     fun setUp() {
-        locationManager = mock()
-        healthConnectManager = mock()
-        stayPointDetector = mock()
+        locationManager = mockk()
+        healthConnectManager = mockk()
+        stayPointDetector = mockk()
         manager = LocationDataManager(locationManager, healthConnectManager, stayPointDetector)
     }
 
     @Test
     fun `현재 위치 null이면 null 반환`() = runTest {
-        whenever(locationManager.getCurrentLocation()).thenReturn(null)
+        coEvery { locationManager.getCurrentLocation() } returns null
 
         assertNull(manager.collectLocationData())
     }
 
     @Test
     fun `운동 기록 없으면 visitedPlaces 비어있고 totalDistanceKm 0`() = runTest {
-        val location = mock<Location>().also {
-            whenever(it.latitude).thenReturn(37.5665)
-            whenever(it.longitude).thenReturn(126.9780)
+        val location = mockk<Location>().apply {
+            every { latitude } returns 37.5665
+            every { longitude } returns 126.9780
         }
-        whenever(locationManager.getCurrentLocation()).thenReturn(location)
-        whenever(healthConnectManager.readExerciseSessionLocations()).thenReturn(emptyList())
-        whenever(stayPointDetector.detect(emptyList())).thenReturn(emptyList())
+        coEvery { locationManager.getCurrentLocation() } returns location
+        coEvery { healthConnectManager.readExerciseSessionLocations() } returns emptyList()
+        every { stayPointDetector.detect(emptyList()) } returns emptyList()
 
         val result = manager.collectLocationData()
 
         assertNotNull(result)
         assertEquals(emptyList<Any>(), result!!.visitedPlaces)
-        assertEquals(0.0, result.totalDistanceKm, 0.001)
+        assertEquals(0.0, result.totalDistanceKm ?: 0.0, 0.001)
     }
 
     @Test
     fun `StayPoint가 RawVisitedPlace로 정상 변환됨`() = runTest {
-        val location = mock<Location>().also {
-            whenever(it.latitude).thenReturn(37.5665)
-            whenever(it.longitude).thenReturn(126.9780)
+        val location = mockk<Location>().apply {
+            every { latitude } returns 37.5665
+            every { longitude } returns 126.9780
         }
         val stayPoint = StayPoint(
             latitude = 37.5172,
@@ -67,9 +68,9 @@ class LocationDataManagerTest {
             endTime = Instant.parse("2024-01-01T06:30:00Z"),
             durationMinutes = 90
         )
-        whenever(locationManager.getCurrentLocation()).thenReturn(location)
-        whenever(healthConnectManager.readExerciseSessionLocations()).thenReturn(emptyList())
-        whenever(stayPointDetector.detect(emptyList())).thenReturn(listOf(stayPoint))
+        coEvery { locationManager.getCurrentLocation() } returns location
+        coEvery { healthConnectManager.readExerciseSessionLocations() } returns emptyList()
+        every { stayPointDetector.detect(emptyList()) } returns listOf(stayPoint)
 
         val result = manager.collectLocationData()
 
@@ -82,23 +83,23 @@ class LocationDataManagerTest {
 
     @Test
     fun `이동 거리 계산 - 동일 좌표 두 세션`() = runTest {
-        val location = mock<Location>().also {
-            whenever(it.latitude).thenReturn(37.5665)
-            whenever(it.longitude).thenReturn(126.9780)
+        val location = mockk<Location>().apply {
+            every { latitude } returns 37.5665
+            every { longitude } returns 126.9780
         }
         // 약 1km 떨어진 두 점
         val locations = listOf(
             LocationPoint(37.5665, 126.9780, Instant.now()),
             LocationPoint(37.5755, 126.9780, Instant.now())  // 약 1km 북쪽
         )
-        whenever(locationManager.getCurrentLocation()).thenReturn(location)
-        whenever(healthConnectManager.readExerciseSessionLocations()).thenReturn(listOf(locations))
-        whenever(stayPointDetector.detect(locations)).thenReturn(emptyList())
+        coEvery { locationManager.getCurrentLocation() } returns location
+        coEvery { healthConnectManager.readExerciseSessionLocations() } returns listOf(locations)
+        every { stayPointDetector.detect(locations) } returns emptyList()
 
         val result = manager.collectLocationData()
 
         assertNotNull(result)
         // 약 1km ± 0.1km 범위 내
-        assertEquals(1.0, result!!.totalDistanceKm, 0.1)
+        assertEquals(1.0, result!!.totalDistanceKm ?: 0.0, 0.1)
     }
 }

--- a/android/app/src/test/java/com/example/graduation_project/data/location/LocationManagerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/location/LocationManagerTest.kt
@@ -2,6 +2,7 @@ package com.example.graduation_project.data.location
 
 import android.location.Location
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.tasks.CancellationToken
 import com.google.android.gms.tasks.OnFailureListener
 import com.google.android.gms.tasks.OnSuccessListener
 import com.google.android.gms.tasks.Task
@@ -23,6 +24,8 @@ import org.junit.Test
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LocationManagerTest {
@@ -100,7 +103,7 @@ class LocationManagerTest {
 
     private fun stubCurrentLocation(successResult: Location?) {
         val task = mockk<Task<Location>>()
-        every { mockFusedClient.getCurrentLocation(any(), any()) } returns task
+        every { mockFusedClient.getCurrentLocation(any<Int>(), any<CancellationToken>()) } returns task
         every { task.addOnSuccessListener(any<OnSuccessListener<Location>>()) } answers {
             firstArg<OnSuccessListener<Location>>().onSuccess(successResult)
             task
@@ -110,7 +113,7 @@ class LocationManagerTest {
 
     private fun stubCurrentLocationHanging() {
         val task = mockk<Task<Location>>()
-        every { mockFusedClient.getCurrentLocation(any(), any()) } returns task
+        every { mockFusedClient.getCurrentLocation(any<Int>(), any<CancellationToken>()) } returns task
         every { task.addOnSuccessListener(any<OnSuccessListener<Location>>()) } returns task
         every { task.addOnFailureListener(any()) } returns task
     }

--- a/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
@@ -8,10 +8,10 @@ import com.example.graduation_project.data.local.dao.MessageDao
 import com.example.graduation_project.data.model.ConversationEndResponse
 import com.example.graduation_project.data.model.ConversationMessageResponse
 import com.example.graduation_project.data.model.ConversationStartResponse
-import com.example.graduation_project.data.model.HealthData
 import com.example.graduation_project.data.repository.ConversationRepository
 import com.example.graduation_project.data.voice.AudioRecordManager
-import com.example.graduation_project.domain.usecase.GetHealthDataUseCase
+import com.example.graduation_project.domain.health.HealthConnectAvailability
+import com.example.graduation_project.domain.health.IHealthRepository
 import com.example.graduation_project.domain.voice.AudioRecordState
 import com.example.graduation_project.presentation.model.ConversationState
 import io.mockk.coEvery
@@ -62,7 +62,7 @@ class ConversationViewModelTest {
     private val mockApplication = mockk<Application>(relaxed = true)
     private val mockAudioRecordState = MutableStateFlow<AudioRecordState>(AudioRecordState.Idle)
     private val mockAudioRecordManager = mockk<AudioRecordManager>(relaxed = true)
-    private val mockGetHealthDataUseCase = mockk<GetHealthDataUseCase>()
+    private val mockHealthRepository = mockk<IHealthRepository>(relaxed = true)
 
     private lateinit var viewModel: ConversationViewModel
 
@@ -75,14 +75,15 @@ class ConversationViewModelTest {
         every { Log.e(any(), any<String>()) } returns 0
         every { Log.e(any(), any<String>(), any()) } returns 0
         every { mockAudioRecordManager.state } returns mockAudioRecordState
-        coEvery { mockGetHealthDataUseCase() } returns HealthData()
+        every { mockHealthRepository.getAvailability() } returns HealthConnectAvailability.NotSupported
+        coEvery { mockHealthRepository.readTodayExerciseRoutes() } returns emptyList()
 
         viewModel = ConversationViewModel(
             application = mockApplication,
             repository = mockRepository,
             messageDao = mockMessageDao,
             audioRecordManager = mockAudioRecordManager,
-            getHealthDataUseCase = mockGetHealthDataUseCase
+            healthRepository = mockHealthRepository
         )
     }
 
@@ -97,7 +98,7 @@ class ConversationViewModelTest {
     fun `startConversation 중복 호출 시 repository는 1번만 호출된다`() =
         runTest(mainDispatcherRule.testDispatcher) {
             // 진행 중(Sending) 상태가 유지되도록 delay로 첫 번째 호출을 지연
-            coEvery { mockRepository.startConversation(any()) } coAnswers {
+            coEvery { mockRepository.startConversation(any(), any()) } coAnswers {
                 delay(1_000)
                 ApiResult.Success(ConversationStartResponse(message = "안녕하세요"))
             }
@@ -106,7 +107,7 @@ class ConversationViewModelTest {
             viewModel.startConversation()  // Sending → Sending 전이 실패 → return@launch
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { mockRepository.startConversation(any()) }
+            coVerify(exactly = 1) { mockRepository.startConversation(any(), any()) }
         }
 
     @Test
@@ -149,7 +150,7 @@ class ConversationViewModelTest {
     @Test
     fun `startConversation 실패 시 Idle로 복구된다`() =
         runTest(mainDispatcherRule.testDispatcher) {
-            coEvery { mockRepository.startConversation(any()) } returns
+            coEvery { mockRepository.startConversation(any(), any()) } returns
                 ApiResult.Error(ApiException.NetworkError())
 
             viewModel.startConversation()
@@ -209,7 +210,7 @@ class ConversationViewModelTest {
      * advanceUntilIdle()은 TestScope의 확장 함수이므로 TestScope 수신자로 선언
      */
     private fun TestScope.setupListeningState() {
-        coEvery { mockRepository.startConversation(any()) } returns
+        coEvery { mockRepository.startConversation(any(), any()) } returns
             ApiResult.Success(ConversationStartResponse(message = "안녕하세요"))
 
         viewModel.startConversation()

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ media3 = "1.2.1"
 mockk = "1.13.12"
 playServicesLocation = "21.3.0"
 healthConnect = "1.1.0"
-playServicesLocation = "21.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -72,9 +71,6 @@ media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "medi
 
 # Health Connect
 health-connect-client = { group = "androidx.health.connect", name = "connect-client", version.ref = "healthConnect" }
-
-# Location
-play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 
 # Test
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }


### PR DESCRIPTION
## Summary
- `libs.versions.toml`의 `playServicesLocation` 버전 중복 선언 및 `play-services-location` 라이브러리 중복 항목 제거
- `LocationDataManagerTest`: `mockito-kotlin` → MockK로 교체 (프로젝트 테스트 의존성 통일)
- `LocationManagerTest`: `setMain`/`resetMain` import 누락 추가, `getCurrentLocation` 타입 명시
- `ConversationViewModelTest`: 생성자 파라미터(`getHealthDataUseCase` → `healthRepository`) 수정, `startConversation` 인자 누락 추가

## Test plan
- [ ] `./gradlew assembleProdDebug` 빌드 성공 확인
- [ ] `./gradlew compileProdDebugUnitTestKotlin` 컴파일 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)