### PR TITLE
fix: 위치 좌표 null 시 역지오코딩 NPE 수정

### DIFF
--- a/server/src/main/java/com/example/echo/location/service/LocationService.java
+++ b/server/src/main/java/com/example/echo/location/service/LocationService.java
@@ -40,10 +40,13 @@ public class LocationService {
             return null;
         }
 
-        String currentCity = geocodingService.getCityName(
-                raw.getCurrentLatitude(),
-                raw.getCurrentLongitude()
-        );
+        String currentCity = null;
+        if (raw.getCurrentLatitude() != null && raw.getCurrentLongitude() != null) {
+            currentCity = geocodingService.getCityName(
+                    raw.getCurrentLatitude(),
+                    raw.getCurrentLongitude()
+            );
+        }
 
         List<VisitedPlace> enrichedPlaces = new ArrayList<>();
         if (raw.getVisitedPlaces() != null) {


### PR DESCRIPTION
## Summary
- `currentLatitude` / `currentLongitude`가 null일 때 `double` 언박싱 과정에서 `NullPointerException` 발생
- `LocationService.enrichLocationData()`에 null 체크 추가 후 역지오코딩 호출

## 원인
위치 권한 거부 또는 위치 수집 실패 시 앱이 null 좌표를 서버로 전송 → `GeocodingService.getCityName(double, double)` primitive 파라미터 언박싱 시 NPE

## Test plan
- [ ] 위치 좌표 null로 `/api/conversations/start` 요청 시 500 없이 정상 응답 확인
- [ ] 위치 좌표 정상값으로 요청 시 기존대로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)