### PR TITLE
fix: LocationService 현재 위치 null 체크 추가

### DIFF
--- a/server/src/main/java/com/example/echo/location/service/LocationService.java
+++ b/server/src/main/java/com/example/echo/location/service/LocationService.java
@@ -40,10 +40,13 @@ public class LocationService {
             return null;
         }
 
-        String currentCity = geocodingService.getCityName(
-                raw.getCurrentLatitude(),
-                raw.getCurrentLongitude()
-        );
+        String currentCity = null;
+        if (raw.getCurrentLatitude() != null && raw.getCurrentLongitude() != null) {
+            currentCity = geocodingService.getCityName(
+                    raw.getCurrentLatitude(),
+                    raw.getCurrentLongitude()
+            );
+        }
 
         List<VisitedPlace> enrichedPlaces = new ArrayList<>();
         if (raw.getVisitedPlaces() != null) {


### PR DESCRIPTION
## Summary
- `currentLatitude`/`currentLongitude`가 null일 때 primitive `double`로 자동 언박싱되며 NPE 발생 → 대화 시작 시 500 에러 수정
- null 체크 추가 후 좌표가 없으면 `currentCity = null`로 처리

## Test plan
- [ ] 위치 권한 없는 상태에서 대화 시작 시 정상 동작 확인
- [ ] 위치 권한 있는 상태에서 대화 시작 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)