### PR TITLE
fix: 위치 권한 요청 다이얼로그 미표시 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,13 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-
-    <!-- 위치 권한 -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-
     <!-- 위치 권한 -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -53,6 +53,8 @@ import com.example.graduation_project.presentation.model.ConversationState
 import com.example.graduation_project.presentation.model.ConversationUiState
 import com.example.graduation_project.presentation.model.MessageUiModel
 import com.example.graduation_project.presentation.model.PlaybackStatus
+import com.example.graduation_project.presentation.permission.LocationPermissionHandler
+import com.example.graduation_project.presentation.permission.LocationPermissionSettingsDialog
 import com.example.graduation_project.presentation.permission.MicrophonePermissionHandler
 import com.example.graduation_project.presentation.permission.PermissionSettingsDialog
 import com.example.graduation_project.domain.permission.PermissionState
@@ -123,36 +125,57 @@ fun ConversationScreen(
 
     // Health Connect 권한 처리 (graceful degradation)
     HealthConnectPermissionHandler {
-        // 마이크 권한 처리
-        MicrophonePermissionHandler(
+        // 위치 권한 처리 (선택적 — 거부해도 대화 가능)
+        LocationPermissionHandler(
             onPermissionResult = { /* 권한 결과 로깅 등 */ }
-        ) { permissionState, requestPermission, openSettings ->
+        ) { locationPermissionState, requestLocationPermission, openLocationSettings ->
 
-            // 권한에 따른 대화 시작 처리
-            val handleStartClick: () -> Unit = {
-                when (permissionState) {
-                    PermissionState.Granted -> viewModel.startConversation()
-                    PermissionState.NotRequested, PermissionState.Denied -> requestPermission()
-                    PermissionState.PermanentlyDenied -> openSettings()
+            // 화면 진입 시 위치 권한 자동 요청
+            LaunchedEffect(locationPermissionState) {
+                if (locationPermissionState == PermissionState.NotRequested) {
+                    requestLocationPermission()
                 }
             }
 
-            // 화면 구성
-            ConversationScreenContent(
-                uiState = uiState,
-                snackbarHostState = snackbarHostState,
-                animationManager = animationManager,
-                onStartClick = handleStartClick,
-                onEndClick = viewModel::onFarewellButtonClicked,
-                onSettingsClick = { showSettingsDialog = true },
-                onRetryClick = viewModel::onUserRetryClicked,
-                onContactSupportClick = { /* TODO: 고객센터 연결 */ }
-            )
+            // 마이크 권한 처리
+            MicrophonePermissionHandler(
+                onPermissionResult = { /* 권한 결과 로깅 등 */ }
+            ) { permissionState, requestPermission, openSettings ->
 
-            // 권한 영구 거부 시 설정 안내 다이얼로그 표시
-            if (permissionState == PermissionState.PermanentlyDenied) {
-                PermissionSettingsDialog(
-                    onOpenSettings = openSettings,
+                // 권한에 따른 대화 시작 처리
+                val handleStartClick: () -> Unit = {
+                    when (permissionState) {
+                        PermissionState.Granted -> viewModel.startConversation()
+                        PermissionState.NotRequested, PermissionState.Denied -> requestPermission()
+                        PermissionState.PermanentlyDenied -> openSettings()
+                    }
+                }
+
+                // 화면 구성
+                ConversationScreenContent(
+                    uiState = uiState,
+                    snackbarHostState = snackbarHostState,
+                    animationManager = animationManager,
+                    onStartClick = handleStartClick,
+                    onEndClick = viewModel::onFarewellButtonClicked,
+                    onSettingsClick = { showSettingsDialog = true },
+                    onRetryClick = viewModel::onUserRetryClicked,
+                    onContactSupportClick = { /* TODO: 고객센터 연결 */ }
+                )
+
+                // 마이크 권한 영구 거부 시 설정 안내 다이얼로그 표시
+                if (permissionState == PermissionState.PermanentlyDenied) {
+                    PermissionSettingsDialog(
+                        onOpenSettings = openSettings,
+                        onDismiss = { /* 다이얼로그 닫기 */ }
+                    )
+                }
+            }
+
+            // 위치 권한 영구 거부 시 설정 안내 다이얼로그 표시
+            if (locationPermissionState == PermissionState.PermanentlyDenied) {
+                LocationPermissionSettingsDialog(
+                    onOpenSettings = openLocationSettings,
                     onDismiss = { /* 다이얼로그 닫기 */ }
                 )
             }


### PR DESCRIPTION
## Summary
- `ConversationScreen`에 `LocationPermissionHandler` 연결 — 화면 진입 시 위치 권한 자동 요청
- 위치 권한 영구 거부 시 `LocationPermissionSettingsDialog` 표시
- `AndroidManifest.xml` 위치 권한 중복 선언 3→1개로 정리

## Test plan
- [ ] 앱 첫 실행 시 위치 권한 다이얼로그 표시 확인
- [ ] 위치 권한 거부 후 대화 시작 정상 동작 확인 (위치 없이도 진행)
- [ ] 위치 권한 영구 거부 시 설정 안내 다이얼로그 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)