### PR TITLE
feat: US1.1 회원가입 (서버 JWT 인프라 + API + Android UI)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -107,6 +107,12 @@ dependencies {
     // Location
     implementation(libs.play.services.location)
 
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
+
+    // Security (EncryptedSharedPreferences)
+    implementation(libs.androidx.security.crypto)
+
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -4,41 +4,75 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.graduation_project.presentation.auth.SignupScreen
 import com.example.graduation_project.presentation.conversation.ConversationScreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 
-/**
- * 앱의 메인 액티비티
- *
- * ## Jetpack Compose 구조
- * - ComponentActivity: Compose 전용 액티비티
- * - enableEdgeToEdge(): 시스템 바 영역까지 콘텐츠 확장
- * - setContent { }: Compose UI를 설정하는 진입점
- *
- * ## 화면 구성
- * - Graduation_projectTheme: Material 3 테마 적용
- * - ConversationScreen: 대화 메인 화면
- */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             Graduation_projectTheme {
-                // 대화 화면 표시
-                ConversationScreen()
+                AppNavHost()
             }
         }
     }
 }
 
-// 앱 미리보기
+private object Routes {
+    const val SIGNUP = "signup"
+    const val ONBOARDING = "onboarding"
+    const val CONVERSATION = "conversation"
+}
+
+@Composable
+private fun AppNavHost() {
+    val navController = rememberNavController()
+
+    NavHost(navController = navController, startDestination = Routes.SIGNUP) {
+        composable(Routes.SIGNUP) {
+            SignupScreen(
+                onSignupSuccess = {
+                    navController.navigate(Routes.ONBOARDING) {
+                        popUpTo(Routes.SIGNUP) { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable(Routes.ONBOARDING) {
+            OnboardingPlaceholder()
+        }
+        composable(Routes.CONVERSATION) {
+            ConversationScreen()
+        }
+    }
+}
+
+@Composable
+private fun OnboardingPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("온보딩 (T1.3에서 구현 예정)")
+    }
+}
+
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 private fun MainActivityPreview() {
     Graduation_projectTheme {
-        ConversationScreen()
+        AppNavHost()
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
@@ -49,4 +49,8 @@ object ApiClient {
     val userApi: UserApi by lazy {
         retrofit.create(UserApi::class.java)
     }
+
+    val authApi: AuthApi by lazy {
+        retrofit.create(AuthApi::class.java)
+    }
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/api/AuthApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/AuthApi.kt
@@ -1,0 +1,12 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.model.SignupRequest
+import com.example.graduation_project.data.model.TokenResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+
+    @POST("/api/auth/signup")
+    suspend fun signup(@Body request: SignupRequest): TokenResponse
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
@@ -1,0 +1,50 @@
+package com.example.graduation_project.data.local
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Access/Refresh Token을 EncryptedSharedPreferences에 안전하게 저장.
+ *
+ * - 첫 호출 시 Keystore 초기화 비용이 큼 → ViewModel/Repository에서 IO 디스패처 호출 권장.
+ */
+class TokenStorage(context: Context) {
+
+    private val masterKey by lazy {
+        MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+    }
+
+    private val prefs by lazy {
+        EncryptedSharedPreferences.create(
+            context,
+            PREF_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    fun saveTokens(accessToken: String, refreshToken: String) {
+        prefs.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_REFRESH_TOKEN, refreshToken)
+            .apply()
+    }
+
+    fun getAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+
+    fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val PREF_NAME = "secure_auth_prefs"
+        private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/model/AuthModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/AuthModels.kt
@@ -1,0 +1,16 @@
+package com.example.graduation_project.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignupRequest(
+    val loginId: String,
+    val password: String,
+    val name: String
+)
+
+@Serializable
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
@@ -1,0 +1,25 @@
+package com.example.graduation_project.data.repository
+
+import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.api.AuthApi
+import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.model.SignupRequest
+import com.example.graduation_project.data.model.TokenResponse
+
+class AuthRepository(
+    private val tokenStorage: TokenStorage,
+    private val authApi: AuthApi = ApiClient.authApi
+) {
+
+    suspend fun signup(loginId: String, password: String, name: String): ApiResult<TokenResponse> {
+        val result = safeApiCall {
+            authApi.signup(SignupRequest(loginId, password, name))
+        }
+        if (result is ApiResult.Success) {
+            tokenStorage.saveTokens(result.data.accessToken, result.data.refreshToken)
+        }
+        return result
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
@@ -1,0 +1,140 @@
+package com.example.graduation_project.presentation.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun SignupScreen(
+    onSignupSuccess: () -> Unit,
+    viewModel: SignupViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.isSignupSuccess) {
+        if (uiState.isSignupSuccess) {
+            onSignupSuccess()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { msg ->
+            snackbarHostState.showSnackbar(msg)
+            viewModel.dismissError()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "회원가입",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(Modifier.height(32.dp))
+
+            OutlinedTextField(
+                value = uiState.loginId,
+                onValueChange = viewModel::updateLoginId,
+                label = { Text("아이디") },
+                singleLine = true,
+                isError = uiState.loginIdError != null,
+                supportingText = {
+                    Text(uiState.loginIdError ?: "영문/숫자 4~20자")
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
+                label = { Text("비밀번호") },
+                singleLine = true,
+                isError = uiState.passwordError != null,
+                supportingText = {
+                    Text(uiState.passwordError ?: "8자 이상, 영문/숫자 조합")
+                },
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = uiState.name,
+                onValueChange = viewModel::updateName,
+                label = { Text("이름") },
+                singleLine = true,
+                isError = uiState.nameError != null,
+                supportingText = {
+                    Text(uiState.nameError ?: "최대 50자")
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = viewModel::signup,
+                enabled = !uiState.isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("회원가입", fontSize = 16.sp)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
@@ -1,0 +1,119 @@
+package com.example.graduation_project.presentation.auth
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.graduation_project.data.api.ApiException
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.repository.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class SignupUiState(
+    val loginId: String = "",
+    val password: String = "",
+    val name: String = "",
+    val loginIdError: String? = null,
+    val passwordError: String? = null,
+    val nameError: String? = null,
+    val errorMessage: String? = null,
+    val isLoading: Boolean = false,
+    val isSignupSuccess: Boolean = false
+)
+
+class SignupViewModel(
+    application: Application,
+    private val repository: AuthRepository = AuthRepository(
+        tokenStorage = TokenStorage(application)
+    )
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(SignupUiState())
+    val uiState: StateFlow<SignupUiState> = _uiState.asStateFlow()
+
+    fun updateLoginId(value: String) {
+        _uiState.update { it.copy(loginId = value, loginIdError = null) }
+    }
+
+    fun updatePassword(value: String) {
+        _uiState.update { it.copy(password = value, passwordError = null) }
+    }
+
+    fun updateName(value: String) {
+        _uiState.update { it.copy(name = value, nameError = null) }
+    }
+
+    fun signup() {
+        val state = _uiState.value
+        val loginIdError = validateLoginId(state.loginId)
+        val passwordError = validatePassword(state.password)
+        val nameError = validateName(state.name)
+
+        if (loginIdError != null || passwordError != null || nameError != null) {
+            _uiState.update {
+                it.copy(
+                    loginIdError = loginIdError,
+                    passwordError = passwordError,
+                    nameError = nameError
+                )
+            }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+
+            when (val result = repository.signup(state.loginId, state.password, state.name)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(isLoading = false, isSignupSuccess = true) }
+                }
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = mapErrorMessage(result.exception)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun dismissError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    private fun mapErrorMessage(exception: ApiException): String = when (exception) {
+        is ApiException.ClientError -> when (exception.code) {
+            409 -> "이미 사용 중인 아이디입니다"
+            400 -> "입력 형식을 확인해주세요"
+            else -> exception.message
+        }
+        is ApiException.NetworkError -> "인터넷 연결을 확인해주세요"
+        is ApiException.ServerError -> "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요"
+        is ApiException.UnknownError -> "알 수 없는 오류가 발생했습니다"
+    }
+
+    private fun validateLoginId(value: String): String? = when {
+        value.isBlank() -> "아이디를 입력해주세요"
+        !value.matches(Regex("^[a-zA-Z0-9]{4,20}$")) -> "영문/숫자 4~20자로 입력해주세요"
+        else -> null
+    }
+
+    private fun validatePassword(value: String): String? = when {
+        value.isBlank() -> "비밀번호를 입력해주세요"
+        !value.matches(Regex("^(?=.*[A-Za-z])(?=.*\\d).{8,}$")) ->
+            "8자 이상, 영문/숫자 조합으로 입력해주세요"
+        else -> null
+    }
+
+    private fun validateName(value: String): String? = when {
+        value.isBlank() -> "이름을 입력해주세요"
+        value.length > 50 -> "이름은 50자 이하로 입력해주세요"
+        else -> null
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ media3 = "1.2.1"
 mockk = "1.13.12"
 playServicesLocation = "21.3.0"
 healthConnect = "1.1.0"
+navigationCompose = "2.8.5"
+securityCrypto = "1.1.0-alpha06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -71,6 +73,12 @@ media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "medi
 
 # Health Connect
 health-connect-client = { group = "androidx.health.connect", name = "connect-client", version.ref = "healthConnect" }
+
+# Navigation Compose
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+
+# EncryptedSharedPreferences
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 # Test
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT (jjwt 0.12.x)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	// Caffeine Cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/server/src/main/java/com/example/echo/auth/controller/AuthController.java
+++ b/server/src/main/java/com/example/echo/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.example.echo.auth.controller;
+
+import com.example.echo.auth.dto.SignupRequest;
+import com.example.echo.auth.dto.TokenResponse;
+import com.example.echo.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<TokenResponse> signup(@Valid @RequestBody SignupRequest request) {
+        TokenResponse response = authService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/dto/SignupRequest.java
+++ b/server/src/main/java/com/example/echo/auth/dto/SignupRequest.java
@@ -1,0 +1,22 @@
+package com.example.echo.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9]{4,20}$",
+                message = "아이디는 영문/숫자 4~20자여야 합니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
+                message = "비밀번호는 8자 이상 영문/숫자 혼합이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "이름은 필수입니다.")
+        @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
+        String name
+) {
+}

--- a/server/src/main/java/com/example/echo/auth/dto/TokenResponse.java
+++ b/server/src/main/java/com/example/echo/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.example.echo.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/server/src/main/java/com/example/echo/auth/entity/RefreshToken.java
+++ b/server/src/main/java/com/example/echo/auth/entity/RefreshToken.java
@@ -1,0 +1,56 @@
+package com.example.echo.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_refresh_tokens_token",
+                columnNames = "token"
+        ),
+        indexes = {
+                @Index(name = "idx_refresh_tokens_user_id", columnList = "user_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, length = 512)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/exception/DuplicateLoginIdException.java
+++ b/server/src/main/java/com/example/echo/auth/exception/DuplicateLoginIdException.java
@@ -1,0 +1,10 @@
+package com.example.echo.auth.exception;
+
+import com.example.echo.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateLoginIdException extends BaseException {
+    public DuplicateLoginIdException(String message) {
+        super(HttpStatus.CONFLICT, message);
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/exception/InvalidCredentialsException.java
+++ b/server/src/main/java/com/example/echo/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,10 @@
+package com.example.echo.auth.exception;
+
+import com.example.echo.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidCredentialsException extends BaseException {
+    public InvalidCredentialsException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/exception/InvalidTokenException.java
+++ b/server/src/main/java/com/example/echo/auth/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.example.echo.auth.exception;
+
+import com.example.echo.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTokenException extends BaseException {
+    public InvalidTokenException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/exception/UnauthorizedException.java
+++ b/server/src/main/java/com/example/echo/auth/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.example.echo.auth.exception;
+
+import com.example.echo.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends BaseException {
+    public UnauthorizedException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/jwt/JwtProvider.java
+++ b/server/src/main/java/com/example/echo/auth/jwt/JwtProvider.java
@@ -1,0 +1,85 @@
+package com.example.echo.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final String secret;
+    private final long accessTokenExpirationMs;
+    private final long refreshTokenExpirationMs;
+
+    private SecretKey key;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpirationMs,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationMs
+    ) {
+        this.secret = secret;
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
+        this.refreshTokenExpirationMs = refreshTokenExpirationMs;
+    }
+
+    @PostConstruct
+    void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId) {
+        return buildToken(userId, accessTokenExpirationMs);
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return buildToken(userId, refreshTokenExpirationMs);
+    }
+
+    public boolean validate(String token) {
+        try {
+            parse(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("JWT 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(parse(token).getSubject());
+    }
+
+    public Date getExpiration(String token) {
+        return parse(token).getExpiration();
+    }
+
+    private String buildToken(Long userId, long expirationMs) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    private Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/example/echo/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,27 @@
+package com.example.echo.auth.repository;
+
+import com.example.echo.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    @Modifying
+    @Transactional
+    @Query("delete from RefreshToken rt where rt.userId = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Transactional
+    @Query("delete from RefreshToken rt where rt.token = :token")
+    void deleteByToken(@Param("token") String token);
+}

--- a/server/src/main/java/com/example/echo/auth/service/AuthService.java
+++ b/server/src/main/java/com/example/echo/auth/service/AuthService.java
@@ -1,0 +1,55 @@
+package com.example.echo.auth.service;
+
+import com.example.echo.auth.dto.SignupRequest;
+import com.example.echo.auth.dto.TokenResponse;
+import com.example.echo.auth.entity.RefreshToken;
+import com.example.echo.auth.exception.DuplicateLoginIdException;
+import com.example.echo.auth.jwt.JwtProvider;
+import com.example.echo.auth.repository.RefreshTokenRepository;
+import com.example.echo.user.entity.User;
+import com.example.echo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenResponse signup(SignupRequest request) {
+        if (userRepository.existsByLoginId(request.loginId())) {
+            throw new DuplicateLoginIdException("이미 사용 중인 아이디입니다.");
+        }
+
+        User user = userRepository.save(User.builder()
+                .loginId(request.loginId())
+                .passwordHash(passwordEncoder.encode(request.password()))
+                .name(request.name())
+                .build());
+
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+
+        LocalDateTime refreshExpiresAt = LocalDateTime.ofInstant(
+                jwtProvider.getExpiration(refreshToken).toInstant(),
+                ZoneId.systemDefault()
+        );
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(user.getId())
+                .token(refreshToken)
+                .expiresAt(refreshExpiresAt)
+                .build());
+
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.example.echo.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 보안 설정 (T1.1-2 최소 버전).
+ *
+ * - BCryptPasswordEncoder Bean 노출 (회원가입 비번 해시용)
+ * - 세션 STATELESS, CSRF/formLogin/httpBasic 비활성 (JWT 환경 준비)
+ * - 모든 엔드포인트 permitAll → 기존 API 동작 유지
+ *
+ * T1.2-1에서 JwtAuthFilter 추가 + 패턴별 authenticated 잠금으로 강화 예정.
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/server/src/main/java/com/example/echo/common/exception/BaseException.java
+++ b/server/src/main/java/com/example/echo/common/exception/BaseException.java
@@ -1,0 +1,19 @@
+package com.example.echo.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 비즈니스 예외 공통 추상 클래스.
+ * 하위 클래스가 상태 코드와 메시지를 정의하면 GlobalExceptionHandler가 일관 매핑한다.
+ */
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    protected BaseException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/server/src/main/java/com/example/echo/common/exception/ErrorResponse.java
+++ b/server/src/main/java/com/example/echo/common/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.example.echo.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        int status,
+        String message,
+        LocalDateTime timestamp
+) {
+    public static ErrorResponse of(HttpStatus status, String message) {
+        return new ErrorResponse(status.value(), message, LocalDateTime.now());
+    }
+}

--- a/server/src/main/java/com/example/echo/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/example/echo/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.example.echo.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBase(BaseException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ErrorResponse.of(e.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        FieldError firstError = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .orElse(null);
+        String message = firstError != null
+                ? firstError.getField() + ": " + firstError.getDefaultMessage()
+                : "잘못된 요청입니다.";
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."));
+    }
+}

--- a/server/src/main/java/com/example/echo/user/entity/User.java
+++ b/server/src/main/java/com/example/echo/user/entity/User.java
@@ -1,0 +1,59 @@
+package com.example.echo.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_users_login_id",
+                columnNames = "login_id"
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "login_id", nullable = false, length = 20)
+    private String loginId;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public User(String loginId, String passwordHash, String name) {
+        this.loginId = loginId;
+        this.passwordHash = passwordHash;
+        this.name = name;
+    }
+}

--- a/server/src/main/java/com/example/echo/user/repository/UserRepository.java
+++ b/server/src/main/java/com/example/echo/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.example.echo.user.repository;
+
+import com.example.echo.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -52,3 +52,9 @@ azure:
     endpoint: https://koreacentral.tts.speech.microsoft.com
     # api-key는 application-local.yaml에서 설정 (예: api-key: your-key-here)
     default-voice: ko-KR-SunHiNeural  # 기본 음성 (친근하고 따뜻한 여성)
+
+# JWT 설정
+jwt:
+  # secret은 application-local.yaml(${JWT_SECRET})에서 주입
+  access-token-expiration: 3600000      # 1시간
+  refresh-token-expiration: 2592000000  # 30일

--- a/server/src/test/java/com/example/echo/auth/jwt/JwtProviderTest.java
+++ b/server/src/test/java/com/example/echo/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,71 @@
+package com.example.echo.auth.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderTest {
+
+    private static final String SECRET = "test-secret-key-for-jwt-provider-unit-test-must-be-long-enough-256bit";
+    private static final long ACCESS_EXP_MS = 3600_000L;       // 1h
+    private static final long REFRESH_EXP_MS = 2_592_000_000L; // 30d
+
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = new JwtProvider(SECRET, ACCESS_EXP_MS, REFRESH_EXP_MS);
+        ReflectionTestUtils.invokeMethod(jwtProvider, "init");
+    }
+
+    @Test
+    void access_token_round_trip() {
+        Long userId = 42L;
+        String token = jwtProvider.generateAccessToken(userId);
+
+        assertThat(jwtProvider.validate(token)).isTrue();
+        assertThat(jwtProvider.getUserId(token)).isEqualTo(userId);
+        assertThat(jwtProvider.getExpiration(token)).isAfter(new Date());
+    }
+
+    @Test
+    void refresh_token_round_trip() {
+        Long userId = 7L;
+        String token = jwtProvider.generateRefreshToken(userId);
+
+        assertThat(jwtProvider.validate(token)).isTrue();
+        assertThat(jwtProvider.getUserId(token)).isEqualTo(userId);
+    }
+
+    @Test
+    void refresh_token_expires_later_than_access_token() {
+        String access = jwtProvider.generateAccessToken(1L);
+        String refresh = jwtProvider.generateRefreshToken(1L);
+
+        assertThat(jwtProvider.getExpiration(refresh))
+                .isAfter(jwtProvider.getExpiration(access));
+    }
+
+    @Test
+    void invalid_token_returns_false() {
+        assertThat(jwtProvider.validate("not-a-real-token")).isFalse();
+        assertThat(jwtProvider.validate("")).isFalse();
+    }
+
+    @Test
+    void token_signed_with_other_secret_fails_validation() {
+        JwtProvider other = new JwtProvider(
+                "another-secret-key-of-sufficient-length-for-hmac-sha-256-algorithm",
+                ACCESS_EXP_MS,
+                REFRESH_EXP_MS
+        );
+        ReflectionTestUtils.invokeMethod(other, "init");
+
+        String tokenFromOther = other.generateAccessToken(1L);
+        assertThat(jwtProvider.validate(tokenFromOther)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- **T1.1-1 서버 JWT 인프라**: User/RefreshToken Entity, JwtProvider(jjwt 0.12.6, HS256), 글로벌 예외 처리, BCrypt 의존성 추가
- **T1.1-2 회원가입 API**: `POST /api/auth/signup` (BCrypt 해시 → JWT 2종 발급 → RefreshToken DB 저장 → 201 Created), Bean Validation(아이디 4~20자 영문/숫자, 비번 8자 이상 영문/숫자), SecurityConfig 선창조(STATELESS, csrf disable)
- **T1.1-3 Android 회원가입**: TokenStorage(EncryptedSharedPreferences), AuthRepository, SignupViewModel(서버와 동일 정규식 클라 검증 + 에러 매핑), SignupScreen(Compose), MainActivity NavHost 도입(signup → onboarding placeholder, 뒤로가기 차단)

## Test plan
- [x] 서버 단위 테스트: `JwtProviderTest` (round-trip / 만료 / 잘못된 토큰 / 다른 secret) 통과
- [x] 서버 통합 테스트(curl): 정상 가입 201 / ID 중복 409 / 비번 형식 위반 400 / DB users·refresh_tokens 저장 확인
- [x] Android `compileLocalDebugKotlin` 빌드 성공
- [ ] 디바이스/에뮬레이터에서 회원가입 → 토큰 저장 → 온보딩 placeholder 진입 + 뒤로가기 차단 확인 (T1.2-1 이전 권장)

## 후속 작업
- T1.2-1 서버 보호 메커니즘 (JwtAuthFilter + CurrentUserArgumentResolver SecurityContext 연결)