### PR TITLE
fix(auth): SignupViewModel Factory 누락으로 인한 앱 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
@@ -35,7 +35,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @Composable
 fun SignupScreen(
     onSignupSuccess: () -> Unit,
-    viewModel: SignupViewModel = viewModel()
+    viewModel: SignupViewModel = viewModel(factory = SignupViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
@@ -2,7 +2,11 @@ package com.example.graduation_project.presentation.auth
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.TokenStorage
@@ -115,5 +119,15 @@ class SignupViewModel(
         value.isBlank() -> "이름을 입력해주세요"
         value.length > 50 -> "이름은 50자 이하로 입력해주세요"
         else -> null
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return SignupViewModel(application) as T
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `SignupViewModel`에 `ViewModelProvider.Factory` companion object 추가
- `SignupScreen`에서 `viewModel(factory = SignupViewModel.Factory)` 로 변경
- 기본 `AndroidViewModelFactory`가 `(Application)` 단일 생성자를 찾지 못해 앱 시작 시 크래시가 발생하던 문제 수정

## Root Cause
`SignupViewModel`의 생성자가 `(Application, AuthRepository)` 형태인데, Android 기본 팩토리는 `(Application)` 단일 생성자만 탐색하여 `NoSuchMethodException` 발생 → 앱 크래시

## Test plan
- [ ] 앱 정상 실행 확인
- [ ] 회원가입 화면 진입 확인
- [ ] 회원가입 성공/실패 플로우 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)