### PR TITLE
feat: US1.2 사용자 로그인 (JWT + Silent Refresh)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     </queries>
 
     <application
+        android:name=".App"
         android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/android/app/src/main/java/com/example/graduation_project/App.kt
+++ b/android/app/src/main/java/com/example/graduation_project/App.kt
@@ -1,0 +1,12 @@
+package com.example.graduation_project
+
+import android.app.Application
+import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.local.TokenStorage
+
+class App : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ApiClient.init(TokenStorage(this))
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.graduation_project
 
+import android.app.Application
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,15 +9,25 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.repository.AuthRepository
+import com.example.graduation_project.presentation.auth.LoginScreen
 import com.example.graduation_project.presentation.auth.SignupScreen
 import com.example.graduation_project.presentation.conversation.ConversationScreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,6 +42,7 @@ class MainActivity : ComponentActivity() {
 }
 
 private object Routes {
+    const val LOGIN = "login"
     const val SIGNUP = "signup"
     const val ONBOARDING = "onboarding"
     const val CONVERSATION = "conversation"
@@ -38,14 +50,34 @@ private object Routes {
 
 @Composable
 private fun AppNavHost() {
+    val context = LocalContext.current
+    val application = context.applicationContext as Application
+    val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application)) }
+    val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
 
-    NavHost(navController = navController, startDestination = Routes.SIGNUP) {
+    val startDestination = remember {
+        if (authRepository.hasAccessToken()) Routes.CONVERSATION else Routes.LOGIN
+    }
+
+    NavHost(navController = navController, startDestination = startDestination) {
+        composable(Routes.LOGIN) {
+            LoginScreen(
+                onLoginSuccess = {
+                    navController.navigate(Routes.CONVERSATION) {
+                        popUpTo(Routes.LOGIN) { inclusive = true }
+                    }
+                },
+                onNavigateToSignup = {
+                    navController.navigate(Routes.SIGNUP)
+                }
+            )
+        }
         composable(Routes.SIGNUP) {
             SignupScreen(
                 onSignupSuccess = {
                     navController.navigate(Routes.ONBOARDING) {
-                        popUpTo(Routes.SIGNUP) { inclusive = true }
+                        popUpTo(Routes.LOGIN) { inclusive = true }
                     }
                 }
             )
@@ -54,7 +86,16 @@ private fun AppNavHost() {
             OnboardingPlaceholder()
         }
         composable(Routes.CONVERSATION) {
-            ConversationScreen()
+            ConversationScreen(
+                onLogout = {
+                    coroutineScope.launch {
+                        withContext(Dispatchers.IO) { authRepository.logout() }
+                        navController.navigate(Routes.LOGIN) {
+                            popUpTo(Routes.CONVERSATION) { inclusive = true }
+                        }
+                    }
+                }
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -5,8 +5,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
@@ -99,7 +105,13 @@ private fun AppNavHost() {
             )
         }
         composable(Routes.ONBOARDING) {
-            OnboardingPlaceholder()
+            OnboardingPlaceholder(
+                onSkip = {
+                    navController.navigate(Routes.CONVERSATION) {
+                        popUpTo(Routes.ONBOARDING) { inclusive = true }
+                    }
+                }
+            )
         }
         composable(Routes.CONVERSATION) {
             ConversationScreen(
@@ -117,12 +129,19 @@ private fun AppNavHost() {
 }
 
 @Composable
-private fun OnboardingPlaceholder() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+private fun OnboardingPlaceholder(onSkip: () -> Unit = {}) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text("온보딩 (T1.3에서 구현 예정)")
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = onSkip) {
+            Text("대화 시작 화면으로 이동")
+        }
     }
 }
 

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
@@ -1,6 +1,7 @@
 package com.example.graduation_project.data.api
 
 import com.example.graduation_project.BuildConfig
+import com.example.graduation_project.data.local.TokenStorage
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -18,39 +19,50 @@ object ApiClient {
     }
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
-        level = if (BuildConfig.DEBUG) {
-            HttpLoggingInterceptor.Level.BODY
-        } else {
-            HttpLoggingInterceptor.Level.NONE
-        }
+        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+        else HttpLoggingInterceptor.Level.NONE
     }
 
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(loggingInterceptor)
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .writeTimeout(30, TimeUnit.SECONDS)
-        .build()
-
-    private val retrofit = Retrofit.Builder()
+    private val authRetrofit = Retrofit.Builder()
         .baseUrl(BuildConfig.BASE_URL)
-        .client(okHttpClient)
+        .client(
+            OkHttpClient.Builder()
+                .addInterceptor(loggingInterceptor)
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .build()
+        )
         .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
         .build()
 
-    val conversationApi: ConversationApi by lazy {
-        retrofit.create(ConversationApi::class.java)
-    }
+    val authApi: AuthApi by lazy { authRetrofit.create(AuthApi::class.java) }
 
-    val diaryApi: DiaryApi by lazy {
-        retrofit.create(DiaryApi::class.java)
-    }
+    lateinit var conversationApi: ConversationApi
+        private set
+    lateinit var diaryApi: DiaryApi
+        private set
+    lateinit var userApi: UserApi
+        private set
 
-    val userApi: UserApi by lazy {
-        retrofit.create(UserApi::class.java)
-    }
+    fun init(tokenStorage: TokenStorage) {
+        val authenticatedClient = OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .addInterceptor(AuthInterceptor(tokenStorage))
+            .authenticator(TokenAuthenticator(tokenStorage, authApi))
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
 
-    val authApi: AuthApi by lazy {
-        retrofit.create(AuthApi::class.java)
+        val authenticatedRetrofit = Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(authenticatedClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        conversationApi = authenticatedRetrofit.create(ConversationApi::class.java)
+        diaryApi = authenticatedRetrofit.create(DiaryApi::class.java)
+        userApi = authenticatedRetrofit.create(UserApi::class.java)
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/api/AuthApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/AuthApi.kt
@@ -1,12 +1,27 @@
 package com.example.graduation_project.data.api
 
+import com.example.graduation_project.data.model.LoginRequest
+import com.example.graduation_project.data.model.RefreshRequest
 import com.example.graduation_project.data.model.SignupRequest
 import com.example.graduation_project.data.model.TokenResponse
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthApi {
 
     @POST("/api/auth/signup")
     suspend fun signup(@Body request: SignupRequest): TokenResponse
+
+    @POST("/api/auth/login")
+    suspend fun login(@Body request: LoginRequest): TokenResponse
+
+    @POST("/api/auth/refresh")
+    suspend fun refresh(@Body request: RefreshRequest): TokenResponse
+
+    @POST("/api/auth/logout")
+    suspend fun logout(
+        @Header("Authorization") authorization: String,
+        @Body request: RefreshRequest
+    )
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/api/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/AuthInterceptor.kt
@@ -1,0 +1,19 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.local.TokenStorage
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor(private val tokenStorage: TokenStorage) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = tokenStorage.getAccessToken()
+        val request = if (token != null) {
+            chain.request().newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else {
+            chain.request()
+        }
+        return chain.proceed(request)
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/TokenAuthenticator.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/TokenAuthenticator.kt
@@ -1,0 +1,55 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.model.RefreshRequest
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class TokenAuthenticator(
+    private val tokenStorage: TokenStorage,
+    private val authApi: AuthApi
+) : Authenticator {
+
+    companion object {
+        private val mutex = Mutex()
+    }
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (response.request.header("Authorization") == null) return null
+
+        val newAccessToken = runBlocking {
+            mutex.withLock {
+                val currentToken = tokenStorage.getAccessToken()
+                val requestToken = response.request.header("Authorization")
+                    ?.removePrefix("Bearer ")
+                // 다른 코루틴이 이미 갱신했으면 새 토큰 바로 사용
+                if (currentToken != null && currentToken != requestToken) {
+                    return@withLock currentToken
+                }
+
+                val refreshToken = tokenStorage.getRefreshToken() ?: return@withLock null
+                try {
+                    val tokenResponse = authApi.refresh(RefreshRequest(refreshToken))
+                    tokenStorage.saveTokens(tokenResponse.accessToken, tokenResponse.refreshToken)
+                    tokenResponse.accessToken
+                } catch (e: Exception) {
+                    tokenStorage.clear()
+                    null
+                }
+            }
+        }
+
+        return if (newAccessToken != null) {
+            response.request.newBuilder()
+                .header("Authorization", "Bearer $newAccessToken")
+                .build()
+        } else {
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/model/AuthModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/AuthModels.kt
@@ -10,6 +10,17 @@ data class SignupRequest(
 )
 
 @Serializable
+data class LoginRequest(
+    val loginId: String,
+    val password: String
+)
+
+@Serializable
+data class RefreshRequest(
+    val refreshToken: String
+)
+
+@Serializable
 data class TokenResponse(
     val accessToken: String,
     val refreshToken: String

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
@@ -5,6 +5,8 @@ import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.api.AuthApi
 import com.example.graduation_project.data.api.safeApiCall
 import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.model.LoginRequest
+import com.example.graduation_project.data.model.RefreshRequest
 import com.example.graduation_project.data.model.SignupRequest
 import com.example.graduation_project.data.model.TokenResponse
 
@@ -22,4 +24,30 @@ class AuthRepository(
         }
         return result
     }
+
+    suspend fun login(loginId: String, password: String): ApiResult<TokenResponse> {
+        val result = safeApiCall {
+            authApi.login(LoginRequest(loginId, password))
+        }
+        if (result is ApiResult.Success) {
+            tokenStorage.saveTokens(result.data.accessToken, result.data.refreshToken)
+        }
+        return result
+    }
+
+    suspend fun logout(): ApiResult<Unit> {
+        val accessToken = tokenStorage.getAccessToken()
+        val refreshToken = tokenStorage.getRefreshToken()
+        val result = if (accessToken != null && refreshToken != null) {
+            safeApiCall {
+                authApi.logout("Bearer $accessToken", RefreshRequest(refreshToken))
+            }
+        } else {
+            ApiResult.Success(Unit)
+        }
+        tokenStorage.clear()
+        return result
+    }
+
+    fun hasAccessToken(): Boolean = tokenStorage.getAccessToken() != null
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
@@ -1,0 +1,126 @@
+package com.example.graduation_project.presentation.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun LoginScreen(
+    onLoginSuccess: () -> Unit,
+    onNavigateToSignup: () -> Unit,
+    viewModel: LoginViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.isLoginSuccess) {
+        if (uiState.isLoginSuccess) {
+            onLoginSuccess()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { msg ->
+            snackbarHostState.showSnackbar(msg)
+            viewModel.dismissError()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "로그인",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(Modifier.height(32.dp))
+
+            OutlinedTextField(
+                value = uiState.loginId,
+                onValueChange = viewModel::updateLoginId,
+                label = { Text("아이디") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
+                label = { Text("비밀번호") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = viewModel::login,
+                enabled = !uiState.isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(20.dp),
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("로그인", fontSize = 16.sp)
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            TextButton(onClick = onNavigateToSignup) {
+                Text("회원가입하기")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
@@ -1,0 +1,80 @@
+package com.example.graduation_project.presentation.auth
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.graduation_project.data.api.ApiException
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.repository.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class LoginUiState(
+    val loginId: String = "",
+    val password: String = "",
+    val errorMessage: String? = null,
+    val isLoading: Boolean = false,
+    val isLoginSuccess: Boolean = false
+)
+
+class LoginViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository: AuthRepository = AuthRepository(
+        tokenStorage = TokenStorage(application)
+    )
+
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    fun updateLoginId(value: String) {
+        _uiState.update { it.copy(loginId = value) }
+    }
+
+    fun updatePassword(value: String) {
+        _uiState.update { it.copy(password = value) }
+    }
+
+    fun login() {
+        val state = _uiState.value
+        if (state.loginId.isBlank() || state.password.isBlank()) {
+            _uiState.update { it.copy(errorMessage = "아이디와 비밀번호를 입력해주세요") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+
+            when (val result = repository.login(state.loginId, state.password)) {
+                is ApiResult.Success -> {
+                    _uiState.update { it.copy(isLoading = false, isLoginSuccess = true) }
+                }
+                is ApiResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = mapErrorMessage(result.exception)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun dismissError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    private fun mapErrorMessage(exception: ApiException): String = when (exception) {
+        is ApiException.ClientError -> when (exception.code) {
+            401 -> "아이디 또는 비밀번호가 올바르지 않습니다"
+            else -> exception.message
+        }
+        is ApiException.NetworkError -> "인터넷 연결을 확인해주세요"
+        is ApiException.ServerError -> "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요"
+        is ApiException.UnknownError -> "알 수 없는 오류가 발생했습니다"
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
@@ -25,12 +25,11 @@ data class SignupUiState(
     val isSignupSuccess: Boolean = false
 )
 
-class SignupViewModel(
-    application: Application,
+class SignupViewModel(application: Application) : AndroidViewModel(application) {
+
     private val repository: AuthRepository = AuthRepository(
         tokenStorage = TokenStorage(application)
     )
-) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(SignupUiState())
     val uiState: StateFlow<SignupUiState> = _uiState.asStateFlow()

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -82,6 +82,7 @@ import com.example.graduation_project.ui.theme.Graduation_projectTheme
  */
 @Composable
 fun ConversationScreen(
+    onLogout: () -> Unit = {},
     viewModel: ConversationViewModel = viewModel(factory = ConversationViewModel.Factory)
 ) {
     // ViewModel의 상태를 Compose State로 변환
@@ -184,7 +185,13 @@ fun ConversationScreen(
 
     // 음성 설정 다이얼로그
     if (showSettingsDialog) {
-        VoiceSettingsDialog(onDismiss = { showSettingsDialog = false })
+        VoiceSettingsDialog(
+            onDismiss = { showSettingsDialog = false },
+            onLogout = {
+                showSettingsDialog = false
+                onLogout()
+            }
+        )
     }
 
     // 종료 확인 다이얼로그

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsDialog.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/VoiceSettingsDialog.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @Composable
 fun VoiceSettingsDialog(
     onDismiss: () -> Unit,
+    onLogout: () -> Unit = {},
     viewModel: VoiceSettingsViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -142,6 +143,22 @@ fun VoiceSettingsDialog(
                     Text(
                         text = "닫기",
                         fontSize = 18.sp
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                OutlinedButton(
+                    onClick = onLogout,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text(
+                        text = "로그아웃",
+                        fontSize = 18.sp,
+                        color = MaterialTheme.colorScheme.error
                     )
                 }
             }

--- a/server/src/main/java/com/example/echo/auth/controller/AuthController.java
+++ b/server/src/main/java/com/example/echo/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.example.echo.auth.controller;
 
+import com.example.echo.auth.dto.LoginRequest;
+import com.example.echo.auth.dto.RefreshRequest;
 import com.example.echo.auth.dto.SignupRequest;
 import com.example.echo.auth.dto.TokenResponse;
 import com.example.echo.auth.service.AuthService;
@@ -23,5 +25,21 @@ public class AuthController {
     public ResponseEntity<TokenResponse> signup(@Valid @RequestBody SignupRequest request) {
         TokenResponse response = authService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(authService.refresh(request.refreshToken()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@Valid @RequestBody RefreshRequest request) {
+        authService.logout(request.refreshToken());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/com/example/echo/auth/dto/LoginRequest.java
+++ b/server/src/main/java/com/example/echo/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.echo.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/server/src/main/java/com/example/echo/auth/dto/RefreshRequest.java
+++ b/server/src/main/java/com/example/echo/auth/dto/RefreshRequest.java
@@ -1,0 +1,9 @@
+package com.example.echo.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/server/src/main/java/com/example/echo/auth/filter/JwtAuthFilter.java
+++ b/server/src/main/java/com/example/echo/auth/filter/JwtAuthFilter.java
@@ -1,0 +1,47 @@
+package com.example.echo.auth.filter;
+
+import com.example.echo.auth.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+        if (token != null && jwtProvider.validate(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return header.substring(BEARER_PREFIX.length());
+    }
+}

--- a/server/src/main/java/com/example/echo/auth/service/AuthService.java
+++ b/server/src/main/java/com/example/echo/auth/service/AuthService.java
@@ -1,9 +1,12 @@
 package com.example.echo.auth.service;
 
+import com.example.echo.auth.dto.LoginRequest;
 import com.example.echo.auth.dto.SignupRequest;
 import com.example.echo.auth.dto.TokenResponse;
 import com.example.echo.auth.entity.RefreshToken;
 import com.example.echo.auth.exception.DuplicateLoginIdException;
+import com.example.echo.auth.exception.InvalidCredentialsException;
+import com.example.echo.auth.exception.InvalidTokenException;
 import com.example.echo.auth.jwt.JwtProvider;
 import com.example.echo.auth.repository.RefreshTokenRepository;
 import com.example.echo.user.entity.User;
@@ -37,15 +40,52 @@ public class AuthService {
                 .name(request.name())
                 .build());
 
-        String accessToken = jwtProvider.generateAccessToken(user.getId());
-        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+        return issueTokens(user.getId());
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByLoginId(request.loginId())
+                .orElseThrow(() -> new InvalidCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다."));
+
+        if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            throw new InvalidCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        return issueTokens(user.getId());
+    }
+
+    @Transactional
+    public TokenResponse refresh(String refreshToken) {
+        RefreshToken stored = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new InvalidTokenException("유효하지 않은 Refresh Token입니다."));
+
+        if (stored.isExpired() || !jwtProvider.validate(refreshToken)) {
+            refreshTokenRepository.deleteByToken(refreshToken);
+            throw new InvalidTokenException("Refresh Token이 만료되었습니다.");
+        }
+
+        Long userId = stored.getUserId();
+        refreshTokenRepository.deleteByToken(refreshToken);
+        return issueTokens(userId);
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+        refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
+    private TokenResponse issueTokens(Long userId) {
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
 
         LocalDateTime refreshExpiresAt = LocalDateTime.ofInstant(
                 jwtProvider.getExpiration(refreshToken).toInstant(),
                 ZoneId.systemDefault()
         );
         refreshTokenRepository.save(RefreshToken.builder()
-                .userId(user.getId())
+                .userId(userId)
                 .token(refreshToken)
                 .expiresAt(refreshExpiresAt)
                 .build());

--- a/server/src/main/java/com/example/echo/common/auth/CurrentUserArgumentResolver.java
+++ b/server/src/main/java/com/example/echo/common/auth/CurrentUserArgumentResolver.java
@@ -1,6 +1,9 @@
 package com.example.echo.common.auth;
 
+import com.example.echo.auth.exception.UnauthorizedException;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -9,9 +12,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
-
-    // MVP용 고정 userId
-    private static final Long FIXED_USER_ID = 1L;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -24,8 +24,12 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
-        // MVP: 고정 userId 반환
-        // TODO: Spring Security 도입 후 실제 인증 정보에서 추출
-        return FIXED_USER_ID;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || !(authentication.getPrincipal() instanceof Long userId)) {
+            throw new UnauthorizedException("인증이 필요합니다.");
+        }
+        return userId;
     }
 }

--- a/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
@@ -1,24 +1,30 @@
 package com.example.echo.common.config;
 
+import com.example.echo.auth.filter.JwtAuthFilter;
+import com.example.echo.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-/**
- * 보안 설정 (T1.1-2 최소 버전).
- *
- * - BCryptPasswordEncoder Bean 노출 (회원가입 비번 해시용)
- * - 세션 STATELESS, CSRF/formLogin/httpBasic 비활성 (JWT 환경 준비)
- * - 모든 엔드포인트 permitAll → 기존 API 동작 유지
- *
- * T1.2-1에서 JwtAuthFilter 추가 + 패턴별 authenticated 잠금으로 강화 예정.
- */
+import java.nio.charset.StandardCharsets;
+
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -32,7 +38,28 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/actuator/health",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(eh -> eh.authenticationEntryPoint(unauthorizedEntryPoint()))
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    private AuthenticationEntryPoint unauthorizedEntryPoint() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            ErrorResponse body = ErrorResponse.of(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+            response.getWriter().write(objectMapper.writeValueAsString(body));
+        };
     }
 }

--- a/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
@@ -40,7 +40,9 @@ public class SecurityConfig {
                 .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",
+                                "/api/auth/signup",
+                                "/api/auth/login",
+                                "/api/auth/refresh",
                                 "/actuator/health",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/server/src/main/java/com/example/echo/user/service/UserService.java
+++ b/server/src/main/java/com/example/echo/user/service/UserService.java
@@ -1,33 +1,27 @@
 package com.example.echo.user.service;
 
+import com.example.echo.auth.exception.UnauthorizedException;
 import com.example.echo.user.dto.UserPreferences;
-import com.example.echo.user.dto.VoiceSettings;
+import com.example.echo.user.entity.User;
+import com.example.echo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
     public UserPreferences getPreferences(Long userId) {
-        // TODO: 실제 DB 연동 시 Repository 사용
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
+
         return UserPreferences.builder()
-                .userId(userId)
-                .name("김영호")
-                .age(68)
-                .birthday(LocalDate.of(1957, 3, 15))
-                .location("서울시 서초구")
-                .familyInfo("아내, 아들 1명, 손녀 2명")
-                .occupation("은퇴 (전 공무원)")
-                .hobbies("등산, 바둑, 뉴스 보기")
-                .preferredTopics("건강, 가족, 시사")
-                .voiceSettings(VoiceSettings.builder()
-                        .voiceSpeed(0.9)
-                        .voiceTone("warm")
-                        .build())
-                .conversationTime(LocalTime.of(9, 0))
-                .preferredSleepHours(7)  // 선호 수면 시간: 7시간
+                .userId(user.getId())
+                .name(user.getName())
                 .build();
     }
 }


### PR DESCRIPTION
## Summary

US1.2 사용자 로그인 기능 구현. JWT Access(1h) + Refresh(30d) Rotation 방식.

### T1.2-1 서버 보호 메커니즘 (`ea5e224`)
- `JwtAuthFilter`: Bearer 토큰 검증 후 `SecurityContext` 주입
- `SecurityConfig`: 공개 엔드포인트(`/api/auth/signup|login|refresh`, `/actuator/health`, swagger) 외 401 강제
- `CurrentUserArgumentResolver`: 고정 `FIXED_USER_ID=1L` 제거 → `SecurityContextHolder`에서 추출
- `AuthenticationEntryPoint`: 미인증 요청에 401 + `ErrorResponse` JSON 반환 (기본 403 대신)

### T1.2-2 서버 로그인/갱신/로그아웃 API (`d54ec95`)
- `POST /api/auth/login` → 200 + `{accessToken, refreshToken}`
- `POST /api/auth/refresh` → Refresh Token Rotation (기존 토큰 즉시 삭제 후 새 토큰 발급)
- `POST /api/auth/logout` → 204, `refresh_tokens` 테이블에서 해당 토큰 삭제
- `UserService`: 더미 데이터 제거 → `UserRepository.findById()`

### T1.2-3 Android 로그인 UI (`19b0b10`)
- `LoginScreen` + `LoginViewModel`: 아이디/비밀번호 입력, 로그인 버튼, 회원가입 화면 진입
- `AuthRepository.login/logout` 추가, `TokenStorage`에 토큰 저장
- 앱 시작 시 `hasAccessToken()`으로 자동 로그인 분기 (`MainActivity`)
- `VoiceSettingsDialog`에 로그아웃 버튼 추가
- `SignupViewModel`: `AndroidViewModel` 단일 생성자 패턴으로 크래시 수정

### T1.2-4 Android Silent Refresh (`1d466a8`)
- `AuthInterceptor`: 모든 요청에 `Authorization: Bearer {token}` 자동 첨부
- `TokenAuthenticator`: 401 응답 시 `refresh` 호출 → 새 토큰으로 요청 재시도. `Mutex`로 동시 갱신 방지
- `ApiClient`: 인증 클라이언트(`conversation/diary/user`)와 비인증 클라이언트(`auth`) 분리. `App.onCreate()`에서 `init(tokenStorage)` 호출

### 기타
- 온보딩 스킵 버튼 임시 추가 (`1f8ec94`) — T1.3 구현 전까지 대화 화면 진입용
- develop 머지 (`37262d1`) — `ErrorResponse.of()` 시그니처 변경에 맞춰 `SecurityConfig` 수정

## Test plan

- [ ] 회원가입 → 온보딩 진입 (T1.1 회귀 확인)
- [ ] 로그인 성공 → 대화 화면 진입
- [ ] 로그인 실패(잘못된 비밀번호) → "아이디 또는 비밀번호가 올바르지 않습니다" 표시
- [ ] 로그아웃 → 로그인 화면 복귀
- [ ] 앱 재시작 → 토큰 있으면 자동 대화 화면 진입
- [ ] Access Token 만료 시뮬레이션(`application-local.yaml`에서 만료 짧게) → Silent Refresh로 끊김 없이 API 호출 성공
- [ ] Refresh Token도 만료 → 401 → 로컬 토큰 자동 삭제 (재로그인 필요)
- [ ] 인증 필요 API에 토큰 없이 호출 → 401 + `{"status":401,"error":"UNAUTHORIZED","message":"인증이 필요합니다."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
