### PR TITLE
chore: location 패키지 DEBUG 로그 활성화 + CI/CD 트리거 main으로 정상화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Build and Deploy to EC2
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths: ['server/**']
 
 env:

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -40,3 +40,7 @@ supertone:
   default-style: serene
   model: sona_speech_2
   api-key: ${SUPERTONE_API_KEY}
+
+logging:
+  level:
+    com.example.echo.location: DEBUG


### PR DESCRIPTION
## Summary

위치 데이터 디버깅을 위한 로그 레벨 조정과 CI/CD 트리거 정상화.

### 1. application-prod.yaml — location 패키지 DEBUG 로그 활성화

`com.example.echo.location` 패키지만 DEBUG로 변경. 다른 패키지는 그대로 INFO 유지.

```yaml
logging:
  level:
    com.example.echo.location: DEBUG
```

**이유:** `LocationService`의 `방문 장소 보강 완료 - placeName: ..., address: ..., 체류: ...분` 로그가 `log.debug`라서 INFO 환경에선 안 보였음. 카카오 역지오코딩 결과(빌딩명 vs 도로명/지번주소)와 체류 시간 기반 날씨 조회 분기를 EC2 컨테이너 로그(`docker logs`)에서 직접 확인하기 위함.

**영향 범위:**
- 로그 양: 호출당 2-3줄 추가 (성능 영향 무시할 수준)
- 디스크: 누적되면 Docker 로그가 커질 수 있음. 본격 운영 전 회전 정책 추가 필요
- **민감정보 주의:** DEBUG 로그에 GPS 좌표/주소가 그대로 찍힘 → 베타/실사용 단계 전에는 INFO로 원복 또는 환경변수 토글로 분리할 것

### 2. deploy.yml — CI/CD 트리거 main으로 변경

원래 T5 CI/CD plan대로 main 브랜치 push 시에만 자동 배포되도록 정상화.

```yaml
on:
  push:
    branches: [main]   # develop -> main
    paths: ['server/**']
```

**이유:** develop 트리거는 개발 중 임시 설정이었음. develop은 통합 브랜치이고 main이 실제 운영 반영 브랜치이므로 main 푸시만 자동 배포되는 게 plan과 일치.

**영향:**
- 머지 후: develop push 시 EC2 자동 배포 안 됨
- main으로 머지된 시점에만 자동 배포
- 긴급 핫픽스/디버그 검증 필요 시에는 별도 test 브랜치를 만들고 deploy.yml 트리거를 임시 변경하는 방식 사용

## Test plan

- [ ] PR 머지 후 develop push 시 GitHub Actions 안 도는 것 확인
- [ ] 별도 main 머지 PR 만들어 main push 시 자동 배포 동작 확인 (다음 PR에서)
- [ ] EC2 컨테이너 로그에서 `방문 장소 보강 완료 - placeName: ..., address: ...` 메시지 출력 확인

## 참고

현재 EC2는 별도 `test/location-debug-log` 브랜치 트리거로 이미 DEBUG 모드 배포 완료 상태. 이 PR은 develop 본류에 동일 설정을 반영하는 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
