### PR TITLE
feat: US1.3 초기 설정 (온보딩 + 설정 화면)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -5,30 +5,28 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.TokenStorage
 import com.example.graduation_project.data.repository.AuthRepository
+import com.example.graduation_project.data.repository.UserRepository
 import com.example.graduation_project.presentation.auth.LoginScreen
 import com.example.graduation_project.presentation.auth.SignupScreen
 import com.example.graduation_project.presentation.common.EchoTab
@@ -37,7 +35,9 @@ import com.example.graduation_project.presentation.conversation.ConversationScre
 import com.example.graduation_project.presentation.history.ConversationHistoryDetailScreen
 import com.example.graduation_project.presentation.history.ConversationHistoryScreen
 import com.example.graduation_project.presentation.home.HomeScreen
+import com.example.graduation_project.presentation.onboarding.OnboardingScreen
 import com.example.graduation_project.presentation.settings.SettingsScreen
+import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,6 +62,7 @@ private object Routes {
     const val LOGIN = "login"
     const val SIGNUP = "signup"
     const val ONBOARDING = "onboarding"
+    const val CHECKING = "checking"
     const val CONVERSATION = "conversation"
     const val HISTORY_DETAIL = "history_detail/{conversationId}"
 
@@ -79,11 +80,12 @@ private fun AppNavHost() {
     val context = LocalContext.current
     val application = context.applicationContext as Application
     val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application)) }
+    val userRepository = remember { UserRepository() }
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
 
     val startDestination = remember {
-        if (authRepository.hasAccessToken()) EchoTab.HOME.route else Routes.LOGIN
+        if (authRepository.hasAccessToken()) Routes.CHECKING else Routes.LOGIN
     }
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -113,11 +115,34 @@ private fun AppNavHost() {
             startDestination = startDestination,
             modifier = Modifier.padding(paddingValues)
         ) {
+            composable(Routes.CHECKING) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = EchoAccentGreen)
+                }
+                LaunchedEffect(Unit) {
+                    val completed = when (val result = userRepository.getOnboardingStatus()) {
+                        is ApiResult.Success -> result.data.completed
+                        is ApiResult.Error -> false
+                    }
+                    val destination = if (completed) EchoTab.HOME.route else Routes.ONBOARDING
+                    navController.navigate(destination) {
+                        popUpTo(Routes.CHECKING) { inclusive = true }
+                    }
+                }
+            }
+
             composable(Routes.LOGIN) {
                 LoginScreen(
                     onLoginSuccess = {
-                        navController.navigate(EchoTab.HOME.route) {
-                            popUpTo(Routes.LOGIN) { inclusive = true }
+                        coroutineScope.launch {
+                            val completed = when (val result = userRepository.getOnboardingStatus()) {
+                                is ApiResult.Success -> result.data.completed
+                                is ApiResult.Error -> false
+                            }
+                            val destination = if (completed) EchoTab.HOME.route else Routes.ONBOARDING
+                            navController.navigate(destination) {
+                                popUpTo(Routes.LOGIN) { inclusive = true }
+                            }
                         }
                     },
                     onNavigateToSignup = {
@@ -137,8 +162,8 @@ private fun AppNavHost() {
             }
 
             composable(Routes.ONBOARDING) {
-                OnboardingPlaceholder(
-                    onSkip = {
+                OnboardingScreen(
+                    onOnboardingComplete = {
                         navController.navigate(EchoTab.HOME.route) {
                             popUpTo(Routes.ONBOARDING) { inclusive = true }
                         }
@@ -206,19 +231,3 @@ private fun AppNavHost() {
     }
 }
 
-@Composable
-private fun OnboardingPlaceholder(onSkip: () -> Unit = {}) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text("온보딩 (T1.3에서 구현 예정)")
-        Spacer(Modifier.height(24.dp))
-        Button(onClick = onSkip) {
-            Text("시작하기")
-        }
-    }
-}

--- a/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
@@ -1,5 +1,6 @@
 package com.example.graduation_project.data.api
 
+import com.example.graduation_project.data.model.OnboardingStatusResponse
 import com.example.graduation_project.data.model.User
 import com.example.graduation_project.data.model.UserPreferences
 import retrofit2.http.Body
@@ -19,4 +20,7 @@ interface UserApi {
 
     @PUT("/api/users/me/preferences")
     suspend fun updatePreferences(@Body preferences: UserPreferences): UserPreferences
+
+    @GET("/api/users/me/onboarding-status")
+    suspend fun getOnboardingStatus(): OnboardingStatusResponse
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -15,15 +15,21 @@ data class UserPreferences(
     val userId: Long? = null,
     val name: String? = null,
     val age: Int? = null,
-    val birthday: String? = null,               // 서버: LocalDate → "yyyy-MM-dd"
+    val birthday: String? = null,
     val location: String? = null,
-    val familyInfo: String? = null,             // renamed: familyRelation → familyInfo
+    val familyInfo: String? = null,
+    val guardianEmail: String? = null,
     val occupation: String? = null,
-    val hobbies: String? = null,                // renamed: hobby → hobbies
-    val preferredTopics: String? = null,        // type changed: List<String> → String
+    val hobbies: String? = null,
+    val preferredTopics: String? = null,
     val voiceSettings: VoiceSettings? = null,
-    val conversationTime: String? = null,       // 서버: LocalTime → "HH:mm"
+    val conversationTime: String? = null,
     val preferredSleepHours: Int? = null
+)
+
+@Serializable
+data class OnboardingStatusResponse(
+    val completed: Boolean
 )
 
 @Serializable

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.api.UserApi
 import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.model.OnboardingStatusResponse
 import com.example.graduation_project.data.model.UserPreferences
 
 class UserRepository(
@@ -11,14 +12,14 @@ class UserRepository(
 ) {
 
     suspend fun getPreferences(): ApiResult<UserPreferences> {
-        return safeApiCall {
-            userApi.getPreferences()
-        }
+        return safeApiCall { userApi.getPreferences() }
     }
 
     suspend fun updatePreferences(preferences: UserPreferences): ApiResult<UserPreferences> {
-        return safeApiCall {
-            userApi.updatePreferences(preferences)
-        }
+        return safeApiCall { userApi.updatePreferences(preferences) }
+    }
+
+    suspend fun getOnboardingStatus(): ApiResult<OnboardingStatusResponse> {
+        return safeApiCall { userApi.getOnboardingStatus() }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/common/BirthdayInput.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/common/BirthdayInput.kt
@@ -1,0 +1,141 @@
+package com.example.graduation_project.presentation.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.graduation_project.ui.theme.EchoAccentGreen
+import com.example.graduation_project.ui.theme.EchoBgCard
+import com.example.graduation_project.ui.theme.EchoBorderSubtle
+import com.example.graduation_project.ui.theme.EchoTextPrimary
+import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.OutfitFontFamily
+import java.time.LocalDate
+
+/** "yyyy-MM-dd" → (년, 월, 일) 문자열. 빈 문자열이면 ("", "", "") */
+internal fun parseBirthday(value: String): Triple<String, String, String> {
+    if (value.isBlank()) return Triple("", "", "")
+    return runCatching {
+        val d = LocalDate.parse(value)
+        Triple(d.year.toString(), d.monthValue.toString(), d.dayOfMonth.toString())
+    }.getOrDefault(Triple("", "", ""))
+}
+
+/** (년, 월, 일) → "yyyy-MM-dd". 유효하지 않으면 null */
+internal fun buildBirthdayString(year: String, month: String, day: String): String? {
+    val y = year.toIntOrNull() ?: return null
+    val m = month.toIntOrNull() ?: return null
+    val d = day.toIntOrNull() ?: return null
+    return runCatching { LocalDate.of(y, m, d).toString() }.getOrNull()
+}
+
+/** 년/월/일 세 칸 직접 입력 Row. 온보딩 스텝과 설정 다이얼로그 양쪽에서 재사용 */
+@Composable
+internal fun BirthdayInputRow(
+    year: String,
+    month: String,
+    day: String,
+    onYearChange: (String) -> Unit,
+    onMonthChange: (String) -> Unit,
+    onDayChange: (String) -> Unit,
+    isError: Boolean = false
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BirthdayField(
+            value = year,
+            suffix = "년",
+            maxLength = 4,
+            placeholder = "1952",
+            weight = 2.2f,
+            onValueChange = onYearChange,
+            isError = isError
+        )
+        BirthdayField(
+            value = month,
+            suffix = "월",
+            maxLength = 2,
+            placeholder = "1",
+            weight = 1f,
+            onValueChange = onMonthChange,
+            isError = isError
+        )
+        BirthdayField(
+            value = day,
+            suffix = "일",
+            maxLength = 2,
+            placeholder = "1",
+            weight = 1f,
+            onValueChange = onDayChange,
+            isError = isError
+        )
+    }
+}
+
+@Composable
+private fun RowScope.BirthdayField(
+    value: String,
+    suffix: String,
+    maxLength: Int,
+    placeholder: String,
+    weight: Float,
+    onValueChange: (String) -> Unit,
+    isError: Boolean
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { v -> onValueChange(v.filter { it.isDigit() }.take(maxLength)) },
+        suffix = {
+            Text(
+                text = suffix,
+                fontFamily = OutfitFontFamily,
+                fontSize = 16.sp,
+                color = EchoTextTertiary
+            )
+        },
+        placeholder = {
+            Text(
+                text = placeholder,
+                fontFamily = OutfitFontFamily,
+                fontSize = 20.sp,
+                color = EchoTextTertiary
+            )
+        },
+        singleLine = true,
+        isError = isError,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        textStyle = TextStyle(
+            fontFamily = OutfitFontFamily,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium,
+            color = EchoTextPrimary
+        ),
+        shape = RoundedCornerShape(12.dp),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedContainerColor = EchoBgCard,
+            unfocusedContainerColor = EchoBgCard,
+            focusedBorderColor = EchoAccentGreen,
+            unfocusedBorderColor = EchoBorderSubtle,
+            focusedTextColor = EchoTextPrimary,
+            unfocusedTextColor = EchoTextPrimary,
+            errorContainerColor = EchoBgCard
+        ),
+        modifier = Modifier.weight(weight)
+    )
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTimePicker.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTimePicker.kt
@@ -1,0 +1,173 @@
+package com.example.graduation_project.presentation.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.graduation_project.ui.theme.EchoAccentGreen
+import com.example.graduation_project.ui.theme.EchoTextPrimary
+import com.example.graduation_project.ui.theme.EchoTextSecondary
+import com.example.graduation_project.ui.theme.OutfitFontFamily
+
+/** "HH:mm" → (isAm, hour 1-12, minute 0-55 rounded to nearest 5) */
+internal fun parseTime(value: String): Triple<Boolean, Int, Int> {
+    if (value.isBlank()) return Triple(true, 9, 0)
+    return runCatching {
+        val (hStr, mStr) = value.split(":")
+        val h = hStr.toInt()
+        val m = (mStr.toInt() / 5) * 5
+        val isAm = h < 12
+        val h12 = when {
+            h == 0 -> 12
+            h > 12 -> h - 12
+            else -> h
+        }
+        Triple(isAm, h12, m)
+    }.getOrDefault(Triple(true, 9, 0))
+}
+
+/** (isAm, hour 1-12, minute 0-55) → "HH:mm" */
+internal fun buildTimeString(isAm: Boolean, hour: Int, minute: Int): String {
+    val h24 = when {
+        isAm && hour == 12 -> 0
+        !isAm && hour == 12 -> 12
+        !isAm -> hour + 12
+        else -> hour
+    }
+    return "%02d:%02d".format(h24, minute)
+}
+
+/** 오전/오후 + 시/분 스테퍼. 온보딩 스텝과 설정 다이얼로그 양쪽에서 재사용 */
+@Composable
+internal fun EchoTimePickerContent(
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    val initial = remember { parseTime(value) }
+    var isAm by remember { mutableStateOf(initial.first) }
+    var hour by remember { mutableStateOf(initial.second) }
+    var minute by remember { mutableStateOf(initial.third) }
+
+    fun notify() = onValueChange(buildTimeString(isAm, hour, minute))
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            listOf(true to "오전", false to "오후").forEach { (amVal, label) ->
+                FilterChip(
+                    selected = isAm == amVal,
+                    onClick = { isAm = amVal; notify() },
+                    label = {
+                        Text(
+                            label,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            fontFamily = OutfitFontFamily
+                        )
+                    },
+                    modifier = Modifier.height(44.dp),
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = EchoAccentGreen,
+                        selectedLabelColor = Color.White
+                    )
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TimeSpinner(
+                display = hour.toString(),
+                label = "시",
+                onUp = { hour = if (hour == 12) 1 else hour + 1; notify() },
+                onDown = { hour = if (hour == 1) 12 else hour - 1; notify() }
+            )
+            Text(
+                text = ":",
+                fontSize = 44.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = OutfitFontFamily,
+                color = EchoTextPrimary,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .padding(bottom = 20.dp)
+            )
+            TimeSpinner(
+                display = "%02d".format(minute),
+                label = "분",
+                onUp = { minute = (minute + 5) % 60; notify() },
+                onDown = { minute = if (minute == 0) 55 else minute - 5; notify() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimeSpinner(
+    display: String,
+    label: String,
+    onUp: () -> Unit,
+    onDown: () -> Unit
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        IconButton(onClick = onUp, modifier = Modifier.size(52.dp)) {
+            Icon(
+                imageVector = Icons.Outlined.KeyboardArrowUp,
+                contentDescription = "증가",
+                tint = EchoAccentGreen,
+                modifier = Modifier.size(36.dp)
+            )
+        }
+        Text(
+            text = display,
+            fontSize = 48.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = OutfitFontFamily,
+            color = EchoTextPrimary
+        )
+        IconButton(onClick = onDown, modifier = Modifier.size(52.dp)) {
+            Icon(
+                imageVector = Icons.Outlined.KeyboardArrowDown,
+                contentDescription = "감소",
+                tint = EchoAccentGreen,
+                modifier = Modifier.size(36.dp)
+            )
+        }
+        Text(
+            text = label,
+            fontSize = 15.sp,
+            fontFamily = OutfitFontFamily,
+            color = EchoTextSecondary
+        )
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package com.example.graduation_project.presentation.onboarding
 
-import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +43,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.presentation.auth.EchoOutlinedTextField
+import com.example.graduation_project.presentation.common.BirthdayInputRow
+import com.example.graduation_project.presentation.common.buildBirthdayString
+import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.EchoBgMuted
 import com.example.graduation_project.ui.theme.EchoBgPage
@@ -285,47 +287,23 @@ private fun StepContent(
 
 @Composable
 private fun DatePickerStep(selected: String, onDateSelected: (String) -> Unit) {
-    val context = LocalContext.current
-    var showPicker by remember { mutableStateOf(false) }
+    val initial = remember { parseBirthday(selected) }
+    var year by remember { mutableStateOf(initial.first) }
+    var month by remember { mutableStateOf(initial.second) }
+    var day by remember { mutableStateOf(initial.third) }
 
-    Column {
-        OutlinedButton(
-            onClick = { showPicker = true },
-            modifier = Modifier.fillMaxWidth().height(56.dp),
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Text(
-                text = if (selected.isNotEmpty()) selected else "날짜 선택",
-                fontSize = 16.sp,
-                fontFamily = OutfitFontFamily,
-                color = if (selected.isNotEmpty()) EchoTextPrimary else EchoTextTertiary
-            )
-        }
-        if (selected.isNotEmpty()) {
-            Spacer(Modifier.height(8.dp))
-            TextButton(onClick = { onDateSelected("") }) {
-                Text("선택 취소", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
-            }
-        }
+    fun notifyChange(y: String, m: String, d: String) {
+        val built = buildBirthdayString(y, m, d)
+        if (built != null) onDateSelected(built)
+        else if (y.isBlank() && m.isBlank() && d.isBlank()) onDateSelected("")
     }
 
-    if (showPicker) {
-        DisposableEffect(Unit) {
-            val today = LocalDate.now()
-            val (y, m, d) = if (selected.isNotEmpty()) {
-                val parsed = runCatching { LocalDate.parse(selected) }.getOrDefault(today)
-                Triple(parsed.year, parsed.monthValue - 1, parsed.dayOfMonth)
-            } else {
-                Triple(today.year - 70, 0, 1)
-            }
-            val dialog = DatePickerDialog(context, { _, year, month, day ->
-                onDateSelected(LocalDate.of(year, month + 1, day).toString())
-            }, y, m, d)
-            dialog.setOnDismissListener { showPicker = false }
-            dialog.show()
-            onDispose { dialog.dismiss() }
-        }
-    }
+    BirthdayInputRow(
+        year = year, month = month, day = day,
+        onYearChange = { year = it; notifyChange(it, month, day) },
+        onMonthChange = { month = it; notifyChange(year, it, day) },
+        onDayChange = { day = it; notifyChange(year, month, it) }
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -1,0 +1,449 @@
+package com.example.graduation_project.presentation.onboarding
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.presentation.auth.EchoOutlinedTextField
+import com.example.graduation_project.ui.theme.EchoAccentGreen
+import com.example.graduation_project.ui.theme.EchoBgMuted
+import com.example.graduation_project.ui.theme.EchoBgPage
+import com.example.graduation_project.ui.theme.EchoTextPrimary
+import com.example.graduation_project.ui.theme.EchoTextSecondary
+import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.OutfitFontFamily
+import java.time.LocalDate
+import java.time.LocalTime
+
+private val stepTitles = listOf(
+    "생년월일", "가족 관계", "보호자 이메일", "거주 지역",
+    "직업", "취미", "선호 대화 주제", "음성 설정", "대화 시간", "선호 수면 시간"
+)
+
+private val stepHints = listOf(
+    "생일을 알려주세요",
+    "예) 딸, 아들, 배우자",
+    "비밀번호 복구에 사용됩니다 (필수)",
+    "예) 서울 강남구",
+    "예) 전직 교사, 은행원",
+    "예) 정원 가꾸기, 독서",
+    "예) 옛날 이야기, 건강",
+    "음성 속도와 톤을 설정해주세요",
+    "매일 같은 시간에 대화를 시작합니다",
+    "하루 평균 몇 시간 주무시나요?"
+)
+
+@Composable
+fun OnboardingScreen(
+    onOnboardingComplete: () -> Unit,
+    viewModel: OnboardingViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.isCompleted) {
+        if (uiState.isCompleted) onOnboardingComplete()
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissError()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(EchoBgPage)
+    ) {
+        // 상단 진행률
+        Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "초기 설정",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = OutfitFontFamily,
+                    color = EchoTextPrimary
+                )
+                Text(
+                    text = "${uiState.currentStep + 1} / $ONBOARDING_STEPS",
+                    fontSize = 16.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = EchoTextSecondary
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            LinearProgressIndicator(
+                progress = { (uiState.currentStep + 1).toFloat() / ONBOARDING_STEPS },
+                modifier = Modifier.fillMaxWidth(),
+                color = EchoAccentGreen,
+                trackColor = EchoBgMuted
+            )
+        }
+
+        // 본문
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+        ) {
+            Text(
+                text = stepTitles[uiState.currentStep],
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = OutfitFontFamily,
+                color = EchoTextPrimary
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stepHints[uiState.currentStep],
+                fontSize = 15.sp,
+                fontFamily = OutfitFontFamily,
+                color = EchoTextSecondary
+            )
+            Spacer(Modifier.height(32.dp))
+
+            StepContent(
+                step = uiState.currentStep,
+                uiState = uiState,
+                onBirthdayChange = viewModel::updateBirthday,
+                onFamilyInfoChange = viewModel::updateFamilyInfo,
+                onGuardianEmailChange = viewModel::updateGuardianEmail,
+                onLocationChange = viewModel::updateLocation,
+                onOccupationChange = viewModel::updateOccupation,
+                onHobbiesChange = viewModel::updateHobbies,
+                onPreferredTopicsChange = viewModel::updatePreferredTopics,
+                onVoiceSpeedChange = viewModel::updateVoiceSpeed,
+                onVoiceToneChange = viewModel::updateVoiceTone,
+                onConversationTimeChange = viewModel::updateConversationTime,
+                onSleepHoursChange = viewModel::updatePreferredSleepHours
+            )
+
+            uiState.fieldError?.let { error ->
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = error,
+                    fontSize = 14.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = androidx.compose.ui.graphics.Color(0xFFE53935)
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+
+        // 하단 버튼
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            if (uiState.currentStep > 0) {
+                OutlinedButton(
+                    onClick = viewModel::previous,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(56.dp),
+                    shape = RoundedCornerShape(16.dp)
+                ) {
+                    Text(
+                        text = "이전",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = OutfitFontFamily,
+                        color = EchoAccentGreen
+                    )
+                }
+            }
+            Button(
+                onClick = viewModel::next,
+                enabled = !uiState.isLoading,
+                modifier = Modifier
+                    .weight(if (uiState.currentStep > 0) 1f else Float.MAX_VALUE)
+                    .height(56.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = EchoAccentGreen,
+                    contentColor = Color.White,
+                    disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
+                )
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.height(22.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(
+                        text = if (uiState.currentStep < ONBOARDING_STEPS - 1) "다음" else "완료",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        fontFamily = OutfitFontFamily
+                    )
+                }
+            }
+        }
+
+        SnackbarHost(snackbarHostState)
+    }
+}
+
+@Composable
+private fun StepContent(
+    step: Int,
+    uiState: OnboardingUiState,
+    onBirthdayChange: (String) -> Unit,
+    onFamilyInfoChange: (String) -> Unit,
+    onGuardianEmailChange: (String) -> Unit,
+    onLocationChange: (String) -> Unit,
+    onOccupationChange: (String) -> Unit,
+    onHobbiesChange: (String) -> Unit,
+    onPreferredTopicsChange: (String) -> Unit,
+    onVoiceSpeedChange: (Double) -> Unit,
+    onVoiceToneChange: (String) -> Unit,
+    onConversationTimeChange: (String) -> Unit,
+    onSleepHoursChange: (String) -> Unit
+) {
+    when (step) {
+        0 -> DatePickerStep(selected = uiState.birthday, onDateSelected = onBirthdayChange)
+        1 -> EchoOutlinedTextField(value = uiState.familyInfo, onValueChange = onFamilyInfoChange, label = "가족 관계")
+        2 -> EchoOutlinedTextField(
+            value = uiState.guardianEmail,
+            onValueChange = onGuardianEmailChange,
+            label = "보호자 이메일",
+            keyboardType = KeyboardType.Email,
+            isError = uiState.fieldError != null
+        )
+        3 -> EchoOutlinedTextField(value = uiState.location, onValueChange = onLocationChange, label = "거주 지역")
+        4 -> EchoOutlinedTextField(value = uiState.occupation, onValueChange = onOccupationChange, label = "직업")
+        5 -> EchoOutlinedTextField(value = uiState.hobbies, onValueChange = onHobbiesChange, label = "취미")
+        6 -> EchoOutlinedTextField(value = uiState.preferredTopics, onValueChange = onPreferredTopicsChange, label = "선호 대화 주제")
+        7 -> VoiceSettingsStep(
+            voiceSpeed = uiState.voiceSpeed,
+            voiceTone = uiState.voiceTone,
+            onSpeedChange = onVoiceSpeedChange,
+            onToneChange = onVoiceToneChange
+        )
+        8 -> TimePickerStep(selected = uiState.conversationTime, onTimeSelected = onConversationTimeChange)
+        9 -> EchoOutlinedTextField(
+            value = uiState.preferredSleepHours,
+            onValueChange = onSleepHoursChange,
+            label = "수면 시간 (시간)",
+            keyboardType = KeyboardType.Number,
+            isError = uiState.fieldError != null
+        )
+    }
+}
+
+@Composable
+private fun DatePickerStep(selected: String, onDateSelected: (String) -> Unit) {
+    val context = LocalContext.current
+    var showPicker by remember { mutableStateOf(false) }
+
+    Column {
+        OutlinedButton(
+            onClick = { showPicker = true },
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Text(
+                text = if (selected.isNotEmpty()) selected else "날짜 선택",
+                fontSize = 16.sp,
+                fontFamily = OutfitFontFamily,
+                color = if (selected.isNotEmpty()) EchoTextPrimary else EchoTextTertiary
+            )
+        }
+        if (selected.isNotEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            TextButton(onClick = { onDateSelected("") }) {
+                Text("선택 취소", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
+        }
+    }
+
+    if (showPicker) {
+        DisposableEffect(Unit) {
+            val today = LocalDate.now()
+            val (y, m, d) = if (selected.isNotEmpty()) {
+                val parsed = runCatching { LocalDate.parse(selected) }.getOrDefault(today)
+                Triple(parsed.year, parsed.monthValue - 1, parsed.dayOfMonth)
+            } else {
+                Triple(today.year - 70, 0, 1)
+            }
+            val dialog = DatePickerDialog(context, { _, year, month, day ->
+                onDateSelected(LocalDate.of(year, month + 1, day).toString())
+            }, y, m, d)
+            dialog.setOnDismissListener { showPicker = false }
+            dialog.show()
+            onDispose { dialog.dismiss() }
+        }
+    }
+}
+
+@Composable
+private fun TimePickerStep(selected: String, onTimeSelected: (String) -> Unit) {
+    val context = LocalContext.current
+    var showPicker by remember { mutableStateOf(false) }
+
+    Column {
+        OutlinedButton(
+            onClick = { showPicker = true },
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Text(
+                text = if (selected.isNotEmpty()) selected else "시간 선택",
+                fontSize = 16.sp,
+                fontFamily = OutfitFontFamily,
+                color = if (selected.isNotEmpty()) EchoTextPrimary else EchoTextTertiary
+            )
+        }
+        if (selected.isNotEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            TextButton(onClick = { onTimeSelected("") }) {
+                Text("선택 취소", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
+        }
+    }
+
+    if (showPicker) {
+        DisposableEffect(Unit) {
+            val (h, m) = if (selected.isNotEmpty()) {
+                runCatching {
+                    val t = LocalTime.parse(selected)
+                    Pair(t.hour, t.minute)
+                }.getOrDefault(Pair(9, 0))
+            } else {
+                Pair(9, 0)
+            }
+            val dialog = TimePickerDialog(context, { _, hour, minute ->
+                onTimeSelected("%02d:%02d".format(hour, minute))
+            }, h, m, true)
+            dialog.setOnDismissListener { showPicker = false }
+            dialog.show()
+            onDispose { dialog.dismiss() }
+        }
+    }
+}
+
+@Composable
+private fun VoiceSettingsStep(
+    voiceSpeed: Double,
+    voiceTone: String,
+    onSpeedChange: (Double) -> Unit,
+    onToneChange: (String) -> Unit
+) {
+    Column {
+        Text(
+            text = "음성 속도",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            fontFamily = OutfitFontFamily,
+            color = EchoTextPrimary
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "${String.format("%.1f", voiceSpeed)}x  ${
+                when {
+                    voiceSpeed < 1.0 -> "느리게"
+                    voiceSpeed > 1.0 -> "빠르게"
+                    else -> "보통"
+                }
+            }",
+            fontSize = 15.sp,
+            fontFamily = OutfitFontFamily,
+            color = EchoAccentGreen
+        )
+        androidx.compose.material3.Slider(
+            value = voiceSpeed.toFloat(),
+            onValueChange = { onSpeedChange(Math.round(it * 10.0) / 10.0) },
+            valueRange = 0.8f..1.2f,
+            steps = 3,
+            modifier = Modifier.fillMaxWidth(),
+            colors = androidx.compose.material3.SliderDefaults.colors(
+                thumbColor = EchoAccentGreen,
+                activeTrackColor = EchoAccentGreen,
+                inactiveTrackColor = EchoBgMuted
+            )
+        )
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text("느리게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
+            Text("빠르게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            text = "음성 톤",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            fontFamily = OutfitFontFamily,
+            color = EchoTextPrimary
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            val tones = listOf("warm" to "따뜻하게", "calm" to "차분하게", "cheerful" to "밝게")
+            tones.forEach { (value, label) ->
+                FilterChip(
+                    selected = voiceTone == value,
+                    onClick = { onToneChange(value) },
+                    label = {
+                        Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily)
+                    },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = EchoAccentGreen,
+                        selectedLabelColor = Color.White
+                    )
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package com.example.graduation_project.presentation.onboarding
 
-import android.app.TimePickerDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -26,7 +25,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -36,7 +34,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -44,6 +41,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.presentation.auth.EchoOutlinedTextField
 import com.example.graduation_project.presentation.common.BirthdayInputRow
+import com.example.graduation_project.presentation.common.EchoTimePickerContent
 import com.example.graduation_project.presentation.common.buildBirthdayString
 import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.ui.theme.EchoAccentGreen
@@ -53,8 +51,6 @@ import com.example.graduation_project.ui.theme.EchoTextPrimary
 import com.example.graduation_project.ui.theme.EchoTextSecondary
 import com.example.graduation_project.ui.theme.EchoTextTertiary
 import com.example.graduation_project.ui.theme.OutfitFontFamily
-import java.time.LocalDate
-import java.time.LocalTime
 
 private val stepTitles = listOf(
     "생년월일", "가족 관계", "보호자 이메일", "거주 지역",
@@ -308,48 +304,11 @@ private fun DatePickerStep(selected: String, onDateSelected: (String) -> Unit) {
 
 @Composable
 private fun TimePickerStep(selected: String, onTimeSelected: (String) -> Unit) {
-    val context = LocalContext.current
-    var showPicker by remember { mutableStateOf(false) }
-
-    Column {
-        OutlinedButton(
-            onClick = { showPicker = true },
-            modifier = Modifier.fillMaxWidth().height(56.dp),
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            Text(
-                text = if (selected.isNotEmpty()) selected else "시간 선택",
-                fontSize = 16.sp,
-                fontFamily = OutfitFontFamily,
-                color = if (selected.isNotEmpty()) EchoTextPrimary else EchoTextTertiary
-            )
-        }
-        if (selected.isNotEmpty()) {
-            Spacer(Modifier.height(8.dp))
-            TextButton(onClick = { onTimeSelected("") }) {
-                Text("선택 취소", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
-            }
-        }
+    val initial = if (selected.isNotEmpty()) selected else "09:00"
+    LaunchedEffect(Unit) {
+        if (selected.isEmpty()) onTimeSelected("09:00")
     }
-
-    if (showPicker) {
-        DisposableEffect(Unit) {
-            val (h, m) = if (selected.isNotEmpty()) {
-                runCatching {
-                    val t = LocalTime.parse(selected)
-                    Pair(t.hour, t.minute)
-                }.getOrDefault(Pair(9, 0))
-            } else {
-                Pair(9, 0)
-            }
-            val dialog = TimePickerDialog(context, { _, hour, minute ->
-                onTimeSelected("%02d:%02d".format(hour, minute))
-            }, h, m, true)
-            dialog.setOnDismissListener { showPicker = false }
-            dialog.show()
-            onDispose { dialog.dismiss() }
-        }
-    }
+    EchoTimePickerContent(value = initial, onValueChange = onTimeSelected)
 }
 
 @Composable

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,119 @@
+package com.example.graduation_project.presentation.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.model.VoiceSettings
+import com.example.graduation_project.data.repository.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+const val ONBOARDING_STEPS = 10
+
+private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
+
+data class OnboardingUiState(
+    val currentStep: Int = 0,
+    val birthday: String = "",
+    val familyInfo: String = "",
+    val guardianEmail: String = "",
+    val location: String = "",
+    val occupation: String = "",
+    val hobbies: String = "",
+    val preferredTopics: String = "",
+    val voiceSpeed: Double = 1.0,
+    val voiceTone: String = "warm",
+    val conversationTime: String = "",
+    val preferredSleepHours: String = "",
+    val fieldError: String? = null,
+    val isLoading: Boolean = false,
+    val isCompleted: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class OnboardingViewModel(
+    private val userRepository: UserRepository = UserRepository()
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingUiState())
+    val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
+
+    fun updateBirthday(value: String) = _uiState.update { it.copy(birthday = value, fieldError = null) }
+    fun updateFamilyInfo(value: String) = _uiState.update { it.copy(familyInfo = value, fieldError = null) }
+    fun updateGuardianEmail(value: String) = _uiState.update { it.copy(guardianEmail = value, fieldError = null) }
+    fun updateLocation(value: String) = _uiState.update { it.copy(location = value, fieldError = null) }
+    fun updateOccupation(value: String) = _uiState.update { it.copy(occupation = value, fieldError = null) }
+    fun updateHobbies(value: String) = _uiState.update { it.copy(hobbies = value, fieldError = null) }
+    fun updatePreferredTopics(value: String) = _uiState.update { it.copy(preferredTopics = value, fieldError = null) }
+    fun updateVoiceSpeed(value: Double) = _uiState.update { it.copy(voiceSpeed = value) }
+    fun updateVoiceTone(value: String) = _uiState.update { it.copy(voiceTone = value) }
+    fun updateConversationTime(value: String) = _uiState.update { it.copy(conversationTime = value, fieldError = null) }
+    fun updatePreferredSleepHours(value: String) = _uiState.update { it.copy(preferredSleepHours = value, fieldError = null) }
+
+    fun next() {
+        val state = _uiState.value
+        val error = validateStep(state)
+        if (error != null) {
+            _uiState.update { it.copy(fieldError = error) }
+            return
+        }
+        if (state.currentStep < ONBOARDING_STEPS - 1) {
+            _uiState.update { it.copy(currentStep = state.currentStep + 1, fieldError = null) }
+        } else {
+            submit()
+        }
+    }
+
+    fun previous() {
+        val step = _uiState.value.currentStep
+        if (step > 0) _uiState.update { it.copy(currentStep = step - 1, fieldError = null) }
+    }
+
+    private fun validateStep(state: OnboardingUiState): String? = when (state.currentStep) {
+        2 -> when {
+            state.guardianEmail.isBlank() -> "보호자 이메일을 입력해주세요"
+            !EMAIL_REGEX.matches(state.guardianEmail) -> "올바른 이메일 형식을 입력해주세요"
+            else -> null
+        }
+        9 -> if (state.preferredSleepHours.isNotBlank()) {
+            val h = state.preferredSleepHours.toIntOrNull()
+            when {
+                h == null -> "숫자를 입력해주세요"
+                h !in 1..24 -> "1~24 사이의 숫자를 입력해주세요"
+                else -> null
+            }
+        } else null
+        else -> null
+    }
+
+    private fun submit() {
+        val state = _uiState.value
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val preferences = UserPreferences(
+                birthday = state.birthday.ifBlank { null },
+                familyInfo = state.familyInfo.ifBlank { null },
+                guardianEmail = state.guardianEmail.ifBlank { null },
+                location = state.location.ifBlank { null },
+                occupation = state.occupation.ifBlank { null },
+                hobbies = state.hobbies.ifBlank { null },
+                preferredTopics = state.preferredTopics.ifBlank { null },
+                voiceSettings = VoiceSettings(voiceSpeed = state.voiceSpeed, voiceTone = state.voiceTone),
+                conversationTime = state.conversationTime.ifBlank { null },
+                preferredSleepHours = state.preferredSleepHours.toIntOrNull()
+            )
+            when (userRepository.updatePreferences(preferences)) {
+                is ApiResult.Success -> _uiState.update { it.copy(isLoading = false, isCompleted = true) }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(isLoading = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
+                }
+            }
+        }
+    }
+
+    fun dismissError() = _uiState.update { it.copy(errorMessage = null) }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -1,7 +1,11 @@
 package com.example.graduation_project.presentation.settings
 
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,32 +14,52 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.model.VoiceSettings
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.EchoAccentRed
 import com.example.graduation_project.ui.theme.EchoBgCard
@@ -45,8 +69,37 @@ import com.example.graduation_project.ui.theme.EchoBorderSubtle
 import com.example.graduation_project.ui.theme.EchoTextPrimary
 import com.example.graduation_project.ui.theme.EchoTextSecondary
 import com.example.graduation_project.ui.theme.EchoTextTertiary
-import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
+import java.time.LocalDate
+import java.time.LocalTime
+
+private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
+
+private fun buildPreferences(
+    state: SettingsUiState,
+    birthday: String? = state.birthday,
+    familyInfo: String? = state.familyInfo,
+    guardianEmail: String? = state.guardianEmail,
+    location: String? = state.location,
+    occupation: String? = state.occupation,
+    hobbies: String? = state.hobbies,
+    preferredTopics: String? = state.preferredTopics,
+    voiceSpeed: Double = state.voiceSpeed,
+    voiceTone: String = state.voiceTone,
+    conversationTime: String? = state.conversationTime,
+    preferredSleepHours: Int? = state.preferredSleepHours
+): UserPreferences = UserPreferences(
+    birthday = birthday,
+    familyInfo = familyInfo,
+    guardianEmail = guardianEmail,
+    location = location,
+    occupation = occupation,
+    hobbies = hobbies,
+    preferredTopics = preferredTopics,
+    voiceSettings = VoiceSettings(voiceSpeed = voiceSpeed, voiceTone = voiceTone),
+    conversationTime = conversationTime,
+    preferredSleepHours = preferredSleepHours
+)
 
 @Composable
 fun SettingsScreen(
@@ -54,214 +107,492 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var editingField by remember { mutableStateOf<String?>(null) }
 
-    SettingsScreenContent(
-        uiState = uiState,
-        onSpeedChange = viewModel::onSpeedChange,
-        onLogout = onLogout
+    LaunchedEffect(uiState.savedMessage) {
+        uiState.savedMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissSavedMessage()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.dismissError()
+        }
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(EchoBgPage)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "설정",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = OutfitFontFamily,
+                color = EchoTextPrimary,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
+            )
+
+            // 프로필 카드
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                shape = RoundedCornerShape(16.dp),
+                color = EchoBgCard
+            ) {
+                Row(
+                    modifier = Modifier.padding(20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Surface(modifier = Modifier.size(56.dp), shape = CircleShape, color = EchoBgMuted) {
+                        Icon(
+                            imageVector = Icons.Outlined.Person,
+                            contentDescription = null,
+                            tint = EchoTextSecondary,
+                            modifier = Modifier.padding(12.dp)
+                        )
+                    }
+                    Column {
+                        Text(
+                            text = if (uiState.userName.isNotBlank()) uiState.userName else "사용자",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            fontFamily = OutfitFontFamily,
+                            color = EchoTextPrimary
+                        )
+                        if (uiState.age != null) {
+                            Text(
+                                text = "${uiState.age}세",
+                                fontSize = 15.sp,
+                                fontFamily = OutfitFontFamily,
+                                color = EchoTextSecondary
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // 선호도 목록 카드
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                shape = RoundedCornerShape(16.dp),
+                color = EchoBgCard
+            ) {
+                Column {
+                    val enabled = !uiState.isSaving
+
+                    PreferenceRow("생년월일", uiState.birthday, enabled = enabled) { editingField = "birthday" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("가족 관계", uiState.familyInfo, enabled = enabled) { editingField = "familyInfo" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow(
+                        label = "보호자 이메일",
+                        value = uiState.guardianEmail,
+                        showWarning = uiState.guardianEmail.isNullOrBlank(),
+                        enabled = enabled
+                    ) { editingField = "guardianEmail" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("거주 지역", uiState.location, enabled = enabled) { editingField = "location" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("직업", uiState.occupation, enabled = enabled) { editingField = "occupation" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("취미", uiState.hobbies, enabled = enabled) { editingField = "hobbies" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("선호 대화 주제", uiState.preferredTopics, enabled = enabled) { editingField = "preferredTopics" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow(
+                        label = "음성 설정",
+                        value = "${String.format("%.1f", uiState.voiceSpeed)}x · ${
+                            when (uiState.voiceTone) {
+                                "calm" -> "차분하게"
+                                "cheerful" -> "밝게"
+                                else -> "따뜻하게"
+                            }
+                        }",
+                        enabled = enabled
+                    ) { editingField = "voiceSettings" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow("대화 시간", uiState.conversationTime, enabled = enabled) { editingField = "conversationTime" }
+                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow(
+                        label = "선호 수면 시간",
+                        value = uiState.preferredSleepHours?.let { "${it}시간" },
+                        enabled = enabled
+                    ) { editingField = "sleepHours" }
+                }
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            // 로그아웃 버튼
+            Button(
+                onClick = onLogout,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = EchoAccentRed, contentColor = Color.White)
+            ) {
+                Text("로그아웃", fontSize = 18.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+
+        SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+    }
+
+    // 다이얼로그
+    val save: (UserPreferences) -> Unit = {
+        viewModel.savePreferences(it)
+        editingField = null
+    }
+
+    when (editingField) {
+        "birthday" -> DatePickerFieldDialog(
+            current = uiState.birthday,
+            onSelected = { save(buildPreferences(uiState, birthday = it)) },
+            onDismiss = { editingField = null }
+        )
+        "familyInfo" -> TextFieldDialog(
+            title = "가족 관계",
+            hint = "예) 딸, 아들, 배우자",
+            initialValue = uiState.familyInfo ?: "",
+            onConfirm = { save(buildPreferences(uiState, familyInfo = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "guardianEmail" -> TextFieldDialog(
+            title = "보호자 이메일",
+            hint = "유효한 이메일 주소를 입력해주세요",
+            initialValue = uiState.guardianEmail ?: "",
+            keyboardType = KeyboardType.Email,
+            validate = { v ->
+                when {
+                    v.isBlank() -> "보호자 이메일을 입력해주세요"
+                    !EMAIL_REGEX.matches(v) -> "올바른 이메일 형식을 입력해주세요"
+                    else -> null
+                }
+            },
+            onConfirm = { save(buildPreferences(uiState, guardianEmail = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "location" -> TextFieldDialog(
+            title = "거주 지역",
+            hint = "예) 서울 강남구",
+            initialValue = uiState.location ?: "",
+            onConfirm = { save(buildPreferences(uiState, location = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "occupation" -> TextFieldDialog(
+            title = "직업",
+            hint = "예) 전직 교사, 은행원",
+            initialValue = uiState.occupation ?: "",
+            onConfirm = { save(buildPreferences(uiState, occupation = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "hobbies" -> TextFieldDialog(
+            title = "취미",
+            hint = "예) 정원 가꾸기, 독서",
+            initialValue = uiState.hobbies ?: "",
+            onConfirm = { save(buildPreferences(uiState, hobbies = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "preferredTopics" -> TextFieldDialog(
+            title = "선호 대화 주제",
+            hint = "예) 옛날 이야기, 건강",
+            initialValue = uiState.preferredTopics ?: "",
+            onConfirm = { save(buildPreferences(uiState, preferredTopics = it.ifBlank { null })) },
+            onDismiss = { editingField = null }
+        )
+        "voiceSettings" -> VoiceSettingsDialog(
+            initialSpeed = uiState.voiceSpeed,
+            initialTone = uiState.voiceTone,
+            onConfirm = { speed, tone -> save(buildPreferences(uiState, voiceSpeed = speed, voiceTone = tone)) },
+            onDismiss = { editingField = null }
+        )
+        "conversationTime" -> TimePickerFieldDialog(
+            current = uiState.conversationTime,
+            onSelected = { save(buildPreferences(uiState, conversationTime = it)) },
+            onDismiss = { editingField = null }
+        )
+        "sleepHours" -> SleepHoursDialog(
+            initialValue = uiState.preferredSleepHours,
+            onConfirm = { save(buildPreferences(uiState, preferredSleepHours = it)) },
+            onDismiss = { editingField = null }
+        )
+    }
+}
+
+@Composable
+private fun PreferenceRow(
+    label: String,
+    value: String?,
+    showWarning: Boolean = false,
+    enabled: Boolean = true,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = if (!value.isNullOrBlank()) value else "미설정",
+                fontSize = 16.sp,
+                fontFamily = OutfitFontFamily,
+                color = if (!value.isNullOrBlank()) EchoTextPrimary else EchoTextTertiary
+            )
+        }
+        if (showWarning) {
+            Icon(Icons.Outlined.Warning, contentDescription = "필수 항목 미설정", tint = EchoAccentRed, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(6.dp))
+        }
+        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = EchoTextTertiary)
+    }
+}
+
+@Composable
+private fun TextFieldDialog(
+    title: String,
+    hint: String = "",
+    initialValue: String,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    validate: (String) -> String? = { null },
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var value by remember { mutableStateOf(initialValue) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = EchoBgCard,
+        title = { Text(title, fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it; error = null },
+                    label = { Text(hint.ifBlank { title }, fontFamily = OutfitFontFamily, color = EchoTextTertiary, fontSize = 14.sp) },
+                    singleLine = true,
+                    isError = error != null,
+                    supportingText = error?.let { { Text(it, fontFamily = OutfitFontFamily, fontSize = 13.sp) } },
+                    keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = EchoBgMuted,
+                        unfocusedContainerColor = EchoBgMuted,
+                        focusedBorderColor = EchoAccentGreen,
+                        unfocusedBorderColor = EchoBorderSubtle,
+                        focusedTextColor = EchoTextPrimary,
+                        unfocusedTextColor = EchoTextPrimary
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val e = validate(value)
+                if (e != null) { error = e } else { onConfirm(value) }
+            }) {
+                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
+        }
     )
 }
 
 @Composable
-private fun SettingsScreenContent(
-    uiState: SettingsUiState,
-    onSpeedChange: (Float) -> Unit,
-    onLogout: () -> Unit
+private fun VoiceSettingsDialog(
+    initialSpeed: Double,
+    initialTone: String,
+    onConfirm: (Double, String) -> Unit,
+    onDismiss: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(EchoBgPage)
-            .verticalScroll(rememberScrollState())
-    ) {
-        Text(
-            text = "설정",
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary,
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
-        )
+    var speed by remember { mutableStateOf(initialSpeed) }
+    var tone by remember { mutableStateOf(initialTone) }
 
-        // 프로필 카드
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp),
-            shape = RoundedCornerShape(16.dp),
-            color = EchoBgCard,
-            tonalElevation = 0.dp
-        ) {
-            Row(
-                modifier = Modifier.padding(20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                Surface(
-                    modifier = Modifier.size(56.dp),
-                    shape = CircleShape,
-                    color = EchoBgMuted
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Person,
-                        contentDescription = null,
-                        tint = EchoTextSecondary,
-                        modifier = Modifier.padding(12.dp)
-                    )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = EchoBgCard,
+        title = { Text("음성 설정", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        text = {
+            Column {
+                Text("음성 속도", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "${String.format("%.1f", speed)}x  ${when { speed < 1.0 -> "느리게"; speed > 1.0 -> "빠르게"; else -> "보통" }}",
+                    fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoAccentGreen
+                )
+                Slider(
+                    value = speed.toFloat(),
+                    onValueChange = { speed = Math.round(it * 10.0) / 10.0 },
+                    valueRange = 0.8f..1.2f,
+                    steps = 3,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = SliderDefaults.colors(thumbColor = EchoAccentGreen, activeTrackColor = EchoAccentGreen, inactiveTrackColor = EchoBgMuted)
+                )
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("느리게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
+                    Text("빠르게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
                 }
-                Column {
-                    Text(
-                        text = if (uiState.userName.isNotBlank()) uiState.userName else "사용자",
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoTextPrimary
-                    )
-                    if (uiState.age != null) {
-                        Text(
-                            text = "${uiState.age}세",
-                            fontSize = 15.sp,
-                            fontFamily = OutfitFontFamily,
-                            color = EchoTextSecondary
+                Spacer(Modifier.height(20.dp))
+                Text("음성 톤", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf("warm" to "따뜻하게", "calm" to "차분하게", "cheerful" to "밝게").forEach { (value, label) ->
+                        FilterChip(
+                            selected = tone == value,
+                            onClick = { tone = value },
+                            label = { Text(label, fontSize = 13.sp, fontFamily = OutfitFontFamily) },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = EchoAccentGreen,
+                                selectedLabelColor = Color.White
+                            )
                         )
                     }
                 }
             }
-        }
-
-        Spacer(Modifier.height(20.dp))
-
-        // 음성 속도 섹션
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp),
-            shape = RoundedCornerShape(16.dp),
-            color = EchoBgCard,
-            tonalElevation = 0.dp
-        ) {
-            Column(modifier = Modifier.padding(20.dp)) {
-                Text(
-                    text = "음성 속도",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    fontFamily = OutfitFontFamily,
-                    color = EchoTextPrimary
-                )
-
-                Spacer(Modifier.height(12.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = "현재 속도",
-                        fontSize = 15.sp,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoTextSecondary
-                    )
-                    Text(
-                        text = "${String.format("%.1f", uiState.voiceSpeed)}x  ${
-                            when {
-                                uiState.voiceSpeed < 1.0f -> "느리게"
-                                uiState.voiceSpeed > 1.0f -> "빠르게"
-                                else -> "보통"
-                            }
-                        }",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoAccentGreen
-                    )
-                }
-
-                Spacer(Modifier.height(8.dp))
-
-                Slider(
-                    value = uiState.voiceSpeed,
-                    onValueChange = onSpeedChange,
-                    valueRange = 0.8f..1.2f,
-                    steps = 3,
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = SliderDefaults.colors(
-                        thumbColor = EchoAccentGreen,
-                        activeTrackColor = EchoAccentGreen,
-                        inactiveTrackColor = EchoBgMuted
-                    )
-                )
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = "느리게",
-                        fontSize = 13.sp,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoTextTertiary
-                    )
-                    Text(
-                        text = "빠르게",
-                        fontSize = 13.sp,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoTextTertiary
-                    )
-                }
-
-                if (uiState.isSaved) {
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = "저장되었습니다",
-                        fontSize = 14.sp,
-                        fontFamily = OutfitFontFamily,
-                        color = EchoAccentGreen
-                    )
-                }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(speed, tone) }) {
+                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
             }
         }
+    )
+}
 
-        Spacer(Modifier.height(32.dp))
+@Composable
+private fun SleepHoursDialog(
+    initialValue: Int?,
+    onConfirm: (Int?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var value by remember { mutableStateOf(initialValue?.toString() ?: "") }
+    var error by remember { mutableStateOf<String?>(null) }
 
-        // 로그아웃 버튼
-        Button(
-            onClick = onLogout,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .height(56.dp),
-            shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = EchoAccentRed,
-                contentColor = Color.White
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = EchoBgCard,
+        title = { Text("선호 수면 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        text = {
+            OutlinedTextField(
+                value = value,
+                onValueChange = { value = it; error = null },
+                label = { Text("시간 (1~24)", fontFamily = OutfitFontFamily, color = EchoTextTertiary, fontSize = 14.sp) },
+                singleLine = true,
+                isError = error != null,
+                supportingText = error?.let { { Text(it, fontFamily = OutfitFontFamily, fontSize = 13.sp) } },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = EchoBgMuted,
+                    unfocusedContainerColor = EchoBgMuted,
+                    focusedBorderColor = EchoAccentGreen,
+                    unfocusedBorderColor = EchoBorderSubtle,
+                    focusedTextColor = EchoTextPrimary,
+                    unfocusedTextColor = EchoTextPrimary
+                ),
+                modifier = Modifier.fillMaxWidth()
             )
-        ) {
-            Text(
-                text = "로그아웃",
-                fontSize = 18.sp,
-                fontWeight = FontWeight.SemiBold,
-                fontFamily = OutfitFontFamily
-            )
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                if (value.isBlank()) {
+                    onConfirm(null)
+                } else {
+                    val h = value.toIntOrNull()
+                    if (h == null || h !in 1..24) error = "1~24 사이의 숫자를 입력해주세요"
+                    else onConfirm(h)
+                }
+            }) {
+                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
         }
+    )
+}
 
-        Spacer(Modifier.height(24.dp))
+@Composable
+private fun DatePickerFieldDialog(
+    current: String?,
+    onSelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val today = LocalDate.now()
+        val (y, m, d) = if (!current.isNullOrBlank()) {
+            runCatching {
+                val p = LocalDate.parse(current)
+                Triple(p.year, p.monthValue - 1, p.dayOfMonth)
+            }.getOrDefault(Triple(today.year - 70, 0, 1))
+        } else {
+            Triple(today.year - 70, 0, 1)
+        }
+        val dialog = DatePickerDialog(context, { _, year, month, day ->
+            onSelected(LocalDate.of(year, month + 1, day).toString())
+        }, y, m, d)
+        dialog.setOnDismissListener { onDismiss() }
+        dialog.show()
+        onDispose { dialog.dismiss() }
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
 @Composable
-private fun SettingsScreenPreview() {
-    Graduation_projectTheme {
-        SettingsScreenContent(
-            uiState = SettingsUiState(
-                userName = "김순자",
-                age = 72,
-                voiceSpeed = 1.0f,
-                isLoading = false
-            ),
-            onSpeedChange = {},
-            onLogout = {}
-        )
+private fun TimePickerFieldDialog(
+    current: String?,
+    onSelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val (h, m) = if (!current.isNullOrBlank()) {
+            runCatching {
+                val t = LocalTime.parse(current)
+                Pair(t.hour, t.minute)
+            }.getOrDefault(Pair(9, 0))
+        } else {
+            Pair(9, 0)
+        }
+        val dialog = TimePickerDialog(context, { _, hour, minute ->
+            onSelected("%02d:%02d".format(hour, minute))
+        }, h, m, true)
+        dialog.setOnDismissListener { onDismiss() }
+        dialog.show()
+        onDispose { dialog.dismiss() }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.example.graduation_project.presentation.settings
 
-import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -60,6 +59,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.model.VoiceSettings
+import com.example.graduation_project.presentation.common.BirthdayInputRow
+import com.example.graduation_project.presentation.common.buildBirthdayString
+import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.EchoAccentRed
 import com.example.graduation_project.ui.theme.EchoBgCard
@@ -70,7 +72,6 @@ import com.example.graduation_project.ui.theme.EchoTextPrimary
 import com.example.graduation_project.ui.theme.EchoTextSecondary
 import com.example.graduation_project.ui.theme.EchoTextTertiary
 import com.example.graduation_project.ui.theme.OutfitFontFamily
-import java.time.LocalDate
 import java.time.LocalTime
 
 private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
@@ -552,24 +553,50 @@ private fun DatePickerFieldDialog(
     onSelected: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val context = LocalContext.current
-    DisposableEffect(Unit) {
-        val today = LocalDate.now()
-        val (y, m, d) = if (!current.isNullOrBlank()) {
-            runCatching {
-                val p = LocalDate.parse(current)
-                Triple(p.year, p.monthValue - 1, p.dayOfMonth)
-            }.getOrDefault(Triple(today.year - 70, 0, 1))
-        } else {
-            Triple(today.year - 70, 0, 1)
+    val initial = remember { parseBirthday(current ?: "") }
+    var year by remember { mutableStateOf(initial.first) }
+    var month by remember { mutableStateOf(initial.second) }
+    var day by remember { mutableStateOf(initial.third) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = EchoBgCard,
+        title = {
+            Text("생년월일", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary)
+        },
+        text = {
+            Column {
+                BirthdayInputRow(
+                    year = year, month = month, day = day,
+                    onYearChange = { year = it; error = null },
+                    onMonthChange = { month = it; error = null },
+                    onDayChange = { day = it; error = null },
+                    isError = error != null
+                )
+                error?.let {
+                    Spacer(Modifier.height(6.dp))
+                    Text(it, fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoAccentRed)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                when {
+                    year.isBlank() && month.isBlank() && day.isBlank() -> onSelected("")
+                    buildBirthdayString(year, month, day) != null -> onSelected(buildBirthdayString(year, month, day)!!)
+                    else -> error = "올바른 날짜를 입력해주세요"
+                }
+            }) {
+                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
         }
-        val dialog = DatePickerDialog(context, { _, year, month, day ->
-            onSelected(LocalDate.of(year, month + 1, day).toString())
-        }, y, m, d)
-        dialog.setOnDismissListener { onDismiss() }
-        dialog.show()
-        onDispose { dialog.dismiss() }
-    }
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.example.graduation_project.presentation.settings
 
-import android.app.TimePickerDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -41,7 +40,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -51,7 +49,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -60,6 +57,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.model.VoiceSettings
 import com.example.graduation_project.presentation.common.BirthdayInputRow
+import com.example.graduation_project.presentation.common.EchoTimePickerContent
 import com.example.graduation_project.presentation.common.buildBirthdayString
 import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.ui.theme.EchoAccentGreen
@@ -72,7 +70,6 @@ import com.example.graduation_project.ui.theme.EchoTextPrimary
 import com.example.graduation_project.ui.theme.EchoTextSecondary
 import com.example.graduation_project.ui.theme.EchoTextTertiary
 import com.example.graduation_project.ui.theme.OutfitFontFamily
-import java.time.LocalTime
 
 private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
 
@@ -605,21 +602,26 @@ private fun TimePickerFieldDialog(
     onSelected: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val context = LocalContext.current
-    DisposableEffect(Unit) {
-        val (h, m) = if (!current.isNullOrBlank()) {
-            runCatching {
-                val t = LocalTime.parse(current)
-                Pair(t.hour, t.minute)
-            }.getOrDefault(Pair(9, 0))
-        } else {
-            Pair(9, 0)
+    var value by remember { mutableStateOf(if (!current.isNullOrBlank()) current else "09:00") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = EchoBgCard,
+        title = {
+            Text("대화 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary)
+        },
+        text = {
+            EchoTimePickerContent(value = value, onValueChange = { value = it })
+        },
+        confirmButton = {
+            TextButton(onClick = { onSelected(value) }) {
+                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            }
         }
-        val dialog = TimePickerDialog(context, { _, hour, minute ->
-            onSelected("%02d:%02d".format(hour, minute))
-        }, h, m, true)
-        dialog.setOnDismissListener { onDismiss() }
-        dialog.show()
-        onDispose { dialog.dismiss() }
-    }
+    )
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -4,10 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.model.UserPreferences
-import com.example.graduation_project.data.model.VoiceSettings
 import com.example.graduation_project.data.repository.UserRepository
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,10 +15,19 @@ data class SettingsUiState(
     val userName: String = "",
     val age: Int? = null,
     val birthday: String? = null,
-    val voiceSpeed: Float = 1.0f,
-    val preferredTopics: String = "",
+    val familyInfo: String? = null,
+    val guardianEmail: String? = null,
+    val location: String? = null,
+    val occupation: String? = null,
+    val hobbies: String? = null,
+    val preferredTopics: String? = null,
+    val voiceSpeed: Double = 1.0,
+    val voiceTone: String = "warm",
+    val conversationTime: String? = null,
+    val preferredSleepHours: Int? = null,
     val isLoading: Boolean = true,
-    val isSaved: Boolean = false,
+    val isSaving: Boolean = false,
+    val savedMessage: String? = null,
     val errorMessage: String? = null
 )
 
@@ -32,8 +38,6 @@ class SettingsViewModel(
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
-    private var debounceJob: Job? = null
-
     init {
         loadSettings()
     }
@@ -41,48 +45,42 @@ class SettingsViewModel(
     private fun loadSettings() {
         viewModelScope.launch {
             when (val result = userRepository.getPreferences()) {
-                is ApiResult.Success -> {
-                    val prefs = result.data
-                    _uiState.update {
-                        it.copy(
-                            userName = prefs.name ?: "",
-                            age = prefs.age,
-                            birthday = prefs.birthday,
-                            voiceSpeed = prefs.voiceSettings?.voiceSpeed?.toFloat() ?: 1.0f,
-                            preferredTopics = prefs.preferredTopics ?: "",
-                            isLoading = false
-                        )
-                    }
+                is ApiResult.Success -> _uiState.update { applyPrefs(it, result.data).copy(isLoading = false) }
+                is ApiResult.Error -> _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    fun savePreferences(preferences: UserPreferences) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            when (val result = userRepository.updatePreferences(preferences)) {
+                is ApiResult.Success -> _uiState.update {
+                    applyPrefs(it, result.data).copy(isSaving = false, savedMessage = "저장되었습니다")
                 }
-                is ApiResult.Error -> {
-                    _uiState.update { it.copy(isLoading = false) }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(isSaving = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
                 }
             }
         }
     }
 
-    fun onSpeedChange(speed: Float) {
-        val rounded = (Math.round(speed * 10.0f) / 10.0f)
-        _uiState.update { it.copy(voiceSpeed = rounded, isSaved = false) }
+    fun dismissSavedMessage() = _uiState.update { it.copy(savedMessage = null) }
+    fun dismissError() = _uiState.update { it.copy(errorMessage = null) }
 
-        debounceJob?.cancel()
-        debounceJob = viewModelScope.launch {
-            delay(500L)
-            saveVoiceSpeed(rounded)
-        }
-    }
-
-    private suspend fun saveVoiceSpeed(speed: Float) {
-        val preferences = UserPreferences(
-            voiceSettings = VoiceSettings(voiceSpeed = speed.toDouble())
-        )
-        when (userRepository.updatePreferences(preferences)) {
-            is ApiResult.Success -> _uiState.update { it.copy(isSaved = true) }
-            is ApiResult.Error -> _uiState.update { it.copy(errorMessage = "저장에 실패했습니다") }
-        }
-    }
-
-    fun dismissError() {
-        _uiState.update { it.copy(errorMessage = null) }
-    }
+    private fun applyPrefs(state: SettingsUiState, prefs: UserPreferences): SettingsUiState = state.copy(
+        userName = prefs.name ?: state.userName,
+        age = prefs.age,
+        birthday = prefs.birthday,
+        familyInfo = prefs.familyInfo,
+        guardianEmail = prefs.guardianEmail,
+        location = prefs.location,
+        occupation = prefs.occupation,
+        hobbies = prefs.hobbies,
+        preferredTopics = prefs.preferredTopics,
+        voiceSpeed = prefs.voiceSettings?.voiceSpeed ?: 1.0,
+        voiceTone = prefs.voiceSettings?.voiceTone ?: "warm",
+        conversationTime = prefs.conversationTime,
+        preferredSleepHours = prefs.preferredSleepHours
+    )
 }

--- a/server/src/main/java/com/example/echo/user/controller/UserController.java
+++ b/server/src/main/java/com/example/echo/user/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.example.echo.user.controller;
+
+import com.example.echo.common.auth.CurrentUser;
+import com.example.echo.user.dto.OnboardingStatusResponse;
+import com.example.echo.user.dto.UserPreferences;
+import com.example.echo.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users/me")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/preferences")
+    public ResponseEntity<UserPreferences> getPreferences(@CurrentUser Long userId) {
+        return ResponseEntity.ok(userService.getPreferences(userId));
+    }
+
+    @PutMapping("/preferences")
+    public ResponseEntity<UserPreferences> updatePreferences(
+            @CurrentUser Long userId,
+            @RequestBody UserPreferences request) {
+        return ResponseEntity.ok(userService.savePreferences(userId, request));
+    }
+
+    @GetMapping("/onboarding-status")
+    public ResponseEntity<OnboardingStatusResponse> getOnboardingStatus(@CurrentUser Long userId) {
+        return ResponseEntity.ok(new OnboardingStatusResponse(userService.isOnboardingCompleted(userId)));
+    }
+}

--- a/server/src/main/java/com/example/echo/user/dto/OnboardingStatusResponse.java
+++ b/server/src/main/java/com/example/echo/user/dto/OnboardingStatusResponse.java
@@ -1,0 +1,4 @@
+package com.example.echo.user.dto;
+
+public record OnboardingStatusResponse(boolean completed) {
+}

--- a/server/src/main/java/com/example/echo/user/dto/UserPreferences.java
+++ b/server/src/main/java/com/example/echo/user/dto/UserPreferences.java
@@ -1,5 +1,6 @@
 package com.example.echo.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,10 +20,12 @@ public class UserPreferences {
     private LocalDate birthday;
     private String location;
     private String familyInfo;
+    private String guardianEmail;
     private String occupation;
     private String hobbies;
     private String preferredTopics;
     private VoiceSettings voiceSettings;
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime conversationTime;
-    private Integer preferredSleepHours;  // 선호 수면 시간 (시간 단위)
+    private Integer preferredSleepHours;
 }

--- a/server/src/main/java/com/example/echo/user/entity/UserPreferences.java
+++ b/server/src/main/java/com/example/echo/user/entity/UserPreferences.java
@@ -1,0 +1,111 @@
+package com.example.echo.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "user_preferences")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreferences {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "birthday")
+    private LocalDate birthday;
+
+    @Column(name = "location", length = 100)
+    private String location;
+
+    @Column(name = "family_info", length = 500)
+    private String familyInfo;
+
+    @Column(name = "guardian_email", length = 255)
+    private String guardianEmail;
+
+    @Column(name = "occupation", length = 100)
+    private String occupation;
+
+    @Column(name = "hobbies", length = 500)
+    private String hobbies;
+
+    @Column(name = "preferred_topics", length = 500)
+    private String preferredTopics;
+
+    @Column(name = "voice_speed")
+    private Double voiceSpeed;
+
+    @Column(name = "voice_tone", length = 50)
+    private String voiceTone;
+
+    @Column(name = "conversation_time")
+    private LocalTime conversationTime;
+
+    @Column(name = "preferred_sleep_hours")
+    private Integer preferredSleepHours;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public UserPreferences(Long userId, LocalDate birthday, String location,
+                           String familyInfo, String guardianEmail, String occupation,
+                           String hobbies, String preferredTopics, Double voiceSpeed,
+                           String voiceTone, LocalTime conversationTime,
+                           Integer preferredSleepHours) {
+        this.userId = userId;
+        this.birthday = birthday;
+        this.location = location;
+        this.familyInfo = familyInfo;
+        this.guardianEmail = guardianEmail;
+        this.occupation = occupation;
+        this.hobbies = hobbies;
+        this.preferredTopics = preferredTopics;
+        this.voiceSpeed = voiceSpeed;
+        this.voiceTone = voiceTone;
+        this.conversationTime = conversationTime;
+        this.preferredSleepHours = preferredSleepHours;
+    }
+
+    public void update(LocalDate birthday, String location, String familyInfo,
+                       String guardianEmail, String occupation, String hobbies,
+                       String preferredTopics, Double voiceSpeed, String voiceTone,
+                       LocalTime conversationTime, Integer preferredSleepHours) {
+        this.birthday = birthday;
+        this.location = location;
+        this.familyInfo = familyInfo;
+        this.guardianEmail = guardianEmail;
+        this.occupation = occupation;
+        this.hobbies = hobbies;
+        this.preferredTopics = preferredTopics;
+        this.voiceSpeed = voiceSpeed;
+        this.voiceTone = voiceTone;
+        this.conversationTime = conversationTime;
+        this.preferredSleepHours = preferredSleepHours;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/example/echo/user/repository/UserPreferencesRepository.java
+++ b/server/src/main/java/com/example/echo/user/repository/UserPreferencesRepository.java
@@ -1,0 +1,13 @@
+package com.example.echo.user.repository;
+
+import com.example.echo.user.entity.UserPreferences;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserPreferencesRepository extends JpaRepository<UserPreferences, Long> {
+
+    Optional<UserPreferences> findByUserId(Long userId);
+
+    boolean existsByUserId(Long userId);
+}

--- a/server/src/main/java/com/example/echo/user/service/UserService.java
+++ b/server/src/main/java/com/example/echo/user/service/UserService.java
@@ -2,26 +2,106 @@ package com.example.echo.user.service;
 
 import com.example.echo.auth.exception.UnauthorizedException;
 import com.example.echo.user.dto.UserPreferences;
+import com.example.echo.user.dto.VoiceSettings;
 import com.example.echo.user.entity.User;
+import com.example.echo.user.repository.UserPreferencesRepository;
 import com.example.echo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.Period;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserPreferencesRepository userPreferencesRepository;
 
     @Transactional(readOnly = true)
     public UserPreferences getPreferences(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
 
-        return UserPreferences.builder()
-                .userId(user.getId())
-                .name(user.getName())
-                .build();
+        return userPreferencesRepository.findByUserId(userId)
+                .map(prefs -> UserPreferences.builder()
+                        .userId(user.getId())
+                        .name(user.getName())
+                        .age(prefs.getBirthday() != null
+                                ? Period.between(prefs.getBirthday(), LocalDate.now()).getYears()
+                                : null)
+                        .birthday(prefs.getBirthday())
+                        .location(prefs.getLocation())
+                        .familyInfo(prefs.getFamilyInfo())
+                        .guardianEmail(prefs.getGuardianEmail())
+                        .occupation(prefs.getOccupation())
+                        .hobbies(prefs.getHobbies())
+                        .preferredTopics(prefs.getPreferredTopics())
+                        .voiceSettings(prefs.getVoiceSpeed() != null
+                                ? VoiceSettings.builder()
+                                        .voiceSpeed(prefs.getVoiceSpeed())
+                                        .voiceTone(prefs.getVoiceTone())
+                                        .build()
+                                : null)
+                        .conversationTime(prefs.getConversationTime())
+                        .preferredSleepHours(prefs.getPreferredSleepHours())
+                        .build())
+                .orElse(UserPreferences.builder()
+                        .userId(user.getId())
+                        .name(user.getName())
+                        .build());
+    }
+
+    @Transactional
+    public UserPreferences savePreferences(Long userId, UserPreferences request) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UnauthorizedException("사용자를 찾을 수 없습니다."));
+
+        Double voiceSpeed = request.getVoiceSettings() != null ? request.getVoiceSettings().getVoiceSpeed() : null;
+        String voiceTone = request.getVoiceSettings() != null ? request.getVoiceSettings().getVoiceTone() : null;
+
+        com.example.echo.user.entity.UserPreferences entity = userPreferencesRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (entity == null) {
+            entity = com.example.echo.user.entity.UserPreferences.builder()
+                    .userId(userId)
+                    .birthday(request.getBirthday())
+                    .location(request.getLocation())
+                    .familyInfo(request.getFamilyInfo())
+                    .guardianEmail(request.getGuardianEmail())
+                    .occupation(request.getOccupation())
+                    .hobbies(request.getHobbies())
+                    .preferredTopics(request.getPreferredTopics())
+                    .voiceSpeed(voiceSpeed)
+                    .voiceTone(voiceTone)
+                    .conversationTime(request.getConversationTime())
+                    .preferredSleepHours(request.getPreferredSleepHours())
+                    .build();
+        } else {
+            entity.update(
+                    request.getBirthday(),
+                    request.getLocation(),
+                    request.getFamilyInfo(),
+                    request.getGuardianEmail(),
+                    request.getOccupation(),
+                    request.getHobbies(),
+                    request.getPreferredTopics(),
+                    voiceSpeed,
+                    voiceTone,
+                    request.getConversationTime(),
+                    request.getPreferredSleepHours()
+            );
+        }
+
+        userPreferencesRepository.save(entity);
+        return getPreferences(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isOnboardingCompleted(Long userId) {
+        return userPreferencesRepository.existsByUserId(userId);
     }
 }


### PR DESCRIPTION
## Summary

- **T1.3-1** 서버: `UserPreferences` 엔티티 + `GET/PUT /api/users/me/preferences`, `GET /api/users/me/onboarding-status` API 구현
- **T1.3-2** Android 온보딩: 10단계 스텝 온보딩 화면 구현 (생년월일/가족관계/보호자이메일/거주지역/직업/취미/선호주제/음성설정/대화시간/수면시간), 앱 시작 시 온보딩 완료 여부 체크 후 분기
- **T1.3-3** Android 설정 화면: 10개 항목 전부 인라인 다이얼로그로 편집 + 즉시 PUT 저장

### 어르신 UX 개선
- **생년월일**: 캘린더 DatePickerDialog(70년 스크롤) → 년/월/일 세 칸 직접 텍스트 입력
- **대화 시간**: 시계 다이얼 TimePickerDialog → 오전/오후 칩 + ▲▼ 스테퍼 (분 5분 단위)

## Test plan

- [ ] 회원가입 후 온보딩 10단계 순서대로 진행, 완료 시 홈 화면 이동 확인
- [ ] 앱 재시작 시 온보딩 완료 여부에 따라 온보딩/홈 분기 확인
- [ ] 설정 화면 진입 → 각 항목 클릭 → 다이얼로그 prefill 확인 → 값 변경 → 확인 → 토스트 + UI 즉시 반영 확인
- [ ] 보호자 이메일 잘못된 형식 입력 → 클라이언트 검증 에러 표시, PUT 호출 안 됨 확인
- [ ] 생년월일 년/월/일 입력 후 유효하지 않은 날짜 입력 시 에러 표시 확인
- [ ] 대화 시간 오전/오후 전환 + ▲▼ 버튼으로 시/분 조작 확인
- [ ] 변경 후 앱 종료 → 재실행 → 설정 재진입 → 변경값 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)