### PR TITLE
fix: voiceSpeed가 null일 때 voiceTone도 버려지는 버그 수정

### DIFF
--- a/server/src/main/java/com/example/echo/user/service/UserService.java
+++ b/server/src/main/java/com/example/echo/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
                         .occupation(prefs.getOccupation())
                         .hobbies(prefs.getHobbies())
                         .preferredTopics(prefs.getPreferredTopics())
-                        .voiceSettings(prefs.getVoiceSpeed() != null
+                        .voiceSettings((prefs.getVoiceSpeed() != null || prefs.getVoiceTone() != null)
                                 ? VoiceSettings.builder()
                                         .voiceSpeed(prefs.getVoiceSpeed())
                                         .voiceTone(prefs.getVoiceTone())


### PR DESCRIPTION
## 문제

`UserService.getPreferences()`에서 `voiceSpeed`가 null이면 `voiceTone`이 설정돼 있어도 `VoiceSettings` 객체 자체가 null로 반환됨.

## 원인

voiceSpeed 하나만 체크해서 null이면 voiceTone도 같이 버려짐.

## 수정

voiceSpeed 또는 voiceTone 중 하나라도 존재하면 VoiceSettings를 생성하도록 조건 변경.

## 영향 범위

`UserService.java` 1줄 수정. TTS 호출 시 voiceTone이 정상 반영됨.