### PR TITLE
fix: 온보딩 저장 검증 누락 및 BaseException 500 응답 버그 수정

### DIFF
--- a/server/src/main/java/com/example/echo/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/example/echo/common/exception/GlobalExceptionHandler.java
@@ -9,10 +9,19 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import com.example.echo.common.exception.BaseException;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        log.warn("Business exception: {} {}", e.getStatus(), e.getMessage());
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(ErrorResponse.of(e.getStatus().value(), e.getStatus().name(), e.getMessage()));
+    }
 
     @ExceptionHandler(SupertoneInsufficientCreditException.class)
     public ResponseEntity<ErrorResponse> handleInsufficientCredit(SupertoneInsufficientCreditException e) {

--- a/server/src/main/java/com/example/echo/user/controller/UserController.java
+++ b/server/src/main/java/com/example/echo/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.example.echo.common.auth.CurrentUser;
 import com.example.echo.user.dto.OnboardingStatusResponse;
 import com.example.echo.user.dto.UserPreferences;
 import com.example.echo.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class UserController {
     @PutMapping("/preferences")
     public ResponseEntity<UserPreferences> updatePreferences(
             @CurrentUser Long userId,
-            @RequestBody UserPreferences request) {
+            @Valid @RequestBody UserPreferences request) {
         return ResponseEntity.ok(userService.savePreferences(userId, request));
     }
 

--- a/server/src/main/java/com/example/echo/user/dto/UserPreferences.java
+++ b/server/src/main/java/com/example/echo/user/dto/UserPreferences.java
@@ -1,6 +1,9 @@
 package com.example.echo.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,15 +20,35 @@ public class UserPreferences {
     private Long userId;
     private String name;
     private Integer age;
+
+    @NotNull(message = "생년월일은 필수입니다.")
     private LocalDate birthday;
+
+    @NotNull(message = "거주 지역은 필수입니다.")
+    @Size(max = 100)
     private String location;
+
+    @Size(max = 500)
     private String familyInfo;
+
+    @Email(message = "보호자 이메일 형식이 올바르지 않습니다.")
+    @Size(max = 255)
     private String guardianEmail;
+
+    @Size(max = 100)
     private String occupation;
+
+    @Size(max = 500)
     private String hobbies;
+
+    @Size(max = 500)
     private String preferredTopics;
+
     private VoiceSettings voiceSettings;
+
+    @NotNull(message = "대화 시간은 필수입니다.")
     @JsonFormat(pattern = "HH:mm")
     private LocalTime conversationTime;
+
     private Integer preferredSleepHours;
 }

--- a/server/src/main/java/com/example/echo/user/service/UserService.java
+++ b/server/src/main/java/com/example/echo/user/service/UserService.java
@@ -102,6 +102,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public boolean isOnboardingCompleted(Long userId) {
-        return userPreferencesRepository.existsByUserId(userId);
+        return userPreferencesRepository.findByUserId(userId)
+                .map(prefs -> prefs.getBirthday() != null
+                        && prefs.getLocation() != null
+                        && prefs.getConversationTime() != null)
+                .orElse(false);
     }
 }


### PR DESCRIPTION
## 수정한 버그

### 1. BaseException이 500으로 응답되던 문제
`UnauthorizedException`, `InvalidCredentialsException` 등 `BaseException` 하위 클래스들이 `GlobalExceptionHandler`에 핸들러가 없어 `Exception.class` fallback으로 처리됐습니다. 401/400이어야 할 응답이 모두 500으로 나갔고, Android의 `TokenAuthenticator`가 silent refresh를 시도하지 않는 문제로 이어졌습니다.

### 2. 온보딩 완료 판단 기준 허술
`isOnboardingCompleted`가 `existsByUserId`(row 존재 여부)만 확인해, 필수 필드 없이 빈 body로 저장해도 온보딩 완료로 처리됐습니다. 필수 필드(`birthday`, `location`, `conversationTime`) 3개 모두 non-null인 경우만 완료로 판단하도록 수정했습니다.

### 3. PUT /preferences 입력 검증 없음
`UserPreferences` DTO에 검증 어노테이션이 없고 컨트롤러에 `@Valid`가 없어, null이나 형식 오류 값이 그대로 저장됐습니다. 단계별 저장 시 이전 데이터가 null로 덮어써지는 데이터 유실도 발생할 수 있었습니다.

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `GlobalExceptionHandler.java` | `BaseException` 핸들러 추가 |
| `UserPreferences.java` | `@NotNull`(birthday, location, conversationTime), `@Email`(guardianEmail), `@Size` 추가 |
| `UserController.java` | `@Valid` 추가 |
| `UserService.java` | `isOnboardingCompleted` 필수 필드 null 체크로 강화 |

## 테스트 체크리스트
- [ ] 아이디/비밀번호 틀렸을 때 400 응답 확인
- [ ] 만료된 토큰으로 요청 시 401 응답 확인
- [ ] 필수 필드 누락된 body로 PUT /preferences 시 400 응답 확인
- [ ] guardianEmail 형식 오류 시 400 응답 확인
- [ ] 필수 3개 필드 모두 저장 전 onboarding-status false 확인
- [ ] 필수 3개 필드 저장 후 onboarding-status true 확인