### PR TITLE
bugfix: 온보딩 네비게이션 오류 및 필수 필드 검증 누락 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -120,11 +120,10 @@ private fun AppNavHost() {
                     CircularProgressIndicator(color = EchoAccentGreen)
                 }
                 LaunchedEffect(Unit) {
-                    val completed = when (val result = userRepository.getOnboardingStatus()) {
-                        is ApiResult.Success -> result.data.completed
-                        is ApiResult.Error -> false
+                    val destination = when (val result = userRepository.getOnboardingStatus()) {
+                        is ApiResult.Success -> if (result.data.completed) EchoTab.HOME.route else Routes.ONBOARDING
+                        is ApiResult.Error -> Routes.LOGIN
                     }
-                    val destination = if (completed) EchoTab.HOME.route else Routes.ONBOARDING
                     navController.navigate(destination) {
                         popUpTo(Routes.CHECKING) { inclusive = true }
                     }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -53,20 +53,20 @@ import com.example.graduation_project.ui.theme.EchoTextTertiary
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
 private val stepTitles = listOf(
-    "생년월일", "가족 관계", "보호자 이메일", "거주 지역",
-    "직업", "취미", "선호 대화 주제", "음성 설정", "대화 시간", "선호 수면 시간"
+    "생년월일", "거주 지역", "대화 시간",
+    "보호자 이메일", "가족 관계", "직업", "취미", "선호 대화 주제", "음성 설정", "선호 수면 시간"
 )
 
 private val stepHints = listOf(
-    "생일을 알려주세요",
+    "생일을 알려주세요 (필수)",
+    "예) 서울 강남구 (필수)",
+    "매일 같은 시간에 대화를 시작합니다 (필수)",
+    "보호자 이메일을 입력해주세요",
     "예) 딸, 아들, 배우자",
-    "비밀번호 복구에 사용됩니다 (필수)",
-    "예) 서울 강남구",
     "예) 전직 교사, 은행원",
     "예) 정원 가꾸기, 독서",
     "예) 옛날 이야기, 건강",
     "음성 속도와 톤을 설정해주세요",
-    "매일 같은 시간에 대화를 시작합니다",
     "하루 평균 몇 시간 주무시나요?"
 )
 
@@ -252,25 +252,30 @@ private fun StepContent(
 ) {
     when (step) {
         0 -> DatePickerStep(selected = uiState.birthday, onDateSelected = onBirthdayChange)
-        1 -> EchoOutlinedTextField(value = uiState.familyInfo, onValueChange = onFamilyInfoChange, label = "가족 관계")
-        2 -> EchoOutlinedTextField(
+        1 -> EchoOutlinedTextField(
+            value = uiState.location,
+            onValueChange = onLocationChange,
+            label = "거주 지역",
+            isError = uiState.fieldError != null
+        )
+        2 -> TimePickerStep(selected = uiState.conversationTime, onTimeSelected = onConversationTimeChange)
+        3 -> EchoOutlinedTextField(
             value = uiState.guardianEmail,
             onValueChange = onGuardianEmailChange,
             label = "보호자 이메일",
             keyboardType = KeyboardType.Email,
             isError = uiState.fieldError != null
         )
-        3 -> EchoOutlinedTextField(value = uiState.location, onValueChange = onLocationChange, label = "거주 지역")
-        4 -> EchoOutlinedTextField(value = uiState.occupation, onValueChange = onOccupationChange, label = "직업")
-        5 -> EchoOutlinedTextField(value = uiState.hobbies, onValueChange = onHobbiesChange, label = "취미")
-        6 -> EchoOutlinedTextField(value = uiState.preferredTopics, onValueChange = onPreferredTopicsChange, label = "선호 대화 주제")
-        7 -> VoiceSettingsStep(
+        4 -> EchoOutlinedTextField(value = uiState.familyInfo, onValueChange = onFamilyInfoChange, label = "가족 관계")
+        5 -> EchoOutlinedTextField(value = uiState.occupation, onValueChange = onOccupationChange, label = "직업")
+        6 -> EchoOutlinedTextField(value = uiState.hobbies, onValueChange = onHobbiesChange, label = "취미")
+        7 -> EchoOutlinedTextField(value = uiState.preferredTopics, onValueChange = onPreferredTopicsChange, label = "선호 대화 주제")
+        8 -> VoiceSettingsStep(
             voiceSpeed = uiState.voiceSpeed,
             voiceTone = uiState.voiceTone,
             onSpeedChange = onVoiceSpeedChange,
             onToneChange = onVoiceToneChange
         )
-        8 -> TimePickerStep(selected = uiState.conversationTime, onTimeSelected = onConversationTimeChange)
         9 -> EchoOutlinedTextField(
             value = uiState.preferredSleepHours,
             onValueChange = onSleepHoursChange,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -74,11 +74,10 @@ class OnboardingViewModel(
     }
 
     private fun validateStep(state: OnboardingUiState): String? = when (state.currentStep) {
-        2 -> when {
-            state.guardianEmail.isBlank() -> "보호자 이메일을 입력해주세요"
-            !EMAIL_REGEX.matches(state.guardianEmail) -> "올바른 이메일 형식을 입력해주세요"
-            else -> null
-        }
+        0 -> if (state.birthday.isBlank()) "생년월일을 입력해주세요" else null
+        1 -> if (state.location.isBlank()) "거주 지역을 입력해주세요" else null
+        3 -> if (state.guardianEmail.isNotBlank() && !EMAIL_REGEX.matches(state.guardianEmail))
+            "올바른 이메일 형식을 입력해주세요" else null
         9 -> if (state.preferredSleepHours.isNotBlank()) {
             val h = state.preferredSleepHours.toIntOrNull()
             when {

--- a/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
+++ b/server/src/main/java/com/example/echo/common/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                                 "/api/auth/signup",
                                 "/api/auth/login",
                                 "/api/auth/refresh",
+                                "/api/auth/logout",
                                 "/actuator/health",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",


### PR DESCRIPTION
## Summary

- **[Android] CHECKING 라우트 네비게이션 버그**: AccessToken/RefreshToken 모두 만료된 상태로 앱 재시작 시 `getOnboardingStatus()` API 오류가 발생해 온보딩 완료 사용자가 ONBOARDING 화면으로 잘못 이동하던 문제 수정 → LOGIN으로 이동
- **[Android] 온보딩 필수 필드 클라이언트 검증 누락**: 생년월일·거주 지역을 빈 값으로 마지막 단계까지 진행 후 서버 400 에러를 받던 문제 수정 → 해당 단계에서 즉시 오류 표시
- **[Android] 온보딩 단계 순서 재배치**: 필수 항목(생년월일 → 거주 지역 → 대화 시간)을 앞으로, 선택 항목을 뒤로 이동
- **[Server] `/api/auth/logout` permitAll 추가**: AccessToken 만료 상태에서 로그아웃 요청 시 401이 반환되던 문제 수정

## Test plan

- [ ] 앱 설치 후 회원가입 → 온보딩 첫 화면이 생년월일인지 확인
- [ ] 생년월일 미입력 후 다음 버튼 클릭 시 오류 메시지 표시 확인
- [ ] 거주 지역 미입력 후 다음 버튼 클릭 시 오류 메시지 표시 확인
- [ ] RefreshToken 만료 상태에서 앱 재시작 시 로그인 화면으로 이동하는지 확인
- [ ] AccessToken 만료 상태에서 로그아웃 요청 시 정상 처리되는지 확인 (서버 로그 확인)