### PR TITLE
fix: EncryptedSharedPreferences 메인 스레드 초기화로 인한 앱 시작 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -13,8 +13,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -84,13 +86,24 @@ private fun AppNavHost() {
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
 
-    val startDestination = remember {
-        if (authRepository.hasAccessToken()) Routes.CHECKING else Routes.LOGIN
+    // EncryptedSharedPreferences 초기화는 Android Keystore를 사용하므로
+    // 메인 스레드에서 동기 호출 시 ANR/크래시 발생. IO 스레드에서 비동기 처리.
+    var startDestination by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(Unit) {
+        val hasToken = withContext(Dispatchers.IO) { authRepository.hasAccessToken() }
+        startDestination = if (hasToken) Routes.CHECKING else Routes.LOGIN
     }
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val showTabBar = currentRoute in tabRoutes
+
+    if (startDestination == null) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(color = EchoAccentGreen)
+        }
+        return
+    }
 
     Scaffold(
         bottomBar = {
@@ -112,7 +125,7 @@ private fun AppNavHost() {
     ) { paddingValues ->
         NavHost(
             navController = navController,
-            startDestination = startDestination,
+            startDestination = startDestination!!,
             modifier = Modifier.padding(paddingValues)
         ) {
             composable(Routes.CHECKING) {


### PR DESCRIPTION
## Summary

- `AppNavHost()`에서 `authRepository.hasAccessToken()`이 Compose 컴포지션 중 메인 스레드에서 동기 호출되어 `EncryptedSharedPreferences`(Android Keystore) 초기화가 메인 스레드를 블로킹, ANR/크래시가 발생하던 문제 수정
- `startDestination`을 `mutableStateOf<String?>(null)`로 변경하고 `LaunchedEffect + Dispatchers.IO`에서 비동기로 토큰 확인 후 목적지 결정
- 토큰 확인 전(null 상태)에는 로딩 스피너 표시

## 변경 파일

- `MainActivity.kt` — `startDestination` 동기 → 비동기 전환

## 비고

- `TokenStorage.kt` 주석에도 "첫 호출 시 Keystore 초기화 비용이 큼, IO 디스패처 호출 권장" 명시되어 있었으나 `MainActivity`에서 지켜지지 않던 부분을 수정
- develop의 `7a45bff` (CHECKING 라우트 네비게이션 수정) 포함하여 리베이스됨

## Test plan

- [ ] 앱 최초 실행 시 로그인 화면으로 정상 이동 확인
- [ ] 로그인 후 재실행 시 홈/온보딩으로 정상 이동 확인
- [ ] 토큰 만료 상태에서 재실행 시 로그인 화면으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
