### PR TITLE
ci: CI/CD 배포 트리거 브랜치를 develop으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Build and Deploy to EC2
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
     paths: ['server/**']
 
 env:


### PR DESCRIPTION
## Summary
- CI/CD 배포 트리거 브랜치를 `main`에서 `develop`으로 변경
- develop에 merge + server/ 변경 시 자동 배포

## Test plan
- [ ] PR merge 후 server/ 변경 시 GitHub Actions 배포 트리거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)