### PR TITLE
feat: SUS 점수 향상을 위한 7가지 UX 개선

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTabBar.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTabBar.kt
@@ -61,7 +61,7 @@ fun EchoTabBar(
                 .clip(RoundedCornerShape(36.dp))
                 .border(1.dp, EchoBorderSubtle, RoundedCornerShape(36.dp))
                 .background(EchoBgCard)
-                .height(62.dp),
+                .height(72.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -89,7 +89,7 @@ private fun EchoTabItem(
 
     Column(
         modifier = modifier
-            .height(62.dp)
+            .height(72.dp)
             .padding(horizontal = 4.dp, vertical = 8.dp)
             .clip(pillShape)
             .then(
@@ -104,15 +104,15 @@ private fun EchoTabItem(
             imageVector = tab.icon,
             contentDescription = tab.label,
             tint = if (isActive) Color.White else EchoTabInactive,
-            modifier = Modifier.size(18.dp)
+            modifier = Modifier.size(24.dp)
         )
         Text(
             text = tab.label,
             color = if (isActive) Color.White else EchoTabInactive,
-            fontSize = 10.sp,
+            fontSize = 12.sp,
             fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
             fontFamily = OutfitFontFamily,
-            lineHeight = 14.sp
+            lineHeight = 16.sp
         )
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -301,7 +301,7 @@ private fun BottomActionSection(
                 .height(64.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = if (isSending) EchoBgMuted else EchoAccentRed,
+                containerColor = if (isSending) EchoBgMuted else EchoTextSecondary,
                 contentColor = if (isSending) EchoTextTertiary else Color.White,
                 disabledContainerColor = EchoBgMuted,
                 disabledContentColor = EchoTextTertiary
@@ -365,7 +365,7 @@ private fun FarewellDialog(
                         modifier = Modifier.weight(1f).height(52.dp),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = EchoAccentRed,
+                            containerColor = EchoTextSecondary,
                             contentColor = Color.White
                         )
                     ) {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/MessageItem.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/MessageItem.kt
@@ -11,6 +11,11 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import com.example.graduation_project.ui.theme.EchoAccentGreen
+import com.example.graduation_project.ui.theme.EchoAiBubble
+import com.example.graduation_project.ui.theme.EchoTextPrimary
+import com.example.graduation_project.ui.theme.EchoTextSecondary
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,7 +86,7 @@ fun MessageItem(
             Text(
                 text = senderText,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = if (message.isFromUser) EchoAccentGreen else EchoTextSecondary,
                 modifier = Modifier.padding(
                     start = if (!message.isFromUser) Dimens.SpacingSmall else 0.dp,
                     end = if (message.isFromUser) Dimens.SpacingSmall else 0.dp,
@@ -100,23 +105,13 @@ fun MessageItem(
                             bottomEnd = if (message.isFromUser) 4.dp else Dimens.MessageBubbleRadius
                         )
                     )
-                    .background(
-                        if (message.isFromUser) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.surfaceVariant
-                        }
-                    )
+                    .background(if (message.isFromUser) EchoAccentGreen else EchoAiBubble)
                     .padding(Dimens.MessageBubblePadding)
             ) {
                 Text(
                     text = message.text,
                     style = MaterialTheme.typography.bodyLarge,
-                    color = if (message.isFromUser) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                    color = if (message.isFromUser) Color.White else EchoTextPrimary
                 )
             }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
@@ -110,7 +110,7 @@ private fun ConversationCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
+                .padding(20.dp)
         ) {
             Text(
                 text = summary.date,
@@ -123,18 +123,18 @@ private fun ConversationCard(
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = summary.timeRange,
-                    fontSize = 14.sp,
+                    fontSize = 16.sp,
                     fontFamily = OutfitFontFamily,
                     color = EchoTextTertiary
                 )
                 Text(
                     text = "·",
-                    fontSize = 14.sp,
+                    fontSize = 16.sp,
                     color = EchoTextTertiary
                 )
                 Text(
                     text = "${summary.durationMin}분",
-                    fontSize = 14.sp,
+                    fontSize = 16.sp,
                     fontFamily = OutfitFontFamily,
                     color = EchoTextTertiary
                 )
@@ -142,11 +142,11 @@ private fun ConversationCard(
             Spacer(Modifier.height(8.dp))
             Text(
                 text = summary.previewText,
-                fontSize = 16.sp,
+                fontSize = 18.sp,
                 fontFamily = OutfitFontFamily,
                 color = EchoTextSecondary,
                 maxLines = 2,
-                lineHeight = 22.sp
+                lineHeight = 26.sp
             )
         }
     }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.EchoBgPage
 import com.example.graduation_project.ui.theme.EchoTextPrimary
 import com.example.graduation_project.ui.theme.EchoTextSecondary
+import com.example.graduation_project.ui.theme.EchoTextTertiary
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -40,6 +41,7 @@ fun HomeScreen(
 
     HomeScreenContent(
         userName = uiState.userName,
+        conversationTime = uiState.conversationTime,
         onStartConversation = onStartConversation
     )
 }
@@ -47,6 +49,7 @@ fun HomeScreen(
 @Composable
 private fun HomeScreenContent(
     userName: String,
+    conversationTime: String? = null,
     onStartConversation: () -> Unit
 ) {
     Column(
@@ -78,6 +81,16 @@ private fun HomeScreenContent(
             color = EchoTextSecondary
         )
 
+        if (!conversationTime.isNullOrBlank()) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "오늘 대화 시간: ${formatConversationTime(conversationTime)}",
+                fontSize = 16.sp,
+                fontFamily = OutfitFontFamily,
+                color = EchoTextTertiary
+            )
+        }
+
         Spacer(Modifier.height(40.dp))
 
         Button(
@@ -101,10 +114,19 @@ private fun HomeScreenContent(
     }
 }
 
+private fun formatConversationTime(time: String): String {
+    return try {
+        val (h, m) = time.split(":").map { it.toInt() }
+        val amPm = if (h < 12) "오전" else "오후"
+        val displayHour = if (h % 12 == 0) 12 else h % 12
+        "$amPm ${displayHour}:${m.toString().padStart(2, '0')}"
+    } catch (e: Exception) { time }
+}
+
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 private fun HomeScreenPreview() {
     Graduation_projectTheme {
-        HomeScreenContent(userName = "김순자", onStartConversation = {})
+        HomeScreenContent(userName = "김순자", conversationTime = "09:00", onStartConversation = {})
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 
 data class HomeUiState(
     val userName: String = "",
+    val conversationTime: String? = null,
     val isLoading: Boolean = true
 )
 
@@ -31,6 +32,7 @@ class HomeViewModel(
                 is ApiResult.Success -> {
                     _uiState.value = HomeUiState(
                         userName = result.data.name ?: "",
+                        conversationTime = result.data.conversationTime,
                         isLoading = false
                     )
                 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -180,55 +180,75 @@ fun OnboardingScreen(
         }
 
         // 하단 버튼
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 24.dp, vertical = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            if (uiState.currentStep > 0) {
-                OutlinedButton(
-                    onClick = viewModel::previous,
+            if (uiState.currentStep in 3..9) {
+                TextButton(
+                    onClick = viewModel::skip,
                     modifier = Modifier
-                        .weight(1f)
-                        .height(56.dp),
-                    shape = RoundedCornerShape(16.dp)
+                        .fillMaxWidth()
+                        .height(44.dp)
                 ) {
                     Text(
-                        text = "이전",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.SemiBold,
+                        text = "건너뛰기",
+                        fontSize = 16.sp,
                         fontFamily = OutfitFontFamily,
-                        color = EchoAccentGreen
+                        color = EchoTextTertiary
                     )
                 }
             }
-            Button(
-                onClick = viewModel::next,
-                enabled = !uiState.isLoading,
-                modifier = Modifier
-                    .weight(if (uiState.currentStep > 0) 1f else Float.MAX_VALUE)
-                    .height(56.dp),
-                shape = RoundedCornerShape(16.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = EchoAccentGreen,
-                    contentColor = Color.White,
-                    disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
-                )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
             ) {
-                if (uiState.isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.height(22.dp),
-                        color = Color.White,
-                        strokeWidth = 2.dp
+                if (uiState.currentStep > 0) {
+                    OutlinedButton(
+                        onClick = viewModel::previous,
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp),
+                        shape = RoundedCornerShape(16.dp)
+                    ) {
+                        Text(
+                            text = "이전",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            fontFamily = OutfitFontFamily,
+                            color = EchoAccentGreen
+                        )
+                    }
+                }
+                Button(
+                    onClick = viewModel::next,
+                    enabled = !uiState.isLoading,
+                    modifier = Modifier
+                        .weight(if (uiState.currentStep > 0) 1f else Float.MAX_VALUE)
+                        .height(56.dp),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = EchoAccentGreen,
+                        contentColor = Color.White,
+                        disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
                     )
-                } else {
-                    Text(
-                        text = if (uiState.currentStep < ONBOARDING_STEPS - 1) "다음" else "완료",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        fontFamily = OutfitFontFamily
-                    )
+                ) {
+                    if (uiState.isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.height(22.dp),
+                            color = Color.White,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(
+                            text = if (uiState.currentStep < ONBOARDING_STEPS - 1) "다음" else "완료",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            fontFamily = OutfitFontFamily
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -81,6 +81,15 @@ class OnboardingViewModel(
         if (step > 0) _uiState.update { it.copy(currentStep = step - 1, fieldError = null) }
     }
 
+    fun skip() {
+        val step = _uiState.value.currentStep
+        if (step < ONBOARDING_STEPS - 1) {
+            _uiState.update { it.copy(currentStep = step + 1, fieldError = null) }
+        } else {
+            submit()
+        }
+    }
+
     private fun validateStep(state: OnboardingUiState): String? = when (state.currentStep) {
         0 -> if (state.birthday.isBlank()) "생년월일을 입력해주세요" else null
         1 -> if (state.location.isBlank()) "거주 지역을 입력해주세요" else null

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -546,15 +546,15 @@ private fun PreferenceRow(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(enabled = enabled, onClick = onClick)
-            .padding(horizontal = 20.dp, vertical = 16.dp),
+            .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
-            Spacer(Modifier.height(2.dp))
+            Text(label, fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Spacer(Modifier.height(3.dp))
             Text(
                 text = if (!value.isNullOrBlank()) value else "미설정",
-                fontSize = 16.sp,
+                fontSize = 17.sp,
                 fontFamily = OutfitFontFamily,
                 color = if (!value.isNullOrBlank()) EchoTextPrimary else EchoTextTertiary
             )
@@ -579,12 +579,12 @@ private fun PermissionStatusRow(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(horizontal = 20.dp, vertical = 16.dp),
+            .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
-            Spacer(Modifier.height(2.dp))
+            Text(label, fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Spacer(Modifier.height(3.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = if (isGranted) Icons.Filled.Check else Icons.Filled.Close,
@@ -613,15 +613,15 @@ private fun AlarmToggleRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 16.dp),
+            .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text("대화 시간 알림", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
-            Spacer(Modifier.height(2.dp))
+            Text("대화 시간 알림", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Spacer(Modifier.height(3.dp))
             Text(
                 text = if (enabled) "매일 알림을 받습니다" else "알림 꺼짐",
-                fontSize = 16.sp,
+                fontSize = 17.sp,
                 fontFamily = OutfitFontFamily,
                 color = if (enabled) EchoTextPrimary else EchoTextTertiary
             )

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/Color.kt
@@ -15,6 +15,7 @@ val EchoTextSecondary = Color(0xFF6D6C6A)
 val EchoTextTertiary  = Color(0xFF9C9B99)
 val EchoBorderSubtle  = Color(0xFFE5E4E1)
 val EchoTabInactive   = Color(0xFFA8A7A5)
+val EchoAiBubble      = Color(0xFFE0DDD9)
 
 // Aliases for RecordingIndicator, PulseEffect backward compat
 val ListeningTeal      = EchoAccentGreen


### PR DESCRIPTION
## Summary

- 탭바 아이콘/텍스트/높이 확대 (고령자 터치 정확도 향상)
- 대화 종료 버튼 색상 빨간색 → 중립 회색 (불안감 제거, Q6·Q9 개선)
- 온보딩 선택 단계(3~9)에 건너뛰기 버튼 추가 (Q2·Q8 개선)
- 홈 화면에 오늘 대화 시간 표시 (Q1·Q5 개선)
- 대화 기록 카드 텍스트 크기 및 패딩 확대 (Q3 개선)
- AI 말풍선 배경색 명확화 (`EchoAiBubble #E0DDD9`) (Q3·Q4 개선)
- 설정 항목 터치 영역·텍스트 크기 개선 (Q3·Q6 개선)

매칭되는 SUS 질문
Q1. 이 시스템을 자주 이용하고 싶다는 생각이 듭니다.
Q2. 시스템이 불필요하게 복잡하다는 것을 알았습니다.
Q3. 이 시스템을 사용하기 쉽다고 생각했습니다.
Q4. 이 시스템을 사용하려면 기술자의 지원이 필요하다고 생각합니다.
Q5. 이 시스템의 다양한 기능이 잘 통합되어 있다는 것을 알았습니다. 
Q6. 이 시스템에 너무 많은 불일치가 있다고 생각했습니다.
Q7. 나는 대부분의 사람들이 이 시스템을 매우 빨리 사용하는 법을 배울 것이라고 상상합니다.
Q8. 시스템을 사용하기가 매우 복잡하다는 것을 알았습니다.
Q9. 나는 이 시스템을 사용하여 매우 자신감을 느꼈다. 
Q10. 이 시스템을 사용하기 전에 많은 것을 배워야 했습니다.

## Test plan

- [ ] 탭바 3개 탭 터치 정확도 및 텍스트 가독성 확인
- [ ] 대화 화면에서 종료 버튼 색상이 회색으로 표시되는지 확인
- [ ] 온보딩 단계 3 이후부터 건너뛰기 버튼 노출 확인, 단계 0~2에서는 미노출 확인
- [ ] 홈 화면에서 conversationTime 설정된 계정 로그인 시 대화 시간 표시 확인
- [ ] 대화 기록 화면에서 카드 텍스트 가독성 확인
- [ ] 대화 화면에서 AI/사용자 말풍선 색상 구분 확인
- [ ] 설정 화면 각 항목 터치 영역 및 텍스트 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)