### PR TITLE
feat: 글씨 크기 및 색상 테마 화면 설정 기능 추가 (어르신 접근성)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.activity.viewModels
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +41,7 @@ import com.example.graduation_project.presentation.history.ConversationHistorySc
 import com.example.graduation_project.presentation.home.HomeScreen
 import com.example.graduation_project.presentation.onboarding.OnboardingScreen
 import com.example.graduation_project.presentation.settings.SettingsScreen
+import com.example.graduation_project.presentation.settings.DisplaySettingsViewModel
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import kotlinx.coroutines.Dispatchers
@@ -48,6 +51,9 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 
 class MainActivity : ComponentActivity() {
+
+    private val displayViewModel: DisplaySettingsViewModel by viewModels { DisplaySettingsViewModel.Factory }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -56,7 +62,8 @@ class MainActivity : ComponentActivity() {
         val navigateTo = intent.getStringExtra("navigate_to")
 
         setContent {
-            Graduation_projectTheme {
+            val displaySettings by displayViewModel.settings.collectAsState()
+            Graduation_projectTheme(displaySettings = displaySettings) {
                 AppNavHost(navigateTo = navigateTo)
             }
         }

--- a/android/app/src/main/java/com/example/graduation_project/data/local/DisplaySettingsStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/DisplaySettingsStorage.kt
@@ -1,0 +1,25 @@
+package com.example.graduation_project.data.local
+
+import android.content.Context
+
+class DisplaySettingsStorage(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+
+    var fontScale: Float
+        get() = prefs.getFloat(KEY_FONT_SCALE, SCALE_MEDIUM)
+        set(value) = prefs.edit().putFloat(KEY_FONT_SCALE, value).apply()
+
+    var isHighContrast: Boolean
+        get() = prefs.getBoolean(KEY_HIGH_CONTRAST, false)
+        set(value) = prefs.edit().putBoolean(KEY_HIGH_CONTRAST, value).apply()
+
+    companion object {
+        private const val PREF_NAME = "display_settings"
+        private const val KEY_FONT_SCALE = "font_scale"
+        private const val KEY_HIGH_CONTRAST = "high_contrast"
+        const val SCALE_SMALL = 0.85f
+        const val SCALE_MEDIUM = 1.0f
+        const val SCALE_LARGE = 1.15f
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
@@ -37,13 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgCard
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoBorderSubtle
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -67,14 +61,15 @@ fun LoginScreen(
         }
     }
 
+    val colors = LocalEchoColors.current
     Scaffold(
-        containerColor = EchoBgPage,
+        containerColor = colors.bgPage,
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
                 .padding(padding)
                 .padding(horizontal = 32.dp)
                 .verticalScroll(rememberScrollState()),
@@ -87,7 +82,7 @@ fun LoginScreen(
                 fontSize = 32.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoAccentGreen
+                color = colors.accentGreen
             )
 
             Spacer(Modifier.height(8.dp))
@@ -96,7 +91,7 @@ fun LoginScreen(
                 text = "함께 이야기 나눠요",
                 fontSize = 16.sp,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextSecondary
+                color = colors.textSecondary
             )
 
             Spacer(Modifier.height(48.dp))
@@ -128,9 +123,9 @@ fun LoginScreen(
                     .height(64.dp),
                 shape = RoundedCornerShape(16.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = EchoAccentGreen,
+                    containerColor = colors.accentGreen,
                     contentColor = Color.White,
-                    disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
+                    disabledContainerColor = colors.accentGreen.copy(alpha = 0.6f)
                 )
             ) {
                 if (uiState.isLoading) {
@@ -156,7 +151,7 @@ fun LoginScreen(
                     text = "회원가입하기",
                     fontSize = 16.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextSecondary
+                    color = colors.textSecondary
                 )
             }
         }
@@ -173,6 +168,7 @@ internal fun EchoOutlinedTextField(
     isError: Boolean = false,
     supportingText: String? = null
 ) {
+    val colors = LocalEchoColors.current
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
@@ -180,7 +176,7 @@ internal fun EchoOutlinedTextField(
             Text(
                 text = label,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextTertiary,
+                color = colors.textTertiary,
                 fontSize = 16.sp
             )
         },
@@ -191,13 +187,13 @@ internal fun EchoOutlinedTextField(
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         shape = RoundedCornerShape(12.dp),
         colors = OutlinedTextFieldDefaults.colors(
-            focusedContainerColor = EchoBgCard,
-            unfocusedContainerColor = EchoBgCard,
-            focusedBorderColor = EchoAccentGreen,
-            unfocusedBorderColor = EchoBorderSubtle,
-            focusedTextColor = EchoTextPrimary,
-            unfocusedTextColor = EchoTextPrimary,
-            cursorColor = EchoAccentGreen
+            focusedContainerColor = colors.bgCard,
+            unfocusedContainerColor = colors.bgCard,
+            focusedBorderColor = colors.accentGreen,
+            unfocusedBorderColor = colors.borderSubtle,
+            focusedTextColor = colors.textPrimary,
+            unfocusedTextColor = colors.textPrimary,
+            cursorColor = colors.accentGreen
         ),
         modifier = Modifier.fillMaxWidth()
     )
@@ -207,17 +203,18 @@ internal fun EchoOutlinedTextField(
 @Composable
 private fun LoginScreenPreview() {
     Graduation_projectTheme {
+        val colors = LocalEchoColors.current
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
                 .padding(horizontal = 32.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text("에코", fontSize = 32.sp, fontWeight = FontWeight.Bold, fontFamily = OutfitFontFamily, color = EchoAccentGreen)
+            Text("에코", fontSize = 32.sp, fontWeight = FontWeight.Bold, fontFamily = OutfitFontFamily, color = colors.accentGreen)
             Spacer(Modifier.height(8.dp))
-            Text("함께 이야기 나눠요", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Text("함께 이야기 나눠요", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(48.dp))
             EchoOutlinedTextField("", {}, "아이디")
             Spacer(Modifier.height(16.dp))
@@ -227,12 +224,12 @@ private fun LoginScreenPreview() {
                 onClick = {},
                 modifier = Modifier.fillMaxWidth().height(64.dp),
                 shape = RoundedCornerShape(16.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = EchoAccentGreen)
+                colors = ButtonDefaults.buttonColors(containerColor = colors.accentGreen)
             ) {
                 Text("로그인", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
             }
             Spacer(Modifier.height(12.dp))
-            TextButton({}) { Text("회원가입하기", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary) }
+            TextButton({}) { Text("회원가입하기", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary) }
         }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
@@ -33,9 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoTextSecondary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -58,14 +56,15 @@ fun SignupScreen(
         }
     }
 
+    val colors = LocalEchoColors.current
     Scaffold(
-        containerColor = EchoBgPage,
+        containerColor = colors.bgPage,
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
                 .padding(padding)
                 .padding(horizontal = 32.dp)
                 .verticalScroll(rememberScrollState()),
@@ -77,7 +76,7 @@ fun SignupScreen(
                 fontSize = 32.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoAccentGreen
+                color = colors.accentGreen
             )
 
             Spacer(Modifier.height(8.dp))
@@ -86,7 +85,7 @@ fun SignupScreen(
                 text = "계정을 만들어보세요",
                 fontSize = 16.sp,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextSecondary
+                color = colors.textSecondary
             )
 
             Spacer(Modifier.height(40.dp))
@@ -132,9 +131,9 @@ fun SignupScreen(
                     .height(64.dp),
                 shape = RoundedCornerShape(16.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = EchoAccentGreen,
+                    containerColor = colors.accentGreen,
                     contentColor = Color.White,
-                    disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
+                    disabledContainerColor = colors.accentGreen.copy(alpha = 0.6f)
                 )
             ) {
                 if (uiState.isLoading) {
@@ -160,17 +159,18 @@ fun SignupScreen(
 @Composable
 private fun SignupScreenPreview() {
     Graduation_projectTheme {
+        val colors = LocalEchoColors.current
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
                 .padding(horizontal = 32.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text("에코", fontSize = 32.sp, fontWeight = FontWeight.Bold, fontFamily = OutfitFontFamily, color = EchoAccentGreen)
+            Text("에코", fontSize = 32.sp, fontWeight = FontWeight.Bold, fontFamily = OutfitFontFamily, color = colors.accentGreen)
             Spacer(Modifier.height(8.dp))
-            Text("계정을 만들어보세요", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Text("계정을 만들어보세요", fontSize = 16.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(40.dp))
             EchoOutlinedTextField("", {}, "이름")
             Spacer(Modifier.height(12.dp))
@@ -182,7 +182,7 @@ private fun SignupScreenPreview() {
                 onClick = {},
                 modifier = Modifier.fillMaxWidth().height(64.dp),
                 shape = RoundedCornerShape(16.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = EchoAccentGreen)
+                colors = ButtonDefaults.buttonColors(containerColor = colors.accentGreen)
             ) {
                 Text("가입하기", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
             }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTabBar.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/common/EchoTabBar.kt
@@ -29,10 +29,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgCard
-import com.example.graduation_project.ui.theme.EchoBorderSubtle
-import com.example.graduation_project.ui.theme.EchoTabInactive
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
 enum class EchoTab(val route: String, val label: String, val icon: ImageVector) {
@@ -47,8 +44,9 @@ fun EchoTabBar(
     onTabSelected: (EchoTab) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colors = LocalEchoColors.current
     Surface(
-        color = EchoBgCard,
+        color = colors.bgCard,
         shadowElevation = 4.dp,
         modifier = modifier.fillMaxWidth()
     ) {
@@ -59,8 +57,8 @@ fun EchoTabBar(
                 .padding(top = 12.dp, bottom = 12.dp)
                 .navigationBarsPadding()
                 .clip(RoundedCornerShape(36.dp))
-                .border(1.dp, EchoBorderSubtle, RoundedCornerShape(36.dp))
-                .background(EchoBgCard)
+                .border(1.dp, colors.borderSubtle, RoundedCornerShape(36.dp))
+                .background(colors.bgCard)
                 .height(62.dp),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
@@ -85,6 +83,7 @@ private fun EchoTabItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val colors = LocalEchoColors.current
     val pillShape = RoundedCornerShape(28.dp)
 
     Column(
@@ -93,7 +92,7 @@ private fun EchoTabItem(
             .padding(horizontal = 4.dp, vertical = 8.dp)
             .clip(pillShape)
             .then(
-                if (isActive) Modifier.background(EchoAccentGreen)
+                if (isActive) Modifier.background(colors.accentGreen)
                 else Modifier
             )
             .clickable(onClick = onClick),
@@ -103,12 +102,12 @@ private fun EchoTabItem(
         Icon(
             imageVector = tab.icon,
             contentDescription = tab.label,
-            tint = if (isActive) Color.White else EchoTabInactive,
+            tint = if (isActive) Color.White else colors.tabInactive,
             modifier = Modifier.size(18.dp)
         )
         Text(
             text = tab.label,
-            color = if (isActive) Color.White else EchoTabInactive,
+            color = if (isActive) Color.White else colors.tabInactive,
             fontSize = 10.sp,
             fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
             fontFamily = OutfitFontFamily,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -50,16 +50,7 @@ import com.example.graduation_project.presentation.model.ConversationUiState
 import com.example.graduation_project.presentation.model.MessageUiModel
 import com.example.graduation_project.presentation.model.PlaybackStatus
 import com.example.graduation_project.presentation.permission.UnifiedPermissionHandler
-import com.example.graduation_project.ui.theme.EchoAccentCoral
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoAccentRed
-import com.example.graduation_project.ui.theme.EchoBgCard
-import com.example.graduation_project.ui.theme.EchoBgMuted
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoBorderSubtle
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -112,8 +103,9 @@ private fun ConversationScreenContent(
     onEndClick: () -> Unit,
     onRetryClick: () -> Unit = {}
 ) {
+    val colors = LocalEchoColors.current
     Scaffold(
-        containerColor = EchoBgPage,
+        containerColor = colors.bgPage,
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValues ->
         Column(
@@ -154,6 +146,7 @@ private fun ConversationScreenContent(
 
 @Composable
 private fun StateIconSection(state: ConversationState) {
+    val colors = LocalEchoColors.current
     val iconSize = 80.dp
 
     Box(
@@ -168,7 +161,7 @@ private fun StateIconSection(state: ConversationState) {
                 Icon(
                     imageVector = Icons.Default.MicOff,
                     contentDescription = "처리 중",
-                    tint = EchoTextTertiary,
+                    tint = colors.textTertiary,
                     modifier = Modifier.size(iconSize)
                 )
             }
@@ -176,13 +169,13 @@ private fun StateIconSection(state: ConversationState) {
                 Box(
                     modifier = Modifier
                         .size(iconSize)
-                        .border(3.dp, EchoAccentCoral, CircleShape),
+                        .border(3.dp, colors.accentCoral, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = Icons.Default.PlayCircle,
                         contentDescription = "재생 중",
-                        tint = EchoAccentCoral,
+                        tint = colors.accentCoral,
                         modifier = Modifier.size(48.dp)
                     )
                 }
@@ -194,23 +187,23 @@ private fun StateIconSection(state: ConversationState) {
                         .size(iconSize)
                         .then(
                             if (isListening)
-                                Modifier.border(3.dp, EchoAccentGreen, CircleShape)
+                                Modifier.border(3.dp, colors.accentGreen, CircleShape)
                             else
-                                Modifier.background(EchoAccentGreen, CircleShape)
+                                Modifier.background(colors.accentGreen, CircleShape)
                         ),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = Icons.Default.Mic,
                         contentDescription = if (isListening) "듣고 있음" else "녹음 중",
-                        tint = if (isListening) EchoAccentGreen else Color.White,
+                        tint = if (isListening) colors.accentGreen else Color.White,
                         modifier = Modifier.size(48.dp)
                     )
                 }
             }
             else -> {
                 CircularProgressIndicator(
-                    color = EchoAccentGreen,
+                    color = colors.accentGreen,
                     modifier = Modifier.size(48.dp)
                 )
             }
@@ -224,6 +217,7 @@ private fun StateTextSection(
     currentAiMessage: String?,
     currentUserSpeech: String?
 ) {
+    val colors = LocalEchoColors.current
     val stateLabel = when (state) {
         is ConversationState.Idle -> "대화를 시작해보세요"
         is ConversationState.Sending -> "처리 중..."
@@ -238,7 +232,7 @@ private fun StateTextSection(
         fontSize = 22.sp,
         fontWeight = FontWeight.Bold,
         fontFamily = OutfitFontFamily,
-        color = EchoTextPrimary,
+        color = colors.textPrimary,
         textAlign = TextAlign.Center
     )
 
@@ -256,7 +250,7 @@ private fun StateTextSection(
             text = subText,
             fontSize = 18.sp,
             fontFamily = OutfitFontFamily,
-            color = EchoTextSecondary,
+            color = colors.textSecondary,
             textAlign = TextAlign.Center,
             lineHeight = 26.sp
         )
@@ -270,6 +264,7 @@ private fun BottomActionSection(
     onStartClick: () -> Unit,
     onEndClick: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     val isActive = state !is ConversationState.Idle && state !is ConversationState.Ended
 
     if (!isActive) {
@@ -281,7 +276,7 @@ private fun BottomActionSection(
                 .height(64.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = EchoAccentGreen,
+                containerColor = colors.accentGreen,
                 contentColor = Color.White
             )
         ) {
@@ -301,10 +296,10 @@ private fun BottomActionSection(
                 .height(64.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = if (isSending) EchoBgMuted else EchoAccentRed,
-                contentColor = if (isSending) EchoTextTertiary else Color.White,
-                disabledContainerColor = EchoBgMuted,
-                disabledContentColor = EchoTextTertiary
+                containerColor = if (isSending) colors.bgMuted else colors.accentRed,
+                contentColor = if (isSending) colors.textTertiary else Color.White,
+                disabledContainerColor = colors.bgMuted,
+                disabledContentColor = colors.textTertiary
             )
         ) {
             Text("대화 종료", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
@@ -317,10 +312,11 @@ private fun FarewellDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = RoundedCornerShape(20.dp),
-            color = EchoBgCard
+            color = colors.bgCard
         ) {
             Column(
                 modifier = Modifier
@@ -333,7 +329,7 @@ private fun FarewellDialog(
                     fontSize = 22.sp,
                     fontWeight = FontWeight.Bold,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextPrimary,
+                    color = colors.textPrimary,
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.height(10.dp))
@@ -341,7 +337,7 @@ private fun FarewellDialog(
                     text = "오늘 대화 내용은 일기로 저장됩니다",
                     fontSize = 15.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextSecondary,
+                    color = colors.textSecondary,
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.height(28.dp))
@@ -354,9 +350,9 @@ private fun FarewellDialog(
                         modifier = Modifier.weight(1f).height(52.dp),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = EchoTextSecondary
+                            contentColor = colors.textSecondary
                         ),
-                        border = BorderStroke(1.dp, EchoBorderSubtle)
+                        border = BorderStroke(1.dp, colors.borderSubtle)
                     ) {
                         Text("이어하기", fontSize = 17.sp, fontFamily = OutfitFontFamily)
                     }
@@ -365,7 +361,7 @@ private fun FarewellDialog(
                         modifier = Modifier.weight(1f).height(52.dp),
                         shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.buttonColors(
-                            containerColor = EchoAccentRed,
+                            containerColor = colors.accentRed,
                             contentColor = Color.White
                         )
                     ) {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/ActiveConversationView.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/ActiveConversationView.kt
@@ -42,7 +42,6 @@ import com.example.graduation_project.presentation.component.RecordingIndicator
 import com.example.graduation_project.presentation.model.ConversationError
 import com.example.graduation_project.presentation.model.ConversationState
 import com.example.graduation_project.presentation.model.PlaybackStatus
-import com.example.graduation_project.ui.theme.CharacterVideoBgColor
 import com.example.graduation_project.ui.theme.Dimens
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/MessageItem.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/components/MessageItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,6 +46,7 @@ fun MessageItem(
     message: MessageUiModel,
     modifier: Modifier = Modifier
 ) {
+    val colors = LocalEchoColors.current
     // 화면 너비의 85%를 최대 너비로 설정
     val configuration = LocalConfiguration.current
     val maxWidth = (configuration.screenWidthDp * Dimens.MessageBubbleMaxWidth).dp
@@ -81,7 +83,7 @@ fun MessageItem(
             Text(
                 text = senderText,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = if (message.isFromUser) colors.accentGreen else colors.textSecondary,
                 modifier = Modifier.padding(
                     start = if (!message.isFromUser) Dimens.SpacingSmall else 0.dp,
                     end = if (message.isFromUser) Dimens.SpacingSmall else 0.dp,
@@ -100,23 +102,13 @@ fun MessageItem(
                             bottomEnd = if (message.isFromUser) 4.dp else Dimens.MessageBubbleRadius
                         )
                     )
-                    .background(
-                        if (message.isFromUser) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.surfaceVariant
-                        }
-                    )
+                    .background(if (message.isFromUser) colors.accentGreen else colors.bgMuted)
                     .padding(Dimens.MessageBubblePadding)
             ) {
                 Text(
                     text = message.text,
                     style = MaterialTheme.typography.bodyLarge,
-                    color = if (message.isFromUser) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                    color = if (message.isFromUser) androidx.compose.ui.graphics.Color.White else colors.textPrimary
                 )
             }
 
@@ -124,7 +116,7 @@ fun MessageItem(
             Text(
                 text = timeText,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                color = colors.textTertiary,
                 modifier = Modifier.padding(
                     start = if (!message.isFromUser) Dimens.SpacingSmall else 0.dp,
                     end = if (message.isFromUser) Dimens.SpacingSmall else 0.dp,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryDetailScreen.kt
@@ -37,11 +37,7 @@ import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.entity.MessageEntity
 import com.example.graduation_project.presentation.conversation.components.MessageItem
 import com.example.graduation_project.presentation.model.MessageUiModel
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -136,10 +132,11 @@ fun ConversationHistoryDetailScreen(
     )
     val uiState by vm.uiState.collectAsState()
 
+    val colors = LocalEchoColors.current
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(EchoBgPage)
+            .background(colors.bgPage)
     ) {
         // Top bar
         Row(
@@ -152,7 +149,7 @@ fun ConversationHistoryDetailScreen(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "뒤로 가기",
-                    tint = EchoTextPrimary
+                    tint = colors.textPrimary
                 )
             }
             Column(modifier = Modifier.padding(start = 8.dp)) {
@@ -162,22 +159,22 @@ fun ConversationHistoryDetailScreen(
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold,
                         fontFamily = OutfitFontFamily,
-                        color = EchoTextPrimary
+                        color = colors.textPrimary
                     )
                     Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                         Text(
                             text = uiState.timeRange,
                             fontSize = 13.sp,
                             fontFamily = OutfitFontFamily,
-                            color = EchoTextTertiary
+                            color = colors.textTertiary
                         )
                         if (uiState.durationMin > 0) {
-                            Text("·", fontSize = 13.sp, color = EchoTextTertiary)
+                            Text("·", fontSize = 13.sp, color = colors.textTertiary)
                             Text(
                                 text = "${uiState.durationMin}분",
                                 fontSize = 13.sp,
                                 fontFamily = OutfitFontFamily,
-                                color = EchoTextTertiary
+                                color = colors.textTertiary
                             )
                         }
                     }
@@ -187,14 +184,14 @@ fun ConversationHistoryDetailScreen(
 
         if (uiState.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(color = EchoAccentGreen)
+                CircularProgressIndicator(color = colors.accentGreen)
             }
         } else if (uiState.messages.isEmpty()) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(
                     text = "메시지가 없습니다",
                     fontSize = 18.sp,
-                    color = EchoTextTertiary,
+                    color = colors.textTertiary,
                     fontFamily = OutfitFontFamily
                 )
             }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
@@ -30,13 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.presentation.model.ConversationSummary
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgCard
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoBorderSubtle
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -47,30 +41,31 @@ fun ConversationHistoryScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
+    val colors = LocalEchoColors.current
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(EchoBgPage)
+            .background(colors.bgPage)
     ) {
         Text(
             text = "대화 기록",
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
             fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary,
+            color = colors.textPrimary,
             modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
         )
 
         if (uiState.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(color = EchoAccentGreen)
+                CircularProgressIndicator(color = colors.accentGreen)
             }
         } else if (uiState.summaries.isEmpty()) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(
                     text = "아직 대화 기록이 없어요",
                     fontSize = 18.sp,
-                    color = EchoTextTertiary,
+                    color = colors.textTertiary,
                     fontFamily = OutfitFontFamily
                 )
             }
@@ -98,13 +93,14 @@ private fun ConversationCard(
     summary: ConversationSummary,
     onClick: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(2.dp, RoundedCornerShape(12.dp))
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(12.dp),
-        color = EchoBgCard,
+        color = colors.bgCard,
         tonalElevation = 0.dp
     ) {
         Column(
@@ -117,7 +113,7 @@ private fun ConversationCard(
                 fontSize = 18.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextPrimary
+                color = colors.textPrimary
             )
             Spacer(Modifier.height(4.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -125,18 +121,18 @@ private fun ConversationCard(
                     text = summary.timeRange,
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextTertiary
+                    color = colors.textTertiary
                 )
                 Text(
                     text = "·",
                     fontSize = 14.sp,
-                    color = EchoTextTertiary
+                    color = colors.textTertiary
                 )
                 Text(
                     text = "${summary.durationMin}분",
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextTertiary
+                    color = colors.textTertiary
                 )
             }
             Spacer(Modifier.height(8.dp))
@@ -144,7 +140,7 @@ private fun ConversationCard(
                 text = summary.previewText,
                 fontSize = 16.sp,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextSecondary,
+                color = colors.textSecondary,
                 maxLines = 2,
                 lineHeight = 22.sp
             )
@@ -156,17 +152,18 @@ private fun ConversationCard(
 @Composable
 private fun HistoryScreenPreview() {
     Graduation_projectTheme {
+        val colors = LocalEchoColors.current
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
         ) {
             Text(
                 text = "대화 기록",
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextPrimary,
+                color = colors.textPrimary,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
             )
             LazyColumn(

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -24,10 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.presentation.conversation.components.AiCharacterImage
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -49,10 +46,11 @@ private fun HomeScreenContent(
     userName: String,
     onStartConversation: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(EchoBgPage)
+            .background(colors.bgPage)
             .padding(horizontal = 32.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -66,7 +64,7 @@ private fun HomeScreenContent(
             fontSize = 26.sp,
             fontWeight = FontWeight.SemiBold,
             fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary
+            color = colors.textPrimary
         )
 
         Spacer(Modifier.height(8.dp))
@@ -75,7 +73,7 @@ private fun HomeScreenContent(
             text = "함께 이야기 나눠요",
             fontSize = 18.sp,
             fontFamily = OutfitFontFamily,
-            color = EchoTextSecondary
+            color = colors.textSecondary
         )
 
         Spacer(Modifier.height(40.dp))
@@ -87,7 +85,7 @@ private fun HomeScreenContent(
                 .height(64.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = EchoAccentGreen,
+                containerColor = colors.accentGreen,
                 contentColor = Color.White
             )
         ) {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -46,12 +46,7 @@ import com.example.graduation_project.presentation.common.BirthdayInputRow
 import com.example.graduation_project.presentation.common.EchoTimePickerContent
 import com.example.graduation_project.presentation.common.buildBirthdayString
 import com.example.graduation_project.presentation.common.parseBirthday
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoBgMuted
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
 private val stepTitles = listOf(
@@ -91,10 +86,11 @@ fun OnboardingScreen(
         }
     }
 
+    val colors = LocalEchoColors.current
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(EchoBgPage)
+            .background(colors.bgPage)
     ) {
         // 상단 진행률
         Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)) {
@@ -108,21 +104,21 @@ fun OnboardingScreen(
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextPrimary
+                    color = colors.textPrimary
                 )
                 Text(
                     text = "${uiState.currentStep + 1} / $ONBOARDING_STEPS",
                     fontSize = 16.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextSecondary
+                    color = colors.textSecondary
                 )
             }
             Spacer(Modifier.height(12.dp))
             LinearProgressIndicator(
                 progress = { (uiState.currentStep + 1).toFloat() / ONBOARDING_STEPS },
                 modifier = Modifier.fillMaxWidth(),
-                color = EchoAccentGreen,
-                trackColor = EchoBgMuted
+                color = colors.accentGreen,
+                trackColor = colors.bgMuted
             )
         }
 
@@ -138,14 +134,14 @@ fun OnboardingScreen(
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextPrimary
+                color = colors.textPrimary
             )
             Spacer(Modifier.height(8.dp))
             Text(
                 text = stepHints[uiState.currentStep],
                 fontSize = 15.sp,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextSecondary
+                color = colors.textSecondary
             )
             Spacer(Modifier.height(32.dp))
 
@@ -199,7 +195,7 @@ fun OnboardingScreen(
                         fontSize = 18.sp,
                         fontWeight = FontWeight.SemiBold,
                         fontFamily = OutfitFontFamily,
-                        color = EchoAccentGreen
+                        color = colors.accentGreen
                     )
                 }
             }
@@ -211,9 +207,9 @@ fun OnboardingScreen(
                     .height(56.dp),
                 shape = RoundedCornerShape(16.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = EchoAccentGreen,
+                    containerColor = colors.accentGreen,
                     contentColor = Color.White,
-                    disabledContainerColor = EchoAccentGreen.copy(alpha = 0.6f)
+                    disabledContainerColor = colors.accentGreen.copy(alpha = 0.6f)
                 )
             ) {
                 if (uiState.isLoading) {
@@ -323,6 +319,7 @@ private fun TimePickerStep(
     alarmEnabled: Boolean,
     onAlarmEnabledChange: (Boolean) -> Unit
 ) {
+    val colors = LocalEchoColors.current
     val initial = if (selected.isNotEmpty()) selected else "09:00"
     LaunchedEffect(Unit) {
         if (selected.isEmpty()) onTimeSelected("09:00")
@@ -346,13 +343,13 @@ private fun TimePickerStep(
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Medium,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextPrimary
+                    color = colors.textPrimary
                 )
                 Text(
                     text = if (alarmEnabled) "설정한 시간에 알림을 보내드려요" else "알림을 받지 않습니다",
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextSecondary
+                    color = colors.textSecondary
                 )
             }
             Switch(
@@ -360,9 +357,9 @@ private fun TimePickerStep(
                 onCheckedChange = onAlarmEnabledChange,
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = Color.White,
-                    checkedTrackColor = EchoAccentGreen,
+                    checkedTrackColor = colors.accentGreen,
                     uncheckedThumbColor = Color.White,
-                    uncheckedTrackColor = EchoBgMuted
+                    uncheckedTrackColor = colors.bgMuted
                 )
             )
         }
@@ -376,13 +373,14 @@ private fun VoiceSettingsStep(
     onSpeedChange: (Double) -> Unit,
     onToneChange: (String) -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Column {
         Text(
             text = "음성 속도",
             fontSize = 16.sp,
             fontWeight = FontWeight.Medium,
             fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary
+            color = colors.textPrimary
         )
         Spacer(Modifier.height(4.dp))
         Text(
@@ -395,7 +393,7 @@ private fun VoiceSettingsStep(
             }",
             fontSize = 15.sp,
             fontFamily = OutfitFontFamily,
-            color = EchoAccentGreen
+            color = colors.accentGreen
         )
         androidx.compose.material3.Slider(
             value = voiceSpeed.toFloat(),
@@ -404,14 +402,14 @@ private fun VoiceSettingsStep(
             steps = 3,
             modifier = Modifier.fillMaxWidth(),
             colors = androidx.compose.material3.SliderDefaults.colors(
-                thumbColor = EchoAccentGreen,
-                activeTrackColor = EchoAccentGreen,
-                inactiveTrackColor = EchoBgMuted
+                thumbColor = colors.accentGreen,
+                activeTrackColor = colors.accentGreen,
+                inactiveTrackColor = colors.bgMuted
             )
         )
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text("느리게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
-            Text("빠르게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
+            Text("느리게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = colors.textTertiary)
+            Text("빠르게", fontSize = 13.sp, fontFamily = OutfitFontFamily, color = colors.textTertiary)
         }
 
         Spacer(Modifier.height(24.dp))
@@ -421,7 +419,7 @@ private fun VoiceSettingsStep(
             fontSize = 16.sp,
             fontWeight = FontWeight.Medium,
             fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary
+            color = colors.textPrimary
         )
         Spacer(Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -434,7 +432,7 @@ private fun VoiceSettingsStep(
                         Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily)
                     },
                     colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = EchoAccentGreen,
+                        selectedContainerColor = colors.accentGreen,
                         selectedLabelColor = Color.White
                     )
                 )

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/DisplaySettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/DisplaySettingsViewModel.kt
@@ -1,0 +1,51 @@
+package com.example.graduation_project.presentation.settings
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.example.graduation_project.data.local.DisplaySettingsStorage
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class DisplaySettings(
+    val fontScale: Float = DisplaySettingsStorage.SCALE_MEDIUM,
+    val isHighContrast: Boolean = false
+)
+
+class DisplaySettingsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val storage = DisplaySettingsStorage(application)
+
+    private val _settings = MutableStateFlow(
+        DisplaySettings(
+            fontScale = storage.fontScale,
+            isHighContrast = storage.isHighContrast
+        )
+    )
+    val settings: StateFlow<DisplaySettings> = _settings.asStateFlow()
+
+    fun setFontScale(scale: Float) {
+        storage.fontScale = scale
+        _settings.update { it.copy(fontScale = scale) }
+    }
+
+    fun setHighContrast(enabled: Boolean) {
+        storage.isHighContrast = enabled
+        _settings.update { it.copy(isHighContrast = enabled) }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return DisplaySettingsViewModel(application) as T
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -81,16 +81,8 @@ import com.example.graduation_project.presentation.common.EchoTimePickerContent
 import com.example.graduation_project.presentation.common.buildBirthdayString
 import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.presentation.health.openHealthConnectSettings
-import com.example.graduation_project.ui.theme.EchoAccentBlue
-import com.example.graduation_project.ui.theme.EchoAccentGreen
-import com.example.graduation_project.ui.theme.EchoAccentRed
-import com.example.graduation_project.ui.theme.EchoBgCard
-import com.example.graduation_project.ui.theme.EchoBgMuted
-import com.example.graduation_project.ui.theme.EchoBgPage
-import com.example.graduation_project.ui.theme.EchoBorderSubtle
-import com.example.graduation_project.ui.theme.EchoTextPrimary
-import com.example.graduation_project.ui.theme.EchoTextSecondary
-import com.example.graduation_project.ui.theme.EchoTextTertiary
+import com.example.graduation_project.data.local.DisplaySettingsStorage
+import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
 private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
@@ -124,9 +116,11 @@ private fun buildPreferences(
 @Composable
 fun SettingsScreen(
     onLogout: () -> Unit,
-    viewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.Factory)
+    viewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.Factory),
+    displayViewModel: DisplaySettingsViewModel = viewModel(factory = DisplaySettingsViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val displaySettings by displayViewModel.settings.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     var editingField by remember { mutableStateOf<String?>(null) }
     val context = LocalContext.current
@@ -157,11 +151,12 @@ fun SettingsScreen(
         }
     }
 
+    val colors = LocalEchoColors.current
     Box(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(EchoBgPage)
+                .background(colors.bgPage)
                 .verticalScroll(rememberScrollState())
         ) {
             Text(
@@ -169,7 +164,7 @@ fun SettingsScreen(
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextPrimary,
+                color = colors.textPrimary,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
             )
 
@@ -179,18 +174,18 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Row(
                     modifier = Modifier.padding(20.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Surface(modifier = Modifier.size(56.dp), shape = CircleShape, color = EchoBgMuted) {
+                    Surface(modifier = Modifier.size(56.dp), shape = CircleShape, color = colors.bgMuted) {
                         Icon(
                             imageVector = Icons.Outlined.Person,
                             contentDescription = null,
-                            tint = EchoTextSecondary,
+                            tint = colors.textSecondary,
                             modifier = Modifier.padding(12.dp)
                         )
                     }
@@ -200,14 +195,14 @@ fun SettingsScreen(
                             fontSize = 20.sp,
                             fontWeight = FontWeight.SemiBold,
                             fontFamily = OutfitFontFamily,
-                            color = EchoTextPrimary
+                            color = colors.textPrimary
                         )
                         if (uiState.age != null) {
                             Text(
                                 text = "${uiState.age}세",
                                 fontSize = 15.sp,
                                 fontFamily = OutfitFontFamily,
-                                color = EchoTextSecondary
+                                color = colors.textSecondary
                             )
                         }
                     }
@@ -218,13 +213,75 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(20.dp))
 
+            // ===== 화면 설정 섹션 =====
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                shape = RoundedCornerShape(16.dp),
+                color = colors.bgCard
+            ) {
+                Column {
+                    CardHeader(
+                        icon = Icons.Outlined.Settings,
+                        title = "화면 설정"
+                    )
+                    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+                        Text("글씨 크기", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                        Spacer(Modifier.height(8.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            listOf(
+                                "소" to DisplaySettingsStorage.SCALE_SMALL,
+                                "중" to DisplaySettingsStorage.SCALE_MEDIUM,
+                                "대" to DisplaySettingsStorage.SCALE_LARGE
+                            ).forEach { (label, scale) ->
+                                FilterChip(
+                                    selected = displaySettings.fontScale == scale,
+                                    onClick = { displayViewModel.setFontScale(scale) },
+                                    label = { Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily) },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        selectedContainerColor = colors.accentGreen,
+                                        selectedLabelColor = Color.White
+                                    )
+                                )
+                            }
+                        }
+                        Spacer(Modifier.height(16.dp))
+                        Text("색상 테마", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                        Spacer(Modifier.height(8.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            FilterChip(
+                                selected = !displaySettings.isHighContrast,
+                                onClick = { displayViewModel.setHighContrast(false) },
+                                label = { Text("기본", fontSize = 14.sp, fontFamily = OutfitFontFamily) },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = colors.accentGreen,
+                                    selectedLabelColor = Color.White
+                                )
+                            )
+                            FilterChip(
+                                selected = displaySettings.isHighContrast,
+                                onClick = { displayViewModel.setHighContrast(true) },
+                                label = { Text("높은 대비", fontSize = 14.sp, fontFamily = OutfitFontFamily) },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = colors.accentGreen,
+                                    selectedLabelColor = Color.White
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
             // ===== 대화 설정 섹션 =====
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
@@ -232,12 +289,12 @@ fun SettingsScreen(
                         title = "대화 설정"
                     )
                     PreferenceRow("대화 시간", uiState.conversationTime, enabled = enabled) { editingField = "conversationTime" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     AlarmToggleRow(
                         enabled = uiState.alarmEnabled,
                         onToggle = { viewModel.setAlarmEnabled(it) }
                     )
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow(
                         label = "음성 설정",
                         value = "${String.format("%.1f", uiState.voiceSpeed)}x · ${
@@ -249,7 +306,7 @@ fun SettingsScreen(
                         }",
                         enabled = enabled
                     ) { editingField = "voiceSettings" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("선호 대화 주제", uiState.preferredTopics, enabled = enabled) { editingField = "preferredTopics" }
                 }
             }
@@ -262,20 +319,20 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
                         icon = Icons.Outlined.Person,
                         title = "내 정보",
-                        iconTint = EchoAccentBlue
+                        iconTint = colors.accentBlue
                     )
                     PreferenceRow("생년월일", uiState.birthday, enabled = enabled) { editingField = "birthday" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("거주 지역", uiState.location, enabled = enabled) { editingField = "location" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("직업", uiState.occupation, enabled = enabled) { editingField = "occupation" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("취미", uiState.hobbies, enabled = enabled) { editingField = "hobbies" }
                 }
             }
@@ -288,13 +345,13 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
                         icon = Icons.Outlined.People,
                         title = "보호자 연결",
-                        iconTint = Color(0xFFFF9800) // Orange
+                        iconTint = Color(0xFFFF9800)
                     )
                     PreferenceRow(
                         label = "보호자 이메일",
@@ -302,7 +359,7 @@ fun SettingsScreen(
                         showWarning = uiState.guardianEmail.isNullOrBlank(),
                         enabled = enabled
                     ) { editingField = "guardianEmail" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("가족 관계", uiState.familyInfo, enabled = enabled) { editingField = "familyInfo" }
                 }
             }
@@ -315,20 +372,20 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
                         icon = Icons.Outlined.Favorite,
                         title = "건강 정보",
-                        iconTint = EchoAccentRed
+                        iconTint = colors.accentRed
                     )
                     PreferenceRow(
                         label = "선호 수면 시간",
                         value = uiState.preferredSleepHours?.let { "${it}시간" },
                         enabled = enabled
                     ) { editingField = "sleepHours" }
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PermissionStatusRow(
                         label = "건강 데이터 권한",
                         isGranted = uiState.hasHealthConnectPermission,
@@ -347,13 +404,13 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
                         icon = Icons.Outlined.LocationOn,
                         title = "위치 수집",
-                        iconTint = EchoAccentBlue
+                        iconTint = colors.accentBlue
                     )
                     PermissionStatusRow(
                         label = "위치 권한",
@@ -367,7 +424,7 @@ fun SettingsScreen(
                             context.startActivity(intent)
                         }
                     )
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow(
                         label = "수집 시작 시간",
                         value = uiState.locationCollectionStartTime,
@@ -384,13 +441,13 @@ fun SettingsScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(16.dp),
-                color = EchoBgCard
+                color = colors.bgCard
             ) {
                 Column {
                     CardHeader(
-                        icon = Icons.Outlined.Settings,
+                        icon = Icons.Outlined.Notifications,
                         title = "앱 설정",
-                        iconTint = EchoTextSecondary
+                        iconTint = colors.textSecondary
                     )
                     // 앱 알림 설정
                     NavigationRow(
@@ -409,7 +466,7 @@ fun SettingsScreen(
                             context.startActivity(intent)
                         }
                     )
-                    HorizontalDivider(color = EchoBorderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 앱 권한 설정
                     NavigationRow(
                         label = "앱 권한 설정",
@@ -434,7 +491,7 @@ fun SettingsScreen(
                     .padding(horizontal = 24.dp)
                     .height(56.dp),
                 shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = EchoAccentRed, contentColor = Color.White)
+                colors = ButtonDefaults.buttonColors(containerColor = colors.accentRed, contentColor = Color.White)
             ) {
                 Text("로그아웃", fontSize = 18.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
             }
@@ -542,6 +599,7 @@ private fun PreferenceRow(
     enabled: Boolean = true,
     onClick: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -550,20 +608,20 @@ private fun PreferenceRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(2.dp))
             Text(
                 text = if (!value.isNullOrBlank()) value else "미설정",
                 fontSize = 16.sp,
                 fontFamily = OutfitFontFamily,
-                color = if (!value.isNullOrBlank()) EchoTextPrimary else EchoTextTertiary
+                color = if (!value.isNullOrBlank()) colors.textPrimary else colors.textTertiary
             )
         }
         if (showWarning) {
-            Icon(Icons.Outlined.Warning, contentDescription = "필수 항목 미설정", tint = EchoAccentRed, modifier = Modifier.size(18.dp))
+            Icon(Icons.Outlined.Warning, contentDescription = "필수 항목 미설정", tint = colors.accentRed, modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(6.dp))
         }
-        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = EchoTextTertiary)
+        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
     }
 }
 
@@ -575,6 +633,7 @@ private fun PermissionStatusRow(
     deniedText: String,
     onClick: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -583,13 +642,13 @@ private fun PermissionStatusRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Text(label, fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(2.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = if (isGranted) Icons.Filled.Check else Icons.Filled.Close,
                     contentDescription = null,
-                    tint = if (isGranted) EchoAccentBlue else EchoAccentRed,
+                    tint = if (isGranted) colors.accentBlue else colors.accentRed,
                     modifier = Modifier.size(16.dp)
                 )
                 Spacer(Modifier.width(4.dp))
@@ -597,11 +656,11 @@ private fun PermissionStatusRow(
                     text = if (isGranted) grantedText else deniedText,
                     fontSize = 16.sp,
                     fontFamily = OutfitFontFamily,
-                    color = if (isGranted) EchoAccentBlue else EchoAccentRed
+                    color = if (isGranted) colors.accentBlue else colors.accentRed
                 )
             }
         }
-        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = EchoTextTertiary)
+        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
     }
 }
 
@@ -610,6 +669,7 @@ private fun AlarmToggleRow(
     enabled: Boolean,
     onToggle: (Boolean) -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -617,13 +677,13 @@ private fun AlarmToggleRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text("대화 시간 알림", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+            Text("대화 시간 알림", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(2.dp))
             Text(
                 text = if (enabled) "매일 알림을 받습니다" else "알림 꺼짐",
                 fontSize = 16.sp,
                 fontFamily = OutfitFontFamily,
-                color = if (enabled) EchoTextPrimary else EchoTextTertiary
+                color = if (enabled) colors.textPrimary else colors.textTertiary
             )
         }
         Switch(
@@ -631,9 +691,9 @@ private fun AlarmToggleRow(
             onCheckedChange = onToggle,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = Color.White,
-                checkedTrackColor = EchoAccentGreen,
+                checkedTrackColor = colors.accentGreen,
                 uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = EchoBgMuted
+                uncheckedTrackColor = colors.bgMuted
             )
         )
     }
@@ -649,31 +709,32 @@ private fun TextFieldDialog(
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     var value by remember { mutableStateOf(initialValue) }
     var error by remember { mutableStateOf<String?>(null) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
-        title = { Text(title, fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        containerColor = colors.bgCard,
+        title = { Text(title, fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary) },
         text = {
             Column {
                 OutlinedTextField(
                     value = value,
                     onValueChange = { value = it; error = null },
-                    label = { Text(hint.ifBlank { title }, fontFamily = OutfitFontFamily, color = EchoTextTertiary, fontSize = 14.sp) },
+                    label = { Text(hint.ifBlank { title }, fontFamily = OutfitFontFamily, color = colors.textTertiary, fontSize = 14.sp) },
                     singleLine = true,
                     isError = error != null,
                     supportingText = error?.let { { Text(it, fontFamily = OutfitFontFamily, fontSize = 13.sp) } },
                     keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
                     shape = RoundedCornerShape(12.dp),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = EchoBgMuted,
-                        unfocusedContainerColor = EchoBgMuted,
-                        focusedBorderColor = EchoAccentGreen,
-                        unfocusedBorderColor = EchoBorderSubtle,
-                        focusedTextColor = EchoTextPrimary,
-                        unfocusedTextColor = EchoTextPrimary
+                        focusedContainerColor = colors.bgMuted,
+                        unfocusedContainerColor = colors.bgMuted,
+                        focusedBorderColor = colors.accentGreen,
+                        unfocusedBorderColor = colors.borderSubtle,
+                        focusedTextColor = colors.textPrimary,
+                        unfocusedTextColor = colors.textPrimary
                     ),
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -684,12 +745,12 @@ private fun TextFieldDialog(
                 val e = validate(value)
                 if (e != null) { error = e } else { onConfirm(value) }
             }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -705,17 +766,18 @@ private fun VoiceSettingsDialog(
     var speed by remember { mutableStateOf(initialSpeed) }
     var tone by remember { mutableStateOf(initialTone) }
 
+    val colors = LocalEchoColors.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
-        title = { Text("음성 설정", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        containerColor = colors.bgCard,
+        title = { Text("음성 설정", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary) },
         text = {
             Column {
-                Text("음성 속도", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("음성 속도", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
                 Spacer(Modifier.height(4.dp))
                 Text(
                     "${String.format("%.1f", speed)}x  ${when { speed < 1.0 -> "느리게"; speed > 1.0 -> "빠르게"; else -> "보통" }}",
-                    fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoAccentGreen
+                    fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.accentGreen
                 )
                 Slider(
                     value = speed.toFloat(),
@@ -723,14 +785,14 @@ private fun VoiceSettingsDialog(
                     valueRange = 0.8f..1.2f,
                     steps = 3,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = SliderDefaults.colors(thumbColor = EchoAccentGreen, activeTrackColor = EchoAccentGreen, inactiveTrackColor = EchoBgMuted)
+                    colors = SliderDefaults.colors(thumbColor = colors.accentGreen, activeTrackColor = colors.accentGreen, inactiveTrackColor = colors.bgMuted)
                 )
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Text("느리게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
-                    Text("빠르게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = EchoTextTertiary)
+                    Text("느리게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = colors.textTertiary)
+                    Text("빠르게", fontSize = 12.sp, fontFamily = OutfitFontFamily, color = colors.textTertiary)
                 }
                 Spacer(Modifier.height(20.dp))
-                Text("음성 톤", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("음성 톤", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
                 Spacer(Modifier.height(8.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     listOf("warm" to "따뜻하게", "calm" to "차분하게", "cheerful" to "밝게").forEach { (value, label) ->
@@ -739,7 +801,7 @@ private fun VoiceSettingsDialog(
                             onClick = { tone = value },
                             label = { Text(label, fontSize = 13.sp, fontFamily = OutfitFontFamily) },
                             colors = FilterChipDefaults.filterChipColors(
-                                selectedContainerColor = EchoAccentGreen,
+                                selectedContainerColor = colors.accentGreen,
                                 selectedLabelColor = Color.White
                             )
                         )
@@ -749,12 +811,12 @@ private fun VoiceSettingsDialog(
         },
         confirmButton = {
             TextButton(onClick = { onConfirm(speed, tone) }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -769,27 +831,28 @@ private fun SleepHoursDialog(
     var value by remember { mutableStateOf(initialValue?.toString() ?: "") }
     var error by remember { mutableStateOf<String?>(null) }
 
+    val colors = LocalEchoColors.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
-        title = { Text("선호 수면 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary) },
+        containerColor = colors.bgCard,
+        title = { Text("선호 수면 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary) },
         text = {
             OutlinedTextField(
                 value = value,
                 onValueChange = { value = it; error = null },
-                label = { Text("시간 (1~24)", fontFamily = OutfitFontFamily, color = EchoTextTertiary, fontSize = 14.sp) },
+                label = { Text("시간 (1~24)", fontFamily = OutfitFontFamily, color = colors.textTertiary, fontSize = 14.sp) },
                 singleLine = true,
                 isError = error != null,
                 supportingText = error?.let { { Text(it, fontFamily = OutfitFontFamily, fontSize = 13.sp) } },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 shape = RoundedCornerShape(12.dp),
                 colors = OutlinedTextFieldDefaults.colors(
-                    focusedContainerColor = EchoBgMuted,
-                    unfocusedContainerColor = EchoBgMuted,
-                    focusedBorderColor = EchoAccentGreen,
-                    unfocusedBorderColor = EchoBorderSubtle,
-                    focusedTextColor = EchoTextPrimary,
-                    unfocusedTextColor = EchoTextPrimary
+                    focusedContainerColor = colors.bgMuted,
+                    unfocusedContainerColor = colors.bgMuted,
+                    focusedBorderColor = colors.accentGreen,
+                    unfocusedBorderColor = colors.borderSubtle,
+                    focusedTextColor = colors.textPrimary,
+                    unfocusedTextColor = colors.textPrimary
                 ),
                 modifier = Modifier.fillMaxWidth()
             )
@@ -804,12 +867,12 @@ private fun SleepHoursDialog(
                     else onConfirm(h)
                 }
             }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -827,11 +890,12 @@ private fun DatePickerFieldDialog(
     var day by remember { mutableStateOf(initial.third) }
     var error by remember { mutableStateOf<String?>(null) }
 
+    val colors = LocalEchoColors.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
+        containerColor = colors.bgCard,
         title = {
-            Text("생년월일", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary)
+            Text("생년월일", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary)
         },
         text = {
             Column {
@@ -844,7 +908,7 @@ private fun DatePickerFieldDialog(
                 )
                 error?.let {
                     Spacer(Modifier.height(6.dp))
-                    Text(it, fontSize = 13.sp, fontFamily = OutfitFontFamily, color = EchoAccentRed)
+                    Text(it, fontSize = 13.sp, fontFamily = OutfitFontFamily, color = colors.accentRed)
                 }
             }
         },
@@ -856,12 +920,12 @@ private fun DatePickerFieldDialog(
                     else -> error = "올바른 날짜를 입력해주세요"
                 }
             }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -875,23 +939,24 @@ private fun TimePickerFieldDialog(
 ) {
     var value by remember { mutableStateOf(if (!current.isNullOrBlank()) current else "09:00") }
 
+    val colors = LocalEchoColors.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
+        containerColor = colors.bgCard,
         title = {
-            Text("대화 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary)
+            Text("대화 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary)
         },
         text = {
             EchoTimePickerContent(value = value, onValueChange = { value = it })
         },
         confirmButton = {
             TextButton(onClick = { onSelected(value) }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -905,11 +970,12 @@ private fun LocationStartTimeDialog(
 ) {
     var value by remember { mutableStateOf(current.ifBlank { "06:00" }) }
 
+    val colors = LocalEchoColors.current
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = EchoBgCard,
+        containerColor = colors.bgCard,
         title = {
-            Text("위치 수집 시작 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = EchoTextPrimary)
+            Text("위치 수집 시작 시간", fontFamily = OutfitFontFamily, fontWeight = FontWeight.SemiBold, color = colors.textPrimary)
         },
         text = {
             Column {
@@ -917,7 +983,7 @@ private fun LocationStartTimeDialog(
                     text = "매일 이 시간에 위치 수집을 시작합니다.\n대화를 시작하면 수집이 종료됩니다.",
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
-                    color = EchoTextSecondary,
+                    color = colors.textSecondary,
                     lineHeight = 20.sp
                 )
                 Spacer(Modifier.height(16.dp))
@@ -926,12 +992,12 @@ private fun LocationStartTimeDialog(
         },
         confirmButton = {
             TextButton(onClick = { onSelected(value) }) {
-                Text("확인", fontFamily = OutfitFontFamily, color = EchoAccentGreen, fontWeight = FontWeight.SemiBold)
+                Text("확인", fontFamily = OutfitFontFamily, color = colors.accentGreen, fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("취소", fontFamily = OutfitFontFamily, color = EchoTextSecondary)
+                Text("취소", fontFamily = OutfitFontFamily, color = colors.textSecondary)
             }
         }
     )
@@ -941,12 +1007,13 @@ private fun LocationStartTimeDialog(
 private fun CardHeader(
     icon: ImageVector,
     title: String,
-    iconTint: Color = EchoAccentGreen
+    iconTint: Color? = null
 ) {
+    val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(EchoBgMuted.copy(alpha = 0.5f))
+            .background(colors.bgMuted.copy(alpha = 0.5f))
             .padding(horizontal = 20.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -954,7 +1021,7 @@ private fun CardHeader(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = iconTint,
+            tint = iconTint ?: colors.accentGreen,
             modifier = Modifier.size(24.dp)
         )
         Text(
@@ -962,7 +1029,7 @@ private fun CardHeader(
             fontSize = 18.sp,
             fontWeight = FontWeight.SemiBold,
             fontFamily = OutfitFontFamily,
-            color = EchoTextPrimary
+            color = colors.textPrimary
         )
     }
 }
@@ -973,6 +1040,7 @@ private fun NavigationRow(
     description: String,
     onClick: () -> Unit
 ) {
+    val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -981,15 +1049,15 @@ private fun NavigationRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 16.sp, fontFamily = OutfitFontFamily, color = EchoTextPrimary)
+            Text(label, fontSize = 16.sp, fontFamily = OutfitFontFamily, color = colors.textPrimary)
             Spacer(Modifier.height(2.dp))
             Text(
                 text = description,
                 fontSize = 14.sp,
                 fontFamily = OutfitFontFamily,
-                color = EchoTextSecondary
+                color = colors.textSecondary
             )
         }
-        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = EchoTextTertiary)
+        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
@@ -1,0 +1,51 @@
+package com.example.graduation_project.ui.theme
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+data class EchoColorScheme(
+    val bgPage: Color,
+    val bgCard: Color,
+    val bgMuted: Color,
+    val accentGreen: Color,
+    val accentBlue: Color,
+    val accentCoral: Color,
+    val accentRed: Color,
+    val textPrimary: Color,
+    val textSecondary: Color,
+    val textTertiary: Color,
+    val borderSubtle: Color,
+    val tabInactive: Color,
+)
+
+val defaultEchoColors = EchoColorScheme(
+    bgPage        = Color(0xFFF5F4F1),
+    bgCard        = Color(0xFFFFFFFF),
+    bgMuted       = Color(0xFFEDECEA),
+    accentGreen   = Color(0xFF3D8A5A),
+    accentBlue    = Color(0xFF4A90D9),
+    accentCoral   = Color(0xFFD89575),
+    accentRed     = Color(0xFFD08068),
+    textPrimary   = Color(0xFF1A1918),
+    textSecondary = Color(0xFF6D6C6A),
+    textTertiary  = Color(0xFF9C9B99),
+    borderSubtle  = Color(0xFFE5E4E1),
+    tabInactive   = Color(0xFFA8A7A5),
+)
+
+val highContrastEchoColors = EchoColorScheme(
+    bgPage        = Color(0xFFFFFFFF),
+    bgCard        = Color(0xFFFFFFFF),
+    bgMuted       = Color(0xFFF0F0EE),
+    accentGreen   = Color(0xFF2E6B47),
+    accentBlue    = Color(0xFF1A6FBF),
+    accentCoral   = Color(0xFFB86A4A),
+    accentRed     = Color(0xFFB05030),
+    textPrimary   = Color(0xFF0A0908),
+    textSecondary = Color(0xFF3D3C3A),
+    textTertiary  = Color(0xFF5A5957),
+    borderSubtle  = Color(0xFFBBBAB6),
+    tabInactive   = Color(0xFF6B6A68),
+)
+
+val LocalEchoColors = compositionLocalOf { defaultEchoColors }

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/Theme.kt
@@ -4,7 +4,11 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import com.example.graduation_project.presentation.settings.DisplaySettings
 
 private val LightColorScheme = lightColorScheme(
     primary             = EchoAccentGreen,
@@ -29,11 +33,23 @@ private val LightColorScheme = lightColorScheme(
 fun Graduation_projectTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = false,
+    displaySettings: DisplaySettings = DisplaySettings(),
     content: @Composable () -> Unit
 ) {
-    MaterialTheme(
-        colorScheme = LightColorScheme,
-        typography = Typography,
-        content = content
-    )
+    val echoColors = if (displaySettings.isHighContrast) highContrastEchoColors else defaultEchoColors
+    val currentDensity = LocalDensity.current
+
+    CompositionLocalProvider(
+        LocalEchoColors provides echoColors,
+        LocalDensity provides Density(
+            density = currentDensity.density,
+            fontScale = displaySettings.fontScale
+        )
+    ) {
+        MaterialTheme(
+            colorScheme = LightColorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- **글씨 크기 3단계** (소 0.85x / 중 1.0x / 대 1.15x): 설정 탭 FilterChip으로 선택 → 앱 전체 `.sp` 값 즉시 확대/축소 (LocalDensity fontScale override)
- **색상 테마 2가지** (기본 베이지 / 높은 대비 화이트): CompositionLocal 교체로 즉시 반영, WCAG 2.1 AA 기준 대비율 충족
- **설정 영속**: SharedPreferences로 저장 → 앱 재시작 후에도 유지
- **레거시 alias 안전**: `RecordingIndicator`, `PulseEffect`가 참조하는 `ListeningTeal`·`PlayingAmber` 등은 `Color.kt`를 그대로 유지해 미수정 처리

## Changes

| 파일 | 내용 |
|------|------|
| `ui/theme/EchoColors.kt` (신규) | `EchoColorScheme` data class, 기본/높은대비 프리셋, `LocalEchoColors` |
| `data/local/DisplaySettingsStorage.kt` (신규) | SharedPreferences 기반 설정 저장 |
| `presentation/settings/DisplaySettingsViewModel.kt` (신규) | AndroidViewModel + Factory 패턴 |
| `ui/theme/Theme.kt` | `displaySettings` 파라미터 추가, `CompositionLocalProvider` 적용 |
| `MainActivity.kt` | `DisplaySettingsViewModel` 연결 |
| `presentation/settings/SettingsScreen.kt` | 화면 설정 섹션 추가 + 전체 색상 마이그레이션 |
| 나머지 화면 10개 | `LocalEchoColors.current` 마이그레이션 |

## Test plan

- [ ] 설정 → 화면 설정 → **대** 선택 → 앱 전체 텍스트 즉시 확대 확인
- [ ] **높은 대비** 선택 → 배경 흰색, 텍스트 진하게 변경 확인
- [ ] 앱 종료 후 재시작 → 설정값 유지 확인
- [ ] 홈/설정/대화기록/대화/온보딩/로그인 각 화면 색상 일관 적용 확인
- [ ] `RecordingIndicator` 펄스 애니메이션 색상 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)