### PR TITLE
fix(auth): 로그인 버튼 클릭 시 앱 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginScreen.kt
@@ -45,7 +45,7 @@ import com.example.graduation_project.ui.theme.OutfitFontFamily
 fun LoginScreen(
     onLoginSuccess: () -> Unit,
     onNavigateToSignup: () -> Unit,
-    viewModel: LoginViewModel = viewModel()
+    viewModel: LoginViewModel = viewModel(factory = LoginViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
@@ -2,7 +2,11 @@ package com.example.graduation_project.presentation.auth
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.TokenStorage
@@ -76,5 +80,15 @@ class LoginViewModel(application: Application) : AndroidViewModel(application) {
         is ApiException.NetworkError -> "인터넷 연결을 확인해주세요"
         is ApiException.ServerError -> "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요"
         is ApiException.UnknownError -> "알 수 없는 오류가 발생했습니다"
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return LoginViewModel(application) as T
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `LoginViewModel`에 `ViewModelProvider.Factory` 추가
- `LoginScreen`에서 `viewModel(factory = LoginViewModel.Factory)` 명시

## 원인

Compose의 `viewModel()` 호출 시 `CreationExtras`에서 `APPLICATION_KEY`를 찾지 못해 크래시 발생.
`AndroidViewModel`을 상속하는 ViewModel은 명시적 Factory 없이 인스턴스화할 수 없음.

동일한 버그가 `SignupViewModel`에서 이미 발생했으며 commit `c53ba4d`에서 수정된 이력이 있음.
`LoginViewModel`에 동일한 수정이 누락된 상태였음.

## Test plan

- [ ] 로그인 화면 진입 → 아이디/비밀번호 입력 → 로그인 버튼 클릭
- [ ] 크래시 없이 홈 화면으로 이동하는지 확인
- [ ] 잘못된 아이디/비밀번호 입력 시 에러 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)