### PR TITLE
fix(auth): 회원가입 버튼 클릭 시 앱 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupScreen.kt
@@ -40,7 +40,7 @@ import com.example.graduation_project.ui.theme.OutfitFontFamily
 @Composable
 fun SignupScreen(
     onSignupSuccess: () -> Unit,
-    viewModel: SignupViewModel = viewModel()
+    viewModel: SignupViewModel = viewModel(factory = SignupViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
@@ -2,7 +2,11 @@ package com.example.graduation_project.presentation.auth
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.TokenStorage
@@ -114,5 +118,15 @@ class SignupViewModel(application: Application) : AndroidViewModel(application) 
         value.isBlank() -> "이름을 입력해주세요"
         value.length > 50 -> "이름은 50자 이하로 입력해주세요"
         else -> null
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return SignupViewModel(application) as T
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `SignupViewModel`에 `ViewModelProvider.Factory` 추가
- `SignupScreen`에서 `viewModel(factory = SignupViewModel.Factory)` 명시

## 원인

develop merge(PR #295, #296 등 62개 커밋) 과정에서 기존에 있던
`SignupViewModel.Factory`가 덮어써져 누락됨.

`LoginViewModel` 수정(PR #315)과 동일한 패턴으로 `SignupViewModel`에도 재적용.

## Test plan

- [ ] 회원가입 화면 진입 → 아이디/비밀번호/이름 입력 → 회원가입 버튼 클릭
- [ ] 크래시 없이 온보딩 화면으로 이동하는지 확인
- [ ] 이미 존재하는 아이디로 시도 시 에러 메시지 표시 확인
- [ ] 로그인 화면에서 로그인 버튼 클릭 정상 동작 확인 (기존 PR #315 수정 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)