### PR TITLE
fix(auth): 로그인/회원가입 이후 화면 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryScreen.kt
@@ -37,7 +37,7 @@ import com.example.graduation_project.ui.theme.OutfitFontFamily
 @Composable
 fun ConversationHistoryScreen(
     onConversationClick: (String) -> Unit,
-    viewModel: ConversationHistoryViewModel = viewModel()
+    viewModel: ConversationHistoryViewModel = viewModel(factory = ConversationHistoryViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryViewModel.kt
@@ -2,7 +2,11 @@ package com.example.graduation_project.presentation.history
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.entity.MessageEntity
 import com.example.graduation_project.presentation.model.ConversationSummary
@@ -79,6 +83,16 @@ class ConversationHistoryViewModel(application: Application) : AndroidViewModel(
     private fun formatTime(timestamp: Long): String {
         val sdf = SimpleDateFormat("a h:mm", Locale.KOREAN)
         return sdf.format(Date(timestamp))
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return ConversationHistoryViewModel(application) as T
+            }
+        }
     }
 
     private fun mockSummaries(): List<ConversationSummary> {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -70,7 +70,7 @@ private val stepHints = listOf(
 @Composable
 fun OnboardingScreen(
     onOnboardingComplete: () -> Unit,
-    viewModel: OnboardingViewModel = viewModel()
+    viewModel: OnboardingViewModel = viewModel(factory = OnboardingViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -2,7 +2,11 @@ package com.example.graduation_project.presentation.onboarding
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiResult
@@ -143,4 +147,14 @@ class OnboardingViewModel(
     }
 
     fun dismissError() = _uiState.update { it.copy(errorMessage = null) }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val application = checkNotNull(extras[APPLICATION_KEY])
+                return OnboardingViewModel(application) as T
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `OnboardingViewModel`에 `ViewModelProvider.Factory` 추가
- `ConversationHistoryViewModel`에 `ViewModelProvider.Factory` 추가
- `OnboardingScreen`, `ConversationHistoryScreen`에서 `viewModel(factory = ...)` 적용

## 원인

`LoginViewModel`과 `SignupViewModel`의 Factory는 이전 커밋에서 수정됐지만, 로그인/회원가입 성공 후 이동하는 화면들에 동일한 문제가 남아 있었음.

`AndroidViewModel(application)`을 상속하는 ViewModel을 `viewModel()` (Factory 없이) 로 생성할 경우, 기본 Factory가 생성자 파라미터를 처리하지 못해 크래시 발생.

**크래시 경로:**
- 로그인 성공 → `OnboardingScreen` → `OnboardingViewModel` 크래시
- 로그인 성공 → 홈 → 기록 탭 → `ConversationHistoryScreen` → `ConversationHistoryViewModel` 크래시
- 회원가입 성공 → `OnboardingScreen` → `OnboardingViewModel` 크래시

## Test plan

- [ ] 로그인 성공 후 온보딩 화면 진입 확인
- [ ] 회원가입 성공 후 온보딩 화면 진입 확인
- [ ] 홈 진입 후 기록 탭 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)