### PR TITLE
fix(conversation): 대화시작 화면 중복 제거 - 홈에서 진입 시 자동 시작

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -70,6 +70,11 @@ fun ConversationScreen(
         }
     }
 
+    // 화면 진입 시 자동으로 대화 시작
+    LaunchedEffect(Unit) {
+        viewModel.startConversation()
+    }
+
     // Ended 상태가 되면 자동으로 뒤로 이동
     LaunchedEffect(uiState.conversationState) {
         if (uiState.conversationState is ConversationState.Ended) {


### PR DESCRIPTION
## Summary
- 홈 화면 "대화 시작" 버튼 클릭 후 ConversationScreen 진입 시 Idle 화면(대화시작 버튼 재노출)이 한 번 더 나오는 문제 수정
- `LaunchedEffect(Unit)`으로 화면 진입 즉시 `startConversation()` 자동 호출
- 사용자는 홈 버튼 한 번만 누르면 바로 대화가 시작됨

## Test plan
- [ ] 홈 화면 "대화 시작" 버튼 클릭 → ConversationScreen에서 Idle 화면 없이 바로 대화 시작되는지 확인
- [ ] 대화 종료 후 홈으로 돌아오는지 확인
- [ ] 대화 종료 다이얼로그 정상 동작 확인