### PR TITLE
fix(display): 글씨크기·테마 설정 즉시 반영 안 되는 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -64,7 +64,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val displaySettings by displayViewModel.settings.collectAsState()
             Graduation_projectTheme(displaySettings = displaySettings) {
-                AppNavHost(navigateTo = navigateTo)
+                AppNavHost(navigateTo = navigateTo, displayViewModel = displayViewModel)
             }
         }
     }
@@ -88,7 +88,7 @@ private object Routes {
 private val tabRoutes = EchoTab.entries.map { it.route }.toSet()
 
 @Composable
-private fun AppNavHost(navigateTo: String? = null) {
+private fun AppNavHost(navigateTo: String? = null, displayViewModel: DisplaySettingsViewModel) {
     val context = LocalContext.current
     val application = context.applicationContext as Application
     val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application)) }
@@ -237,6 +237,7 @@ private fun AppNavHost(navigateTo: String? = null) {
             // 설정 탭
             composable(EchoTab.SETTINGS.route) {
                 SettingsScreen(
+                    displayViewModel = displayViewModel,
                     onLogout = {
                         coroutineScope.launch {
                             withContext(Dispatchers.IO) { authRepository.logout() }

--- a/android/app/src/main/java/com/example/graduation_project/data/local/DisplaySettingsStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/DisplaySettingsStorage.kt
@@ -18,8 +18,8 @@ class DisplaySettingsStorage(context: Context) {
         private const val PREF_NAME = "display_settings"
         private const val KEY_FONT_SCALE = "font_scale"
         private const val KEY_HIGH_CONTRAST = "high_contrast"
-        const val SCALE_SMALL = 0.85f
+        const val SCALE_SMALL = 0.8f
         const val SCALE_MEDIUM = 1.0f
-        const val SCALE_LARGE = 1.15f
+        const val SCALE_LARGE = 1.3f
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
@@ -34,18 +34,18 @@ val defaultEchoColors = EchoColorScheme(
 )
 
 val highContrastEchoColors = EchoColorScheme(
-    bgPage        = Color(0xFFFFFFFF),
+    bgPage        = Color(0xFFFFFBF5),  // 따뜻한 오프화이트 — 노안 눈부심 감소
     bgCard        = Color(0xFFFFFFFF),
-    bgMuted       = Color(0xFFF0F0EE),
-    accentGreen   = Color(0xFF2E6B47),
-    accentBlue    = Color(0xFF1A6FBF),
-    accentCoral   = Color(0xFFB86A4A),
-    accentRed     = Color(0xFFB05030),
-    textPrimary   = Color(0xFF0A0908),
-    textSecondary = Color(0xFF3D3C3A),
-    textTertiary  = Color(0xFF5A5957),
-    borderSubtle  = Color(0xFFBBBAB6),
-    tabInactive   = Color(0xFF6B6A68),
+    bgMuted       = Color(0xFFEEECE8),
+    accentGreen   = Color(0xFF1A5C38),  // 채도 유지하며 어둡게 — 버튼 가독성
+    accentBlue    = Color(0xFF0D4D9C),
+    accentCoral   = Color(0xFFA84A25),  // 따뜻한 강조색 명확히
+    accentRed     = Color(0xFF962010),
+    textPrimary   = Color(0xFF0F0E0D),  // 준검정 — 할레이션 없이 선명
+    textSecondary = Color(0xFF2A2928),  // 확실히 읽힘
+    textTertiary  = Color(0xFF4A4947),  // 노안 인식 한계 수준 확보
+    borderSubtle  = Color(0xFF888683),  // 칸 구분선 명확히
+    tabInactive   = Color(0xFF555453),  // 비활성 탭 인식
 )
 
 val LocalEchoColors = compositionLocalOf { defaultEchoColors }

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/Theme.kt
@@ -43,7 +43,7 @@ fun Graduation_projectTheme(
         LocalEchoColors provides echoColors,
         LocalDensity provides Density(
             density = currentDensity.density,
-            fontScale = displaySettings.fontScale
+            fontScale = currentDensity.fontScale * displaySettings.fontScale
         )
     ) {
         MaterialTheme(


### PR DESCRIPTION
## Summary

- `SettingsScreen`이 `NavBackStackEntry` 범위 `DisplaySettingsViewModel`을 별도 생성하여 `MainActivity` 테마가 갱신되지 않던 근본 원인 수정
- `fontScale`을 시스템 접근성 설정과 곱하여 반영 (기존: 앱 설정으로 완전 대체)
- 글씨크기 단계 범위 확대 (소 0.85→0.8 / 대 1.15→1.3)
- `highContrastEchoColors` 노안 친화 색상으로 재설계 (눈부심 감소·텍스트 계층 명확화)

## 원인 분석

```
기존 문제 흐름:
SettingsScreen.viewModel() → NavBackStackEntry 범위 VM (새 인스턴스)
                                      ↓ SharedPreferences 저장
MainActivity.displayViewModel → Activity 범위 VM (별도 인스턴스, StateFlow 미갱신)
                                      ↓
Graduation_projectTheme → 재구성 안 됨 → 화면 변화 없음
```

```
수정 후 흐름:
MainActivity.displayViewModel → AppNavHost 파라미터로 전달
                                      ↓
SettingsScreen(displayViewModel = displayViewModel) → 동일 인스턴스 사용
                                      ↓
StateFlow 갱신 → Graduation_projectTheme 재구성 → 즉시 반영 ✓
```

## Test plan

- [ ] 설정 화면에서 글씨크기 변경 후 홈·대화 화면으로 이동 시 즉시 반영 확인
- [ ] 고대비 테마 토글 시 배경 외 텍스트·테두리 색상도 명확히 변경 확인
- [ ] 앱 재시작 후 설정 유지 확인
- [ ] 시스템 글씨크기 1.2배 상태에서 앱 "대" 선택 시 두 배율이 곱해지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)