### PR TITLE
feat: 설정 화면 개선 및 위치 수집 상태 토글 추가

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -64,7 +64,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val displaySettings by displayViewModel.settings.collectAsState()
             Graduation_projectTheme(displaySettings = displaySettings) {
-                AppNavHost(navigateTo = navigateTo)
+                AppNavHost(navigateTo = navigateTo, displayViewModel = displayViewModel)
             }
         }
     }
@@ -88,7 +88,7 @@ private object Routes {
 private val tabRoutes = EchoTab.entries.map { it.route }.toSet()
 
 @Composable
-private fun AppNavHost(navigateTo: String? = null) {
+private fun AppNavHost(navigateTo: String? = null, displayViewModel: DisplaySettingsViewModel) {
     val context = LocalContext.current
     val application = context.applicationContext as Application
     val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application)) }
@@ -244,7 +244,8 @@ private fun AppNavHost(navigateTo: String? = null) {
                                 popUpTo(0) { inclusive = true }
                             }
                         }
-                    }
+                    },
+                    displayViewModel = displayViewModel
                 )
             }
 

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
@@ -50,6 +50,7 @@ class LocationCollectionService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
         Log.d(TAG, "LocationCollectionService 생성")
 
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
@@ -93,6 +94,7 @@ class LocationCollectionService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        isRunning = false
         Log.d(TAG, "LocationCollectionService 종료")
         collectionJob?.cancel()
     }
@@ -144,7 +146,7 @@ class LocationCollectionService : Service() {
         )
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("에코")
+            .setContentTitle("📍 에코")
             .setContentText("오늘 방문 장소를 기록하고 있어요")
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentIntent(pendingIntent)
@@ -253,8 +255,8 @@ class LocationCollectionService : Service() {
         )
 
         val notification = NotificationCompat.Builder(this, GREETING_CHANNEL_ID)
-            .setContentTitle("좋은 아침이에요! ☀️")
-            .setContentText("오늘 하루도 방문 장소를 기록할게요")
+            .setContentTitle("☀️ 오늘도 행복한 하루 되세요!")
+            .setContentText("조금 이따 대화 시간에 만나요!")
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
@@ -278,6 +280,11 @@ class LocationCollectionService : Service() {
         private const val GREETING_TIMEOUT_MS = 10 * 60 * 1000L     // 10분
 
         const val ACTION_STOP = "com.example.graduation_project.STOP_LOCATION_SERVICE"
+
+        // 서비스 실행 상태
+        @Volatile
+        var isRunning: Boolean = false
+            private set
 
         /**
          * 서비스 시작

--- a/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
@@ -98,7 +98,11 @@ fun UnifiedPermissionHandler(
     // 알림 권한 요청 런처 (Android 13+)
     val notificationLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
-    ) { _ ->
+    ) { granted ->
+        // 알림 권한 허용 시 정확한 알람 권한도 요청
+        if (granted && !PermissionChecker.hasExactAlarmPermission(context)) {
+            PermissionChecker.openExactAlarmSettings(context)
+        }
         currentStep = PermissionStep.HEALTH_CONNECT
     }
 
@@ -312,5 +316,30 @@ object PermissionChecker {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         context.startActivity(intent)
+    }
+
+    /**
+     * 정확한 알람 권한 확인 (Android 12+)
+     */
+    fun hasExactAlarmPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as android.app.AlarmManager
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+    }
+
+    /**
+     * 정확한 알람 권한 설정 화면 열기 (Android 12+)
+     */
+    fun openExactAlarmSettings(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -82,6 +82,7 @@ import com.example.graduation_project.presentation.common.buildBirthdayString
 import com.example.graduation_project.presentation.common.parseBirthday
 import com.example.graduation_project.presentation.health.openHealthConnectSettings
 import com.example.graduation_project.data.local.DisplaySettingsStorage
+import com.example.graduation_project.presentation.permission.PermissionChecker
 import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
@@ -390,8 +391,7 @@ fun SettingsScreen(
                         label = "건강 데이터 권한",
                         isGranted = uiState.hasHealthConnectPermission,
                         grantedText = "허용됨",
-                        deniedText = "탭하여 설정",
-                        onClick = { openHealthConnectSettings(context) }
+                        deniedText = "허용 필요"
                     )
                 }
             }
@@ -416,13 +416,14 @@ fun SettingsScreen(
                         label = "위치 권한",
                         isGranted = uiState.hasBackgroundLocationPermission,
                         grantedText = "항상 허용됨",
-                        deniedText = "탭하여 설정",
-                        onClick = {
-                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                data = Uri.fromParts("package", context.packageName, null)
-                            }
-                            context.startActivity(intent)
-                        }
+                        deniedText = "허용 필요"
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 위치 수집 상태 토글
+                    LocationCollectionToggleRow(
+                        isRunning = uiState.isLocationCollectionRunning,
+                        hasPermission = uiState.hasBackgroundLocationPermission,
+                        onToggle = { viewModel.toggleLocationCollection() }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow(
@@ -449,22 +450,12 @@ fun SettingsScreen(
                         title = "앱 설정",
                         iconTint = colors.textSecondary
                     )
-                    // 앱 알림 설정
-                    NavigationRow(
-                        label = "앱 알림 설정",
-                        description = "시스템 알림 설정으로 이동",
-                        onClick = {
-                            val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-                                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-                                }
-                            } else {
-                                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                    data = Uri.fromParts("package", context.packageName, null)
-                                }
-                            }
-                            context.startActivity(intent)
-                        }
+                    // 알림 권한 표시
+                    PermissionStatusRow(
+                        label = "알림 권한",
+                        isGranted = uiState.hasNotificationPermission,
+                        grantedText = "허용됨",
+                        deniedText = "허용 필요"
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 앱 권한 설정
@@ -631,13 +622,13 @@ private fun PermissionStatusRow(
     isGranted: Boolean,
     grantedText: String,
     deniedText: String,
-    onClick: () -> Unit
+    onClick: (() -> Unit)? = null
 ) {
     val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
             .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -689,6 +680,54 @@ private fun AlarmToggleRow(
         Switch(
             checked = enabled,
             onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = colors.accentGreen,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = colors.bgMuted
+            )
+        )
+    }
+}
+
+@Composable
+private fun LocationCollectionToggleRow(
+    isRunning: Boolean,
+    hasPermission: Boolean,
+    onToggle: () -> Unit
+) {
+    val colors = LocalEchoColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("위치 수집 상태", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+            Spacer(Modifier.height(3.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .background(
+                            color = if (isRunning) colors.accentGreen else colors.textTertiary,
+                            shape = androidx.compose.foundation.shape.CircleShape
+                        )
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = if (isRunning) "수집 중" else "중지됨",
+                    fontSize = 17.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = if (isRunning) colors.accentGreen else colors.textTertiary
+                )
+            }
+        }
+        Switch(
+            checked = isRunning,
+            onCheckedChange = { onToggle() },
+            enabled = hasPermission,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = Color.White,
                 checkedTrackColor = colors.accentGreen,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.model.UserPreferences
@@ -38,10 +39,12 @@ data class SettingsUiState(
     val alarmEnabled: Boolean = false,
     // 위치 수집 설정
     val locationCollectionStartTime: String = "06:00",
+    val isLocationCollectionRunning: Boolean = false,
     // 권한 상태
     val hasLocationPermission: Boolean = false,
     val hasBackgroundLocationPermission: Boolean = false,
     val hasHealthConnectPermission: Boolean = false,
+    val hasNotificationPermission: Boolean = true,
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val savedMessage: String? = null,
@@ -76,14 +79,17 @@ class SettingsViewModel(
         val hasLocation = PermissionChecker.hasForegroundLocationPermission(context)
         val hasBackgroundLocation = PermissionChecker.hasBackgroundLocationPermission(context)
         val hasHealthConnect = PermissionChecker.isHealthConnectAvailable(context)
+        val hasNotification = PermissionChecker.hasNotificationPermission(context)
 
         _uiState.update {
             it.copy(
                 alarmEnabled = alarmEnabled,
                 locationCollectionStartTime = locationStartTime,
+                isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = hasLocation,
                 hasBackgroundLocationPermission = hasBackgroundLocation,
-                hasHealthConnectPermission = hasHealthConnect
+                hasHealthConnectPermission = hasHealthConnect,
+                hasNotificationPermission = hasNotification
             )
         }
 
@@ -106,15 +112,31 @@ class SettingsViewModel(
 
         _uiState.update {
             it.copy(
+                isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = PermissionChecker.hasForegroundLocationPermission(context),
                 hasBackgroundLocationPermission = currentBackgroundPermission,
-                hasHealthConnectPermission = PermissionChecker.isHealthConnectAvailable(context)
+                hasHealthConnectPermission = PermissionChecker.isHealthConnectAvailable(context),
+                hasNotificationPermission = PermissionChecker.hasNotificationPermission(context)
             )
         }
 
         // 위치 권한이 새로 허용되었으면 서비스 시작
         if (!previousBackgroundPermission && currentBackgroundPermission) {
             LocationScheduler.enableLocationCollection(context)
+        }
+    }
+
+    /**
+     * 위치 수집 시작/중지 토글
+     */
+    fun toggleLocationCollection() {
+        val context = getApplication<Application>()
+        if (LocationCollectionService.isRunning) {
+            LocationCollectionService.stop(context)
+            _uiState.update { it.copy(isLocationCollectionRunning = false, savedMessage = "위치 수집이 중지되었습니다") }
+        } else {
+            LocationCollectionService.start(context)
+            _uiState.update { it.copy(isLocationCollectionRunning = true, savedMessage = "위치 수집이 시작되었습니다") }
         }
     }
 


### PR DESCRIPTION
## Summary
- 글씨 크기/색상 테마 변경 시 즉시 반영되도록 수정 (ViewModel 인스턴스 공유)
- 위치 수집 상태 표시 및 수동 시작/중지 토글 추가
- 권한 표시 UI 개선 (알림, 위치, 건강 데이터 - 표시만, 클릭 불가)
- 알림 권한 요청 시 정확한 알람 권한도 함께 요청
- 아침 알림 문구 개선 ("☀️ 오늘도 행복한 하루 되세요!")
- Foreground 서비스 알림에 아이콘 추가 ("📍 에코")

## Changes
| 파일 | 변경 내용 |
|------|----------|
| MainActivity.kt | DisplaySettingsViewModel을 SettingsScreen에 전달 |
| LocationCollectionService.kt | isRunning 상태 추가, 알림 문구 개선 |
| UnifiedPermissionHandler.kt | 알림 권한 허용 시 정확한 알람 권한 요청 |
| SettingsScreen.kt | 위치 수집 토글 UI, 권한 표시 UI 개선 |
| SettingsViewModel.kt | 위치 수집 토글 기능, 알림 권한 상태 추가 |

## Test plan
- [ ] 글씨 크기/색상 테마 변경 시 즉시 반영 확인
- [ ] 위치 수집 토글 ON/OFF 동작 확인
- [ ] 권한 표시 UI가 클릭 불가한지 확인
- [ ] 아침 알림 문구 확인
- [ ] Foreground 서비스 알림 아이콘 확인

🤖 Generated with [Claude Code](https://claude.ai/code)