### PR TITLE
feat(home): 홈 화면 날짜/날씨 표시 + 프롬프트 날씨 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
@@ -44,6 +44,8 @@ object ApiClient {
         private set
     lateinit var userApi: UserApi
         private set
+    lateinit var weatherApi: WeatherApi
+        private set
 
     fun init(tokenStorage: TokenStorage) {
         val authenticatedClient = OkHttpClient.Builder()
@@ -64,5 +66,6 @@ object ApiClient {
         conversationApi = authenticatedRetrofit.create(ConversationApi::class.java)
         diaryApi = authenticatedRetrofit.create(DiaryApi::class.java)
         userApi = authenticatedRetrofit.create(UserApi::class.java)
+        weatherApi = authenticatedRetrofit.create(WeatherApi::class.java)
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/api/WeatherApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/WeatherApi.kt
@@ -1,0 +1,14 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.model.WeatherResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WeatherApi {
+
+    @GET("/api/weather")
+    suspend fun getWeather(
+        @Query("lat") lat: Double,
+        @Query("lon") lon: Double
+    ): WeatherResponse
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/model/WeatherModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/WeatherModels.kt
@@ -1,0 +1,9 @@
+package com.example.graduation_project.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherResponse(
+    val description: String,
+    val temperature: Int
+)

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/WeatherRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/WeatherRepository.kt
@@ -1,0 +1,16 @@
+package com.example.graduation_project.data.repository
+
+import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.api.WeatherApi
+import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.model.WeatherResponse
+
+class WeatherRepository(
+    private val weatherApi: WeatherApi = ApiClient.weatherApi
+) {
+
+    suspend fun getWeather(lat: Double, lon: Double): ApiResult<WeatherResponse> {
+        return safeApiCall { weatherApi.getWeather(lat, lon) }
+    }
+}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.graduation_project.presentation.home
 
+import android.app.Application
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,11 +19,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.data.model.WeatherResponse
 import com.example.graduation_project.presentation.conversation.components.AiCharacterImage
 import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
@@ -31,13 +34,17 @@ import com.example.graduation_project.ui.theme.OutfitFontFamily
 @Composable
 fun HomeScreen(
     onStartConversation: () -> Unit,
-    viewModel: HomeViewModel = viewModel()
+    viewModel: HomeViewModel = viewModel(
+        factory = HomeViewModel.Factory(LocalContext.current.applicationContext as Application)
+    )
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     HomeScreenContent(
         userName = uiState.userName,
         conversationTime = uiState.conversationTime,
+        date = uiState.date,
+        weather = uiState.weather,
         onStartConversation = onStartConversation
     )
 }
@@ -46,6 +53,8 @@ fun HomeScreen(
 private fun HomeScreenContent(
     userName: String,
     conversationTime: String? = null,
+    date: String = "",
+    weather: WeatherResponse? = null,
     onStartConversation: () -> Unit
 ) {
     val colors = LocalEchoColors.current
@@ -57,6 +66,27 @@ private fun HomeScreenContent(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        if (date.isNotBlank()) {
+            Text(
+                text = date,
+                fontSize = 16.sp,
+                fontFamily = OutfitFontFamily,
+                color = colors.textSecondary
+            )
+        }
+
+        if (weather != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "${weather.description} · ${weather.temperature}°C",
+                fontSize = 15.sp,
+                fontFamily = OutfitFontFamily,
+                color = colors.textTertiary
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
         AiCharacterImage(size = 180.dp)
 
         Spacer(Modifier.height(32.dp))
@@ -124,6 +154,12 @@ private fun formatConversationTime(time: String): String {
 @Composable
 private fun HomeScreenPreview() {
     Graduation_projectTheme {
-        HomeScreenContent(userName = "김순자", conversationTime = "09:00", onStartConversation = {})
+        HomeScreenContent(
+            userName = "김순자",
+            conversationTime = "09:00",
+            date = "5월 16일 금요일",
+            weather = WeatherResponse(description = "맑음", temperature = 22),
+            onStartConversation = {}
+        )
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
@@ -1,45 +1,82 @@
 package com.example.graduation_project.presentation.home
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.location.LocationManager
+import com.example.graduation_project.data.model.WeatherResponse
 import com.example.graduation_project.data.repository.UserRepository
+import com.example.graduation_project.data.repository.WeatherRepository
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 data class HomeUiState(
     val userName: String = "",
     val conversationTime: String? = null,
+    val date: String = "",
+    val weather: WeatherResponse? = null,
     val isLoading: Boolean = true
 )
 
 class HomeViewModel(
-    private val userRepository: UserRepository = UserRepository()
-) : ViewModel() {
+    application: Application,
+    private val userRepository: UserRepository = UserRepository(),
+    private val weatherRepository: WeatherRepository = WeatherRepository(),
+    private val locationManager: LocationManager = LocationManager(application)
+) : AndroidViewModel(application) {
 
-    private val _uiState = MutableStateFlow(HomeUiState())
+    private val _uiState = MutableStateFlow(HomeUiState(date = formatToday()))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
-        loadUserName()
+        viewModelScope.launch {
+            val userDeferred = async { loadUserPreferences() }
+            val weatherDeferred = async { loadWeather() }
+            userDeferred.await()
+            weatherDeferred.await()
+            _uiState.value = _uiState.value.copy(isLoading = false)
+        }
     }
 
-    private fun loadUserName() {
-        viewModelScope.launch {
-            when (val result = userRepository.getPreferences()) {
-                is ApiResult.Success -> {
-                    _uiState.value = HomeUiState(
-                        userName = result.data.name ?: "",
-                        conversationTime = result.data.conversationTime,
-                        isLoading = false
-                    )
-                }
-                is ApiResult.Error -> {
-                    _uiState.value = HomeUiState(isLoading = false)
-                }
+    private suspend fun loadUserPreferences() {
+        when (val result = userRepository.getPreferences()) {
+            is ApiResult.Success -> {
+                _uiState.value = _uiState.value.copy(
+                    userName = result.data.name ?: "",
+                    conversationTime = result.data.conversationTime
+                )
             }
+            is ApiResult.Error -> Unit
+        }
+    }
+
+    private suspend fun loadWeather() {
+        val location = locationManager.getCurrentLocation() ?: return
+        when (val result = weatherRepository.getWeather(location.latitude, location.longitude)) {
+            is ApiResult.Success -> {
+                _uiState.value = _uiState.value.copy(weather = result.data)
+            }
+            is ApiResult.Error -> Unit
+        }
+    }
+
+    companion object {
+        fun Factory(application: Application) = viewModelFactory {
+            initializer { HomeViewModel(application) }
+        }
+
+        private fun formatToday(): String {
+            val formatter = DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
+            return LocalDate.now().format(formatter)
         }
     }
 }

--- a/server/src/main/java/com/example/echo/common/controller/WeatherController.java
+++ b/server/src/main/java/com/example/echo/common/controller/WeatherController.java
@@ -1,0 +1,31 @@
+package com.example.echo.common.controller;
+
+import com.example.echo.common.auth.CurrentUser;
+import com.example.echo.common.client.WeatherClient;
+import com.example.echo.common.dto.WeatherData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/weather")
+@RequiredArgsConstructor
+public class WeatherController {
+
+    private final WeatherClient weatherClient;
+
+    @GetMapping
+    public ResponseEntity<WeatherData> getWeather(
+            @CurrentUser Long userId,
+            @RequestParam Double lat,
+            @RequestParam Double lon) {
+        WeatherData weather = weatherClient.getCurrentWeather(lat, lon);
+        if (weather == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(weather);
+    }
+}

--- a/server/src/main/java/com/example/echo/context/service/ContextService.java
+++ b/server/src/main/java/com/example/echo/context/service/ContextService.java
@@ -69,13 +69,15 @@ public class ContextService {
         LocationData locationData = locationService.enrichLocationData(rawLocationData);
 
         // 5. 컨텍스트 생성 및 저장
+        Double lat = rawLocationData != null ? rawLocationData.getCurrentLatitude() : null;
+        Double lon = rawLocationData != null ? rawLocationData.getCurrentLongitude() : null;
         UserContext context = UserContext.builder()
                 .userId(userId)
                 .date(LocalDate.now())
                 .conversationHistory(new ArrayList<>())
                 .enrichedHealthData(enrichedHealthData)
                 .preferences(preferences)
-                .todayWeather(weatherClient.getCurrentWeather(null, null))
+                .todayWeather(weatherClient.getCurrentWeather(lat, lon))
                 .locationData(locationData)
                 .lastAccessTime(LocalDateTime.now())
                 .isActive(true)


### PR DESCRIPTION
## Summary
- 홈 화면(대화 시작 전 화면) 캐릭터 위에 오늘 날짜 및 현재 날씨 표시
- 기존 버그 수정: 대화 프롬프트에 날씨가 항상 null로 들어가던 문제 해결

## 변경 내용

### Server
- `WeatherController` 추가: `GET /api/weather?lat={lat}&lon={lon}` 엔드포인트
  - 기존 `WeatherClient`(OpenWeatherMap, Caffeine 30분 캐시) 재사용
- `ContextService` 버그 수정: `getCurrentWeather(null, null)` → `getCurrentWeather(lat, lon)`
  - Android에서 전송된 실제 위경도를 사용하도록 수정

### Android
- `WeatherApi`, `WeatherRepository`, `WeatherModels` 추가
- `HomeViewModel`: `AndroidViewModel`로 전환, GPS 위치 기반 날씨 + 오늘 날짜 로드
- `HomeScreen`: 캐릭터 위에 날짜(`5월 16일 금요일`), 날씨(`맑음 · 22°C`) 표시
  - 위치 권한 없거나 날씨 실패 시 날짜만 표시 (조용히 실패)

## Test plan
- [ ] 홈 화면 진입 시 캐릭터 위에 날짜 표시 확인
- [ ] 위치 권한 허용 상태에서 날씨 정보 표시 확인
- [ ] 위치 권한 없는 상태에서 날짜만 표시되고 크래시 없음 확인
- [ ] 대화 시작 후 프롬프트에 날씨 정보가 null이 아닌 실제 값으로 반영되는지 확인
- [ ] `GET /api/weather?lat=37.5665&lon=126.9780` 호출 시 200 + JSON 응답 확인