### PR TITLE
refactor: 설정 화면 preferences 업데이트를 개별 필드 엔드포인트로 분리

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
@@ -1,8 +1,6 @@
 package com.example.graduation_project.data.api
 
-import com.example.graduation_project.data.model.OnboardingStatusResponse
-import com.example.graduation_project.data.model.User
-import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.model.*
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT
@@ -20,6 +18,36 @@ interface UserApi {
 
     @PUT("/api/users/me/preferences")
     suspend fun updatePreferences(@Body preferences: UserPreferences): UserPreferences
+
+    @PUT("/api/users/me/preferences/birthday")
+    suspend fun updateBirthday(@Body request: BirthdayUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/location")
+    suspend fun updateLocation(@Body request: LocationUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/family-info")
+    suspend fun updateFamilyInfo(@Body request: FamilyInfoUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/guardian-email")
+    suspend fun updateGuardianEmail(@Body request: GuardianEmailUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/occupation")
+    suspend fun updateOccupation(@Body request: OccupationUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/hobbies")
+    suspend fun updateHobbies(@Body request: HobbiesUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/preferred-topics")
+    suspend fun updatePreferredTopics(@Body request: PreferredTopicsUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/voice-settings")
+    suspend fun updateVoiceSettings(@Body request: VoiceSettingsUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/conversation-time")
+    suspend fun updateConversationTime(@Body request: ConversationTimeUpdateRequest): UserPreferences
+
+    @PUT("/api/users/me/preferences/preferred-sleep-hours")
+    suspend fun updatePreferredSleepHours(@Body request: PreferredSleepHoursUpdateRequest): UserPreferences
 
     @GET("/api/users/me/onboarding-status")
     suspend fun getOnboardingStatus(): OnboardingStatusResponse

--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -33,6 +33,36 @@ data class OnboardingStatusResponse(
 )
 
 @Serializable
+data class BirthdayUpdateRequest(val birthday: String?)
+
+@Serializable
+data class LocationUpdateRequest(val location: String?)
+
+@Serializable
+data class FamilyInfoUpdateRequest(val familyInfo: String?)
+
+@Serializable
+data class GuardianEmailUpdateRequest(val guardianEmail: String?)
+
+@Serializable
+data class OccupationUpdateRequest(val occupation: String?)
+
+@Serializable
+data class HobbiesUpdateRequest(val hobbies: String?)
+
+@Serializable
+data class PreferredTopicsUpdateRequest(val preferredTopics: String?)
+
+@Serializable
+data class VoiceSettingsUpdateRequest(val voiceSpeed: Double?, val voiceTone: String?)
+
+@Serializable
+data class ConversationTimeUpdateRequest(val conversationTime: String?)
+
+@Serializable
+data class PreferredSleepHoursUpdateRequest(val preferredSleepHours: Int?)
+
+@Serializable
 data class VoiceSettings(
     val voiceSpeed: Double = 1.0,
     val voiceTone: String = "warm"

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
@@ -4,8 +4,7 @@ import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.api.UserApi
 import com.example.graduation_project.data.api.safeApiCall
-import com.example.graduation_project.data.model.OnboardingStatusResponse
-import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.model.*
 
 class UserRepository(
     private val userApi: UserApi = ApiClient.userApi
@@ -18,6 +17,36 @@ class UserRepository(
     suspend fun updatePreferences(preferences: UserPreferences): ApiResult<UserPreferences> {
         return safeApiCall { userApi.updatePreferences(preferences) }
     }
+
+    suspend fun updateBirthday(birthday: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateBirthday(BirthdayUpdateRequest(birthday)) }
+
+    suspend fun updateLocation(location: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateLocation(LocationUpdateRequest(location)) }
+
+    suspend fun updateFamilyInfo(familyInfo: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateFamilyInfo(FamilyInfoUpdateRequest(familyInfo)) }
+
+    suspend fun updateGuardianEmail(guardianEmail: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateGuardianEmail(GuardianEmailUpdateRequest(guardianEmail)) }
+
+    suspend fun updateOccupation(occupation: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateOccupation(OccupationUpdateRequest(occupation)) }
+
+    suspend fun updateHobbies(hobbies: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateHobbies(HobbiesUpdateRequest(hobbies)) }
+
+    suspend fun updatePreferredTopics(preferredTopics: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updatePreferredTopics(PreferredTopicsUpdateRequest(preferredTopics)) }
+
+    suspend fun updateVoiceSettings(voiceSpeed: Double?, voiceTone: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateVoiceSettings(VoiceSettingsUpdateRequest(voiceSpeed, voiceTone)) }
+
+    suspend fun updateConversationTime(conversationTime: String?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updateConversationTime(ConversationTimeUpdateRequest(conversationTime)) }
+
+    suspend fun updatePreferredSleepHours(preferredSleepHours: Int?): ApiResult<UserPreferences> =
+        safeApiCall { userApi.updatePreferredSleepHours(PreferredSleepHoursUpdateRequest(preferredSleepHours)) }
 
     suspend fun getOnboardingStatus(): ApiResult<OnboardingStatusResponse> {
         return safeApiCall { userApi.getOnboardingStatus() }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -74,8 +74,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.graduation_project.data.model.UserPreferences
-import com.example.graduation_project.data.model.VoiceSettings
 import com.example.graduation_project.presentation.common.BirthdayInputRow
 import com.example.graduation_project.presentation.common.EchoTimePickerContent
 import com.example.graduation_project.presentation.common.buildBirthdayString
@@ -87,32 +85,6 @@ import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
 
 private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
-
-private fun buildPreferences(
-    state: SettingsUiState,
-    birthday: String? = state.birthday,
-    familyInfo: String? = state.familyInfo,
-    guardianEmail: String? = state.guardianEmail,
-    location: String? = state.location,
-    occupation: String? = state.occupation,
-    hobbies: String? = state.hobbies,
-    preferredTopics: String? = state.preferredTopics,
-    voiceSpeed: Double = state.voiceSpeed,
-    voiceTone: String = state.voiceTone,
-    conversationTime: String? = state.conversationTime,
-    preferredSleepHours: Int? = state.preferredSleepHours
-): UserPreferences = UserPreferences(
-    birthday = birthday,
-    familyInfo = familyInfo,
-    guardianEmail = guardianEmail,
-    location = location,
-    occupation = occupation,
-    hobbies = hobbies,
-    preferredTopics = preferredTopics,
-    voiceSettings = VoiceSettings(voiceSpeed = voiceSpeed, voiceTone = voiceTone),
-    conversationTime = conversationTime,
-    preferredSleepHours = preferredSleepHours
-)
 
 @Composable
 fun SettingsScreen(
@@ -494,23 +466,20 @@ fun SettingsScreen(
     }
 
     // 다이얼로그
-    val save: (UserPreferences) -> Unit = {
-        viewModel.savePreferences(it)
-        editingField = null
-    }
+    fun dismiss() { editingField = null }
 
     when (editingField) {
         "birthday" -> DatePickerFieldDialog(
             current = uiState.birthday,
-            onSelected = { save(buildPreferences(uiState, birthday = it)) },
-            onDismiss = { editingField = null }
+            onSelected = { viewModel.updateBirthday(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "familyInfo" -> TextFieldDialog(
             title = "가족 관계",
             hint = "예) 딸, 아들, 배우자",
             initialValue = uiState.familyInfo ?: "",
-            onConfirm = { save(buildPreferences(uiState, familyInfo = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updateFamilyInfo(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "guardianEmail" -> TextFieldDialog(
             title = "보호자 이메일",
@@ -524,60 +493,57 @@ fun SettingsScreen(
                     else -> null
                 }
             },
-            onConfirm = { save(buildPreferences(uiState, guardianEmail = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updateGuardianEmail(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "location" -> TextFieldDialog(
             title = "거주 지역",
             hint = "예) 서울 강남구",
             initialValue = uiState.location ?: "",
-            onConfirm = { save(buildPreferences(uiState, location = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updateLocation(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "occupation" -> TextFieldDialog(
             title = "직업",
             hint = "예) 전직 교사, 은행원",
             initialValue = uiState.occupation ?: "",
-            onConfirm = { save(buildPreferences(uiState, occupation = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updateOccupation(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "hobbies" -> TextFieldDialog(
             title = "취미",
             hint = "예) 정원 가꾸기, 독서",
             initialValue = uiState.hobbies ?: "",
-            onConfirm = { save(buildPreferences(uiState, hobbies = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updateHobbies(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "preferredTopics" -> TextFieldDialog(
             title = "선호 대화 주제",
             hint = "예) 옛날 이야기, 건강",
             initialValue = uiState.preferredTopics ?: "",
-            onConfirm = { save(buildPreferences(uiState, preferredTopics = it.ifBlank { null })) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updatePreferredTopics(it.ifBlank { null }); dismiss() },
+            onDismiss = { dismiss() }
         )
         "voiceSettings" -> VoiceSettingsDialog(
             initialSpeed = uiState.voiceSpeed,
             initialTone = uiState.voiceTone,
-            onConfirm = { speed, tone -> save(buildPreferences(uiState, voiceSpeed = speed, voiceTone = tone)) },
-            onDismiss = { editingField = null }
+            onConfirm = { speed, tone -> viewModel.updateVoiceSettings(speed, tone); dismiss() },
+            onDismiss = { dismiss() }
         )
         "conversationTime" -> TimePickerFieldDialog(
             current = uiState.conversationTime,
-            onSelected = { save(buildPreferences(uiState, conversationTime = it)) },
-            onDismiss = { editingField = null }
+            onSelected = { viewModel.updateConversationTime(it); dismiss() },
+            onDismiss = { dismiss() }
         )
         "sleepHours" -> SleepHoursDialog(
             initialValue = uiState.preferredSleepHours,
-            onConfirm = { save(buildPreferences(uiState, preferredSleepHours = it)) },
-            onDismiss = { editingField = null }
+            onConfirm = { viewModel.updatePreferredSleepHours(it); dismiss() },
+            onDismiss = { dismiss() }
         )
         "locationStartTime" -> LocationStartTimeDialog(
             current = uiState.locationCollectionStartTime,
-            onSelected = {
-                viewModel.setLocationCollectionStartTime(it)
-                editingField = null
-            },
-            onDismiss = { editingField = null }
+            onSelected = { viewModel.setLocationCollectionStartTime(it); dismiss() },
+            onDismiss = { dismiss() }
         )
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -154,19 +154,39 @@ class SettingsViewModel(
         _uiState.update { it.copy(savedMessage = "위치 수집 시간이 설정되었습니다") }
     }
 
-    fun savePreferences(preferences: UserPreferences) {
+    fun updateBirthday(birthday: String?) = updateField { userRepository.updateBirthday(birthday) }
+    fun updateLocation(location: String?) = updateField { userRepository.updateLocation(location) }
+    fun updateFamilyInfo(familyInfo: String?) = updateField { userRepository.updateFamilyInfo(familyInfo) }
+    fun updateGuardianEmail(guardianEmail: String?) = updateField { userRepository.updateGuardianEmail(guardianEmail) }
+    fun updateOccupation(occupation: String?) = updateField { userRepository.updateOccupation(occupation) }
+    fun updateHobbies(hobbies: String?) = updateField { userRepository.updateHobbies(hobbies) }
+    fun updatePreferredTopics(preferredTopics: String?) = updateField { userRepository.updatePreferredTopics(preferredTopics) }
+    fun updateVoiceSettings(voiceSpeed: Double, voiceTone: String) = updateField { userRepository.updateVoiceSettings(voiceSpeed, voiceTone) }
+    fun updatePreferredSleepHours(hours: Int?) = updateField { userRepository.updatePreferredSleepHours(hours) }
+
+    fun updateConversationTime(time: String?) {
         viewModelScope.launch {
             _uiState.update { it.copy(isSaving = true) }
-            when (val result = userRepository.updatePreferences(preferences)) {
+            when (val result = userRepository.updateConversationTime(time)) {
                 is ApiResult.Success -> {
-                    _uiState.update {
-                        applyPrefs(it, result.data).copy(isSaving = false, savedMessage = "저장되었습니다")
-                    }
+                    val savedTime = result.data.conversationTime
+                    alarmStorage.saveConversationTime(savedTime)
+                    updateAlarmSchedule(savedTime)
+                    _uiState.update { applyPrefs(it, result.data).copy(isSaving = false, savedMessage = "저장되었습니다") }
+                }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(isSaving = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
+                }
+            }
+        }
+    }
 
-                    // 대화 시간 로컬 저장 및 알람 스케줄링
-                    val time = result.data.conversationTime
-                    alarmStorage.saveConversationTime(time)
-                    updateAlarmSchedule(time)
+    private fun updateField(apiCall: suspend () -> ApiResult<UserPreferences>) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            when (val result = apiCall()) {
+                is ApiResult.Success -> _uiState.update {
+                    applyPrefs(it, result.data).copy(isSaving = false, savedMessage = "저장되었습니다")
                 }
                 is ApiResult.Error -> _uiState.update {
                     it.copy(isSaving = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
@@ -189,19 +209,7 @@ class SettingsViewModel(
 
             // 서버에도 기본 시간 저장
             viewModelScope.launch {
-                val currentState = _uiState.value
-                val preferences = UserPreferences(
-                    birthday = currentState.birthday,
-                    familyInfo = currentState.familyInfo,
-                    guardianEmail = currentState.guardianEmail,
-                    location = currentState.location,
-                    occupation = currentState.occupation,
-                    hobbies = currentState.hobbies,
-                    preferredTopics = currentState.preferredTopics,
-                    conversationTime = time,
-                    preferredSleepHours = currentState.preferredSleepHours
-                )
-                userRepository.updatePreferences(preferences)
+                userRepository.updateConversationTime(time)
             }
         }
 

--- a/server/src/main/java/com/example/echo/user/controller/UserController.java
+++ b/server/src/main/java/com/example/echo/user/controller/UserController.java
@@ -1,8 +1,7 @@
 package com.example.echo.user.controller;
 
 import com.example.echo.common.auth.CurrentUser;
-import com.example.echo.user.dto.OnboardingStatusResponse;
-import com.example.echo.user.dto.UserPreferences;
+import com.example.echo.user.dto.*;
 import com.example.echo.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +25,76 @@ public class UserController {
             @CurrentUser Long userId,
             @Valid @RequestBody UserPreferences request) {
         return ResponseEntity.ok(userService.savePreferences(userId, request));
+    }
+
+    @PutMapping("/preferences/birthday")
+    public ResponseEntity<UserPreferences> updateBirthday(
+            @CurrentUser Long userId,
+            @Valid @RequestBody BirthdayUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateBirthday(userId, request.getBirthday()));
+    }
+
+    @PutMapping("/preferences/location")
+    public ResponseEntity<UserPreferences> updateLocation(
+            @CurrentUser Long userId,
+            @Valid @RequestBody LocationUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateLocation(userId, request.getLocation()));
+    }
+
+    @PutMapping("/preferences/family-info")
+    public ResponseEntity<UserPreferences> updateFamilyInfo(
+            @CurrentUser Long userId,
+            @Valid @RequestBody FamilyInfoUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateFamilyInfo(userId, request.getFamilyInfo()));
+    }
+
+    @PutMapping("/preferences/guardian-email")
+    public ResponseEntity<UserPreferences> updateGuardianEmail(
+            @CurrentUser Long userId,
+            @Valid @RequestBody GuardianEmailUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateGuardianEmail(userId, request.getGuardianEmail()));
+    }
+
+    @PutMapping("/preferences/occupation")
+    public ResponseEntity<UserPreferences> updateOccupation(
+            @CurrentUser Long userId,
+            @Valid @RequestBody OccupationUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateOccupation(userId, request.getOccupation()));
+    }
+
+    @PutMapping("/preferences/hobbies")
+    public ResponseEntity<UserPreferences> updateHobbies(
+            @CurrentUser Long userId,
+            @Valid @RequestBody HobbiesUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateHobbies(userId, request.getHobbies()));
+    }
+
+    @PutMapping("/preferences/preferred-topics")
+    public ResponseEntity<UserPreferences> updatePreferredTopics(
+            @CurrentUser Long userId,
+            @Valid @RequestBody PreferredTopicsUpdateRequest request) {
+        return ResponseEntity.ok(userService.updatePreferredTopics(userId, request.getPreferredTopics()));
+    }
+
+    @PutMapping("/preferences/voice-settings")
+    public ResponseEntity<UserPreferences> updateVoiceSettings(
+            @CurrentUser Long userId,
+            @Valid @RequestBody VoiceSettingsUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateVoiceSettings(userId, request.getVoiceSpeed(), request.getVoiceTone()));
+    }
+
+    @PutMapping("/preferences/conversation-time")
+    public ResponseEntity<UserPreferences> updateConversationTime(
+            @CurrentUser Long userId,
+            @Valid @RequestBody ConversationTimeUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateConversationTime(userId, request.getConversationTime()));
+    }
+
+    @PutMapping("/preferences/preferred-sleep-hours")
+    public ResponseEntity<UserPreferences> updatePreferredSleepHours(
+            @CurrentUser Long userId,
+            @Valid @RequestBody PreferredSleepHoursUpdateRequest request) {
+        return ResponseEntity.ok(userService.updatePreferredSleepHours(userId, request.getPreferredSleepHours()));
     }
 
     @GetMapping("/onboarding-status")

--- a/server/src/main/java/com/example/echo/user/dto/BirthdayUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/BirthdayUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BirthdayUpdateRequest {
+    @NotNull(message = "생년월일은 필수입니다.")
+    private LocalDate birthday;
+}

--- a/server/src/main/java/com/example/echo/user/dto/ConversationTimeUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/ConversationTimeUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.example.echo.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationTimeUpdateRequest {
+    @NotNull(message = "대화 시간은 필수입니다.")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime conversationTime;
+}

--- a/server/src/main/java/com/example/echo/user/dto/FamilyInfoUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/FamilyInfoUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FamilyInfoUpdateRequest {
+    @Size(max = 500)
+    private String familyInfo;
+}

--- a/server/src/main/java/com/example/echo/user/dto/GuardianEmailUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/GuardianEmailUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuardianEmailUpdateRequest {
+    @Email(message = "보호자 이메일 형식이 올바르지 않습니다.")
+    @Size(max = 255)
+    private String guardianEmail;
+}

--- a/server/src/main/java/com/example/echo/user/dto/HobbiesUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/HobbiesUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HobbiesUpdateRequest {
+    @Size(max = 500)
+    private String hobbies;
+}

--- a/server/src/main/java/com/example/echo/user/dto/LocationUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/LocationUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationUpdateRequest {
+    @NotNull(message = "거주 지역은 필수입니다.")
+    @Size(max = 100)
+    private String location;
+}

--- a/server/src/main/java/com/example/echo/user/dto/OccupationUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/OccupationUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OccupationUpdateRequest {
+    @Size(max = 100)
+    private String occupation;
+}

--- a/server/src/main/java/com/example/echo/user/dto/PreferredSleepHoursUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/PreferredSleepHoursUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.example.echo.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreferredSleepHoursUpdateRequest {
+    private Integer preferredSleepHours;
+}

--- a/server/src/main/java/com/example/echo/user/dto/PreferredTopicsUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/PreferredTopicsUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PreferredTopicsUpdateRequest {
+    @Size(max = 500)
+    private String preferredTopics;
+}

--- a/server/src/main/java/com/example/echo/user/dto/VoiceSettingsUpdateRequest.java
+++ b/server/src/main/java/com/example/echo/user/dto/VoiceSettingsUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.echo.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoiceSettingsUpdateRequest {
+    private Double voiceSpeed;
+
+    @Size(max = 50)
+    private String voiceTone;
+}

--- a/server/src/main/java/com/example/echo/user/entity/UserPreferences.java
+++ b/server/src/main/java/com/example/echo/user/entity/UserPreferences.java
@@ -108,4 +108,55 @@ public class UserPreferences {
         this.preferredSleepHours = preferredSleepHours;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateLocation(String location) {
+        this.location = location;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateFamilyInfo(String familyInfo) {
+        this.familyInfo = familyInfo;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateGuardianEmail(String guardianEmail) {
+        this.guardianEmail = guardianEmail;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateOccupation(String occupation) {
+        this.occupation = occupation;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateHobbies(String hobbies) {
+        this.hobbies = hobbies;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updatePreferredTopics(String preferredTopics) {
+        this.preferredTopics = preferredTopics;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateVoiceSettings(Double voiceSpeed, String voiceTone) {
+        this.voiceSpeed = voiceSpeed;
+        this.voiceTone = voiceTone;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateConversationTime(LocalTime conversationTime) {
+        this.conversationTime = conversationTime;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updatePreferredSleepHours(Integer preferredSleepHours) {
+        this.preferredSleepHours = preferredSleepHours;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/server/src/main/java/com/example/echo/user/service/UserService.java
+++ b/server/src/main/java/com/example/echo/user/service/UserService.java
@@ -100,6 +100,81 @@ public class UserService {
         return getPreferences(userId);
     }
 
+    @Transactional
+    public UserPreferences updateBirthday(Long userId, java.time.LocalDate birthday) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateBirthday(birthday);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateLocation(Long userId, String location) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateLocation(location);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateFamilyInfo(Long userId, String familyInfo) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateFamilyInfo(familyInfo);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateGuardianEmail(Long userId, String guardianEmail) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateGuardianEmail(guardianEmail);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateOccupation(Long userId, String occupation) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateOccupation(occupation);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateHobbies(Long userId, String hobbies) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateHobbies(hobbies);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updatePreferredTopics(Long userId, String preferredTopics) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updatePreferredTopics(preferredTopics);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateVoiceSettings(Long userId, Double voiceSpeed, String voiceTone) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateVoiceSettings(voiceSpeed, voiceTone);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updateConversationTime(Long userId, java.time.LocalTime conversationTime) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updateConversationTime(conversationTime);
+        return getPreferences(userId);
+    }
+
+    @Transactional
+    public UserPreferences updatePreferredSleepHours(Long userId, Integer preferredSleepHours) {
+        com.example.echo.user.entity.UserPreferences entity = getPreferencesEntity(userId);
+        entity.updatePreferredSleepHours(preferredSleepHours);
+        return getPreferences(userId);
+    }
+
+    private com.example.echo.user.entity.UserPreferences getPreferencesEntity(Long userId) {
+        return userPreferencesRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalStateException("온보딩이 완료되지 않았습니다."));
+    }
+
     @Transactional(readOnly = true)
     public boolean isOnboardingCompleted(Long userId) {
         return userPreferencesRepository.findByUserId(userId)


### PR DESCRIPTION
## Summary
- 기존 `PUT /api/users/me/preferences` (전체 페이로드)는 온보딩 전용으로 유지
- 설정 화면 인라인 편집용 개별 PUT 엔드포인트 10개 추가 (`/birthday`, `/location`, `/family-info`, `/guardian-email`, `/occupation`, `/hobbies`, `/preferred-topics`, `/voice-settings`, `/conversation-time`, `/preferred-sleep-hours`)
- Android 설정 화면도 개별 엔드포인트 호출로 교체 (한 필드 수정 시 해당 필드만 전송)

## Changes
**Server**
- `UserPreferences` entity에 필드별 `updateXxx()` 메서드 10개 추가
- 필드 전용 요청 DTO 10개 추가 (`BirthdayUpdateRequest` 등)
- `UserService`에 필드별 업데이트 메서드 10개 추가
- `UserController`에 개별 PUT 엔드포인트 10개 추가

**Android**
- `UserModels.kt`: 요청 DTO 10개 추가
- `UserApi.kt`: 개별 PUT API 메서드 10개 추가
- `UserRepository.kt`: 개별 update 메서드 10개 추가
- `SettingsViewModel.kt`: `savePreferences(UserPreferences)` → 개별 `updateXxx()` 메서드로 교체
- `SettingsScreen.kt`: `buildPreferences()` 헬퍼 제거, 다이얼로그 콜백 → 개별 ViewModel 메서드 직접 호출

## Test plan
- [ ] 설정 화면에서 각 필드 수정 후 저장 → 해당 필드만 변경되고 나머지 필드 유지 확인
- [ ] 온보딩 흐름 정상 동작 확인 (기존 bulk PUT 유지)
- [ ] Swagger UI(`/swagger-ui.html`)에서 신규 엔드포인트 10개 노출 확인
- [ ] 온보딩 미완료 사용자가 개별 엔드포인트 호출 시 400 에러 반환 확인