### PR TITLE
fix: 홈 화면 날씨 좌표 신뢰성 개선 및 홈-대화 날씨 일관성 보장

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.location.LocationManager
+import com.example.graduation_project.data.location.LocationStorageManager
 import com.example.graduation_project.data.model.WeatherResponse
 import com.example.graduation_project.data.repository.UserRepository
 import com.example.graduation_project.data.repository.WeatherRepository
@@ -31,7 +33,10 @@ class HomeViewModel(
     application: Application,
     private val userRepository: UserRepository = UserRepository(),
     private val weatherRepository: WeatherRepository = WeatherRepository(),
-    private val locationManager: LocationManager = LocationManager(application)
+    private val locationManager: LocationManager = LocationManager(application),
+    private val locationStorageManager: LocationStorageManager = LocationStorageManager(
+        AppDatabase.getInstance(application).locationPointDao()
+    )
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(HomeUiState(date = formatToday()))
@@ -60,13 +65,18 @@ class HomeViewModel(
     }
 
     private suspend fun loadWeather() {
-        val location = locationManager.getCurrentLocation() ?: return
-        when (val result = weatherRepository.getWeather(location.latitude, location.longitude)) {
-            is ApiResult.Success -> {
-                _uiState.value = _uiState.value.copy(weather = result.data)
-            }
+        val (lat, lon) = resolveCoordinates() ?: return
+        when (val result = weatherRepository.getWeather(lat, lon)) {
+            is ApiResult.Success -> _uiState.value = _uiState.value.copy(weather = result.data)
             is ApiResult.Error -> Unit
         }
+    }
+
+    private suspend fun resolveCoordinates(): Pair<Double, Double>? {
+        locationStorageManager.getTodayLocations().lastOrNull()?.let {
+            return it.latitude to it.longitude
+        }
+        return locationManager.getCurrentLocation()?.let { it.latitude to it.longitude }
     }
 
     companion object {

--- a/server/src/main/java/com/example/echo/common/client/WeatherClient.java
+++ b/server/src/main/java/com/example/echo/common/client/WeatherClient.java
@@ -58,6 +58,18 @@ public class WeatherClient {
             .expireAfterWrite(Duration.ofHours(24))
             .build();
 
+    /**
+     * 사용자별 날씨 캐시 (홈 화면 ↔ 대화 프롬프트 일관성 보장)
+     * - 키: userId
+     * - 값: WeatherData (홈 화면에서 조회한 날씨)
+     * - TTL: 30분
+     * - 최대 크기: 1000명
+     */
+    private final Cache<Long, WeatherData> userWeatherCache = Caffeine.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(Duration.ofMinutes(30))
+            .build();
+
     public WeatherClient(WeatherApiClient weatherApiClient,
                          @Value("${weather.api.key}") String apiKey) {
         this.weatherApiClient = weatherApiClient;
@@ -202,6 +214,16 @@ public class WeatherClient {
                     latitude, longitude, timestamp, e.getMessage());
             return null;
         }
+    }
+
+    public void cacheUserWeather(Long userId, WeatherData weather) {
+        if (userId != null && weather != null) {
+            userWeatherCache.put(userId, weather);
+        }
+    }
+
+    public WeatherData getCachedUserWeather(Long userId) {
+        return userId == null ? null : userWeatherCache.getIfPresent(userId);
     }
 
     /**

--- a/server/src/main/java/com/example/echo/common/controller/WeatherController.java
+++ b/server/src/main/java/com/example/echo/common/controller/WeatherController.java
@@ -26,6 +26,7 @@ public class WeatherController {
         if (weather == null) {
             return ResponseEntity.noContent().build();
         }
+        weatherClient.cacheUserWeather(userId, weather);
         return ResponseEntity.ok(weather);
     }
 }

--- a/server/src/main/java/com/example/echo/context/service/ContextService.java
+++ b/server/src/main/java/com/example/echo/context/service/ContextService.java
@@ -1,6 +1,7 @@
 package com.example.echo.context.service;
 
 import com.example.echo.common.client.WeatherClient;
+import com.example.echo.common.dto.WeatherData;
 import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import com.example.echo.health.dto.EnrichedHealthData;
@@ -69,15 +70,22 @@ public class ContextService {
         LocationData locationData = locationService.enrichLocationData(rawLocationData);
 
         // 5. 컨텍스트 생성 및 저장
-        Double lat = rawLocationData != null ? rawLocationData.getCurrentLatitude() : null;
-        Double lon = rawLocationData != null ? rawLocationData.getCurrentLongitude() : null;
+        WeatherData weather = weatherClient.getCachedUserWeather(userId);
+        if (weather == null) {
+            Double lat = rawLocationData != null ? rawLocationData.getCurrentLatitude() : null;
+            Double lon = rawLocationData != null ? rawLocationData.getCurrentLongitude() : null;
+            weather = weatherClient.getCurrentWeather(lat, lon);
+            log.info("[컨텍스트] per-user 캐시 미스 → 좌표 fallback fetch (userId={})", userId);
+        } else {
+            log.info("[컨텍스트] per-user 캐시 hit (userId={})", userId);
+        }
         UserContext context = UserContext.builder()
                 .userId(userId)
                 .date(LocalDate.now())
                 .conversationHistory(new ArrayList<>())
                 .enrichedHealthData(enrichedHealthData)
                 .preferences(preferences)
-                .todayWeather(weatherClient.getCurrentWeather(lat, lon))
+                .todayWeather(weather)
                 .locationData(locationData)
                 .lastAccessTime(LocalDateTime.now())
                 .isActive(true)


### PR DESCRIPTION
## Summary
- **Android** `HomeViewModel`: 백그라운드 수집 GPS(`LocationStorageManager`)를 1순위 좌표로 사용하고, 데이터가 없을 때만 `LocationManager.getCurrentLocation()` fallback — 오래된 `lastKnownLocation` 문제 해소
- **Server** `WeatherClient`: userId 기반 per-user 캐시(TTL 30분) 추가 — 홈 화면과 대화 프롬프트가 동일한 날씨 데이터를 재사용
- **Server** `WeatherController`: `GET /api/weather` 응답 전 userId 캐시에 저장
- **Server** `ContextService`: 대화 시작 시 per-user 캐시 우선 조회, 캐시 미스 시 좌표 기반 fallback + 로그

## Test plan
- [ ] 홈 진입 → 서버 로그에서 `현재 날씨 캐시 미스 - API 호출: X.X,Y.Y` 좌표가 실제 위치 ~10km 이내인지 확인
- [ ] 홈 날씨 확인 후 "대화 시작" → 서버 로그에 `[컨텍스트] per-user 캐시 hit` 출력, 표시된 날씨와 동일한지 확인
- [ ] 위치 권한 거부 / 앱 첫 실행(GPS 미수집) → 날씨 미표시 + 크래시 없음
- [ ] 홈 진입 후 30분 이상 경과 후 대화 시작 → `[컨텍스트] per-user 캐시 미스` 로그 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)