### PR TITLE
feat(ux): 홈 화면 캐릭터 WebP 교체 및 대화 종료 UX 개선

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.R
+import kotlinx.coroutines.delay
 import com.example.graduation_project.presentation.conversation.components.AnimatedWebpImage
 import com.example.graduation_project.presentation.model.ConversationError
 import com.example.graduation_project.presentation.model.ConversationState
@@ -66,9 +67,10 @@ fun ConversationScreen(
         viewModel.startConversation()
     }
 
-    // Ended 상태가 되면 자동으로 뒤로 이동
+    // Ended 상태가 되면 웨이브 애니메이션 + 작별 메시지를 보여준 후 뒤로 이동
     LaunchedEffect(uiState.conversationState) {
         if (uiState.conversationState is ConversationState.Ended) {
+            delay(2000L)
             onBack()
         }
     }
@@ -173,7 +175,7 @@ private fun StateTextSection(
         is ConversationState.Playing -> "에코가 말하고 있어요"
         is ConversationState.Recording -> "말씀해주세요"
         is ConversationState.Listening -> "듣고 있어요"
-        else -> ""
+        is ConversationState.Ended -> "오늘 대화가 저장되었으니, 내일 또 봐요"
     }
 
     Text(
@@ -214,44 +216,47 @@ private fun BottomActionSection(
     onEndClick: () -> Unit
 ) {
     val colors = LocalEchoColors.current
-    val isActive = state !is ConversationState.Idle && state !is ConversationState.Ended
 
-    if (!isActive) {
-        Button(
-            onClick = onStartClick,
-            enabled = !isLoading,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(64.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = colors.accentGreen,
-                contentColor = Color.White
-            )
-        ) {
-            if (isLoading) {
-                CircularProgressIndicator(color = Color.White, modifier = Modifier.size(22.dp))
-            } else {
-                Text("대화 시작", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
+    when {
+        state is ConversationState.Ended -> { /* 종료 후 대기 중 — 버튼 없음 */ }
+        state is ConversationState.Idle -> {
+            Button(
+                onClick = onStartClick,
+                enabled = !isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = colors.accentGreen,
+                    contentColor = Color.White
+                )
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(color = Color.White, modifier = Modifier.size(22.dp))
+                } else {
+                    Text("대화 시작", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
+                }
             }
         }
-    } else {
-        val isSending = state is ConversationState.Sending
-        Button(
-            onClick = onEndClick,
-            enabled = !isSending,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(64.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = if (isSending) colors.bgMuted else colors.accentRed,
-                contentColor = if (isSending) colors.textTertiary else Color.White,
-                disabledContainerColor = colors.bgMuted,
-                disabledContentColor = colors.textTertiary
-            )
-        ) {
-            Text("대화 종료", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
+        else -> {
+            val isSending = state is ConversationState.Sending
+            Button(
+                onClick = onEndClick,
+                enabled = !isSending,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp),
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isSending) colors.bgMuted else colors.accentRed,
+                    contentColor = if (isSending) colors.textTertiary else Color.White,
+                    disabledContainerColor = colors.bgMuted,
+                    disabledContentColor = colors.textTertiary
+                )
+            ) {
+                Text("대화 종료", fontSize = 22.sp, fontWeight = FontWeight.SemiBold, fontFamily = OutfitFontFamily)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -23,7 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.graduation_project.presentation.conversation.components.AiCharacterImage
+import com.example.graduation_project.R
+import com.example.graduation_project.presentation.conversation.components.AnimatedWebpImage
 import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import com.example.graduation_project.ui.theme.OutfitFontFamily
@@ -57,7 +59,10 @@ private fun HomeScreenContent(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        AiCharacterImage(size = 180.dp)
+        AnimatedWebpImage(
+            resId = R.raw.echo_05_greeting,
+            modifier = Modifier.size(180.dp)
+        )
 
         Spacer(Modifier.height(32.dp))
 


### PR DESCRIPTION
## Summary

- **HomeScreen**: 기존 `AiCharacterImage`(wellbot.png + Compose 애니메이션)를 `AnimatedWebpImage(echo_05_greeting.webp)`로 교체하여 대화 전/중 화면 캐릭터 표현 일관화
- **ConversationScreen**: 대화 종료 시 `"오늘 대화가 저장되었으니, 내일 또 봐요"` 작별 메시지 텍스트 추가
- **ConversationScreen**: 종료 후 즉시 홈으로 이동하던 것을 2초 delay로 변경, 웨이브 애니메이션과 작별 메시지를 노출 후 전환
- **ConversationScreen**: `Ended` 상태 2초 대기 중 버튼 숨김 처리 (어색한 "대화 시작" 버튼 노출 방지)

## Test plan

- [ ] HomeScreen 진입 시 `echo_05_greeting.webp` 애니메이션이 표시되는지 확인 (wellbot.png 대신)
- [ ] 대화 시작 → 종료 버튼 → 확인 → 작별 메시지 + 웨이브 애니메이션이 약 2초간 표시되는지 확인
- [ ] 2초 후 HomeScreen으로 자동 전환되는지 확인
- [ ] 종료 대기 2초 동안 버튼이 나타나지 않는지 확인
- [ ] `./gradlew assembleDebug` 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)