### PR TITLE
fix(location): 위치 수집 서비스 개선 및 기본 대화 시간 변경

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
@@ -16,6 +16,7 @@ import com.example.graduation_project.MainActivity
 import com.example.graduation_project.R
 import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationScheduler
+import java.util.Calendar
 
 /**
  * 대화 알람 수신 및 알림 표시
@@ -109,7 +110,10 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
             bigText = "에코와 함께 오늘 하루를 이야기해 보세요!"
         }
 
-        // 알림 생성 (대화 시작까지 유지)
+        // 자정까지 남은 시간 계산 (대화 안 하면 자정에 자동 취소)
+        val timeoutMs = calculateMillisUntilMidnight()
+
+        // 알림 생성 (대화 시작 또는 자정에 자동 취소)
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle("에코와 대화할 시간이에요")
@@ -120,10 +124,26 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
             .setAutoCancel(false)  // 클릭해도 알림 유지 (대화 시작 시 취소)
             .setOngoing(true)      // 스와이프로 삭제 불가
             .setContentIntent(pendingIntent)
+            .setTimeoutAfter(timeoutMs)  // 자정에 자동 취소
             .build()
 
         notificationManager.notify(NOTIFICATION_ID, notification)
-        Log.d(TAG, "대화 알림 표시 완료 (위치 권한: $hasLocationPermission)")
+        Log.d(TAG, "대화 알림 표시 완료 (위치 권한: $hasLocationPermission, 자정까지: ${timeoutMs / 1000 / 60}분)")
+    }
+
+    /**
+     * 자정까지 남은 시간(밀리초) 계산
+     */
+    private fun calculateMillisUntilMidnight(): Long {
+        val now = Calendar.getInstance()
+        val midnight = Calendar.getInstance().apply {
+            add(Calendar.DAY_OF_YEAR, 1)
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        return midnight.timeInMillis - now.timeInMillis
     }
 
     companion object {

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
@@ -176,7 +176,8 @@ class LocationCollectionService : Service() {
 
     private suspend fun collectLocation() {
         if (!hasLocationPermission()) {
-            Log.w(TAG, "위치 권한 없음 - 수집 건너뜀")
+            Log.w(TAG, "위치 권한 없음 - 서비스 중지")
+            stopSelf()  // 권한 없으면 서비스 중지 (리소스 낭비 방지)
             return
         }
 
@@ -201,10 +202,16 @@ class LocationCollectionService : Service() {
     }
 
     private fun hasLocationPermission(): Boolean {
-        return ContextCompat.checkSelfPermission(
+        val hasFineLocation = ContextCompat.checkSelfPermission(
             this,
             Manifest.permission.ACCESS_FINE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
+
+        if (!hasFineLocation) {
+            Log.d(TAG, "정밀 위치 권한(FINE) 없음 - 50m 체류 감지에 필수")
+        }
+
+        return hasFineLocation
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
@@ -125,18 +125,14 @@ object LocationScheduler {
 
     /**
      * 위치 수집 활성화
-     * - 현재 시간이 시작 시간 ~ 대화 시간 사이면 서비스 즉시 시작
-     * - 그 외 시간대면 알람만 스케줄링
+     * - 대화 시간 전이면 즉시 서비스 시작 (권한 허용 직후 바로 수집 시작)
+     * - 대화 시간 이후면 다음날 알람만 스케줄링
      */
     fun enableLocationCollection(context: Context) {
-        val locationStorage = LocationCollectionStorage(context)
         val alarmStorage = ConversationAlarmStorage(context)
 
-        val startHour = locationStorage.getStartHour()
-        val startMinute = locationStorage.getStartMinute()
-
-        // 대화 시간 가져오기 (기본값: 09:00)
-        val conversationTime = alarmStorage.getConversationTime() ?: "09:00"
+        // 대화 시간 가져오기 (기본값: 21:00)
+        val conversationTime = alarmStorage.getConversationTime() ?: "21:00"
         val endHour = try { conversationTime.split(":")[0].toInt() } catch (e: Exception) { 9 }
         val endMinute = try { conversationTime.split(":")[1].toInt() } catch (e: Exception) { 0 }
 
@@ -145,25 +141,18 @@ object LocationScheduler {
         val currentHour = now.get(Calendar.HOUR_OF_DAY)
         val currentMinute = now.get(Calendar.MINUTE)
         val currentMinutes = currentHour * 60 + currentMinute
-        val startMinutes = startHour * 60 + startMinute
         val endMinutes = endHour * 60 + endMinute
 
-        // 시작 시간 ~ 대화 시간 사이인지 확인
-        val isWithinCollectionTime = if (startMinutes < endMinutes) {
-            // 같은 날 (예: 06:00 ~ 09:00)
-            currentMinutes in startMinutes until endMinutes
-        } else {
-            // 자정을 넘는 경우 (예: 22:00 ~ 06:00) - 이 케이스는 거의 없음
-            currentMinutes >= startMinutes || currentMinutes < endMinutes
-        }
+        // 대화 시간 전인지 확인 (대화 시간 전이면 아직 오늘 대화가 안 끝났으므로 수집 필요)
+        val isBeforeConversationTime = currentMinutes < endMinutes
 
-        if (isWithinCollectionTime) {
-            // 시작 시간 ~ 대화 시간 사이 → 즉시 서비스 시작
-            Log.d(TAG, "수집 시간대($startHour:$startMinute ~ $endHour:$endMinute) 내 - 위치 수집 즉시 시작")
+        if (isBeforeConversationTime) {
+            // 대화 시간 전 → 즉시 서비스 시작 (권한 허용 직후 바로 수집)
+            Log.d(TAG, "대화 시간($endHour:$endMinute) 전 - 위치 수집 즉시 시작")
             LocationCollectionService.start(context)
         } else {
-            // 수집 시간대 외 → 알람만 스케줄링
-            Log.d(TAG, "수집 시간대($startHour:$startMinute ~ $endHour:$endMinute) 외 - 알람만 스케줄링")
+            // 대화 시간 이후 → 오늘 대화는 이미 끝났으므로 내일부터 수집
+            Log.d(TAG, "대화 시간($endHour:$endMinute) 이후 - 내일 아침부터 수집 시작 예정")
         }
 
         scheduleMorningAlarm(context)

--- a/android/app/src/main/java/com/example/graduation_project/data/location/MorningAlarmReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/MorningAlarmReceiver.kt
@@ -19,8 +19,8 @@ class MorningAlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         Log.d(TAG, "아침 6시 알람 수신 - 위치 수집 서비스 시작")
 
-        // 위치 권한 체크
-        val hasLocationPermission = ContextCompat.checkSelfPermission(
+        // 위치 권한 체크 (정확한 체류 감지를 위해 FINE 권한 필수)
+        val hasFineLocation = ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.ACCESS_FINE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
@@ -30,8 +30,15 @@ class MorningAlarmReceiver : BroadcastReceiver() {
             Manifest.permission.ACCESS_BACKGROUND_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
 
-        if (!hasLocationPermission || !hasBackgroundPermission) {
-            Log.w(TAG, "위치 권한 없음 - 서비스 시작 건너뜀")
+        Log.d(TAG, "권한 상태: FINE=$hasFineLocation, BACKGROUND=$hasBackgroundPermission")
+
+        if (!hasFineLocation) {
+            Log.w(TAG, "정밀 위치 권한(FINE) 없음 - 서비스 시작 건너뜀 (50m 체류 감지에 필수)")
+            return
+        }
+
+        if (!hasBackgroundPermission) {
+            Log.w(TAG, "백그라운드 위치 권한 없음 - 서비스 시작 건너뜀")
             return
         }
 

--- a/android/app/src/main/java/com/example/graduation_project/data/receiver/BootReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/receiver/BootReceiver.kt
@@ -44,8 +44,8 @@ class BootReceiver : BroadcastReceiver() {
             return
         }
 
-        // 위치 권한 체크
-        val hasLocationPermission = ContextCompat.checkSelfPermission(
+        // 위치 권한 체크 (정확한 체류 감지를 위해 FINE 권한 필수)
+        val hasFineLocation = ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.ACCESS_FINE_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
@@ -55,8 +55,10 @@ class BootReceiver : BroadcastReceiver() {
             Manifest.permission.ACCESS_BACKGROUND_LOCATION
         ) == PackageManager.PERMISSION_GRANTED
 
-        if (!hasLocationPermission) {
-            Log.w(TAG, "위치 권한 없음 - 위치 서비스 시작 건너뜀")
+        Log.d(TAG, "권한 상태: FINE=$hasFineLocation, BACKGROUND=$hasBackgroundPermission")
+
+        if (!hasFineLocation) {
+            Log.w(TAG, "정밀 위치 권한(FINE) 없음 - 위치 서비스 시작 건너뜀 (50m 체류 감지에 필수)")
             return
         }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -194,7 +194,7 @@ private fun HomeScreenPreview() {
     Graduation_projectTheme {
         HomeScreenContent(
             userName = "김순자",
-            conversationTime = "09:00",
+            conversationTime = "21:00",
             date = "5월 16일 금요일",
             weather = WeatherResponse(description = "맑음", temperature = 22),
             onStartConversation = {}

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -340,9 +340,9 @@ private fun TimePickerStep(
     onAlarmEnabledChange: (Boolean) -> Unit
 ) {
     val colors = LocalEchoColors.current
-    val initial = if (selected.isNotEmpty()) selected else "09:00"
+    val initial = if (selected.isNotEmpty()) selected else "21:00"
     LaunchedEffect(Unit) {
-        if (selected.isEmpty()) onTimeSelected("09:00")
+        if (selected.isEmpty()) onTimeSelected("21:00")
     }
 
     Column {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -944,7 +944,7 @@ private fun TimePickerFieldDialog(
     onSelected: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
-    var value by remember { mutableStateOf(if (!current.isNullOrBlank()) current else "09:00") }
+    var value by remember { mutableStateOf(if (!current.isNullOrBlank()) current else "21:00") }
 
     val colors = LocalEchoColors.current
     AlertDialog(

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -266,7 +266,7 @@ class SettingsViewModel(
     }
 
     companion object {
-        private const val DEFAULT_CONVERSATION_TIME = "09:00"
+        private const val DEFAULT_CONVERSATION_TIME = "21:00"
 
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## Summary
- 권한 체크 로직에 상세 로그 추가 (디버깅 용이)
- 시간대 로직 완화: 대화 시간 전이면 즉시 서비스 시작
- 기본 대화 시간 09:00 → 21:00으로 변경
- 위치 권한 거부 시 서비스 자동 중지 (리소스 낭비 방지)
- 대화 알림 자정 자동 취소 기능 추가

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `MorningAlarmReceiver.kt` | 권한 체크 로그 추가, FINE 권한 필수 명시 |
| `BootReceiver.kt` | 권한 체크 로그 추가, FINE 권한 필수 명시 |
| `LocationCollectionService.kt` | 권한 없으면 서비스 자동 중지 |
| `LocationScheduler.kt` | 대화 시간 전이면 즉시 시작, 기본값 21:00 |
| `ConversationAlarmReceiver.kt` | 대화 알림 자정 자동 취소 |
| `SettingsViewModel.kt` | 기본 대화 시간 21:00 |
| `SettingsScreen.kt` | 기본 대화 시간 21:00 |
| `OnboardingScreen.kt` | 기본 대화 시간 21:00 |
| `HomeScreen.kt` | Preview 기본값 21:00 |

## Test plan
- [ ] 권한 허용 후 위치 수집 서비스 즉시 시작 확인
- [ ] 권한 거부 시 서비스 자동 중지 확인
- [ ] 대화 알림 자정 자동 취소 확인
- [ ] 기본 대화 시간 21:00 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)