### PR TITLE
feat(settings): 알림 권한 통합 및 위치 수집 개선

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <!-- 알림 권한 (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- 배터리 최적화 해제 요청 (위치 수집 서비스 유지) -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <!-- Health Connect 읽기 권한 -->
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />

--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -42,6 +42,8 @@ import com.example.graduation_project.presentation.home.HomeScreen
 import com.example.graduation_project.presentation.onboarding.OnboardingScreen
 import com.example.graduation_project.presentation.settings.SettingsScreen
 import com.example.graduation_project.presentation.settings.DisplaySettingsViewModel
+import com.example.graduation_project.data.location.LocationScheduler
+import com.example.graduation_project.BuildConfig
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
 import kotlinx.coroutines.Dispatchers
@@ -54,9 +56,28 @@ class MainActivity : ComponentActivity() {
 
     private val displayViewModel: DisplaySettingsViewModel by viewModels { DisplaySettingsViewModel.Factory }
 
+    /**
+     * 앱 재설치 감지 후 알람 재예약
+     * - 버전 코드가 변경되었거나 처음 실행 시에만 알람 재예약
+     */
+    private fun rescheduleAlarmsIfReinstalled() {
+        val prefs = getSharedPreferences("app_state", MODE_PRIVATE)
+        val savedVersionCode = prefs.getLong("last_version_code", -1)
+        val currentVersionCode = BuildConfig.VERSION_CODE.toLong()
+
+        if (savedVersionCode != currentVersionCode) {
+            // 재설치 또는 업데이트 감지 → 알람 재예약
+            LocationScheduler.enableLocationCollection(this)
+            prefs.edit().putLong("last_version_code", currentVersionCode).apply()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // 앱 재설치 감지 후 알람 재예약
+        rescheduleAlarmsIfReinstalled()
 
         // 알림 딥링크 처리
         val navigateTo = intent.getStringExtra("navigate_to")

--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
@@ -157,7 +157,7 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
         const val EXTRA_NAVIGATE_TO = "navigate_to"
         const val NAVIGATE_TO_HOME = "home"
 
-        private const val FAREWELL_TIMEOUT_MS = 10 * 60 * 1000L  // 10분
+        private const val FAREWELL_TIMEOUT_MS = 3 * 60 * 1000L   // 3분
 
         /**
          * 대화 알림 취소 (대화 시작 시 호출)
@@ -169,7 +169,7 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
         }
 
         /**
-         * 대화 종료 알림 표시 (10분 후 자동 사라짐)
+         * 대화 종료 알림 표시 (3분 후 자동 사라짐)
          */
         fun showFarewellNotification(context: Context) {
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -193,7 +193,7 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
                 .setContentText("내일 또 만나요!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setAutoCancel(true)
-                .setTimeoutAfter(FAREWELL_TIMEOUT_MS)  // 10분 후 자동 사라짐
+                .setTimeoutAfter(FAREWELL_TIMEOUT_MS)  // 3분 후 자동 사라짐
                 .build()
 
             notificationManager.notify(FAREWELL_NOTIFICATION_ID, notification)

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
@@ -24,6 +24,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
+import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -31,6 +32,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 /**
  * 백그라운드 GPS 위치 수집 서비스
@@ -44,6 +47,8 @@ class LocationCollectionService : Service() {
 
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private lateinit var locationStorageManager: LocationStorageManager
+    private lateinit var locationCollectionStorage: LocationCollectionStorage
+    private lateinit var conversationAlarmStorage: ConversationAlarmStorage
 
     private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
     private var collectionJob: Job? = null
@@ -57,6 +62,8 @@ class LocationCollectionService : Service() {
 
         val database = AppDatabase.getInstance(this)
         locationStorageManager = LocationStorageManager(database.locationPointDao())
+        locationCollectionStorage = LocationCollectionStorage(this)
+        conversationAlarmStorage = ConversationAlarmStorage(this)
 
         createNotificationChannel()
     }
@@ -169,8 +176,46 @@ class LocationCollectionService : Service() {
                 Log.d(TAG, "다음 수집까지 ${intervalMs / 60000}분 대기")
 
                 delay(intervalMs)
+
+                // 시간 범위 체크 - 범위 밖이면 서비스 자동 중지
+                if (!isCurrentTimeInRange()) {
+                    Log.d(TAG, "수집 시간 범위 종료 - 서비스 자동 중지")
+                    stopSelf()
+                    return@launch
+                }
+
                 collectLocation()
             }
+        }
+    }
+
+    /**
+     * 현재 시간이 수집 범위(시작 시간 ~ 대화 시간) 내인지 확인
+     */
+    private fun isCurrentTimeInRange(): Boolean {
+        return try {
+            val startTimeStr = locationCollectionStorage.getStartTime()
+            // 대화 시간이 설정되지 않은 경우 기본값 21:00 사용
+            val endTimeStr = conversationAlarmStorage.getConversationTime() ?: DEFAULT_CONVERSATION_TIME
+
+            val formatter = DateTimeFormatter.ofPattern("HH:mm")
+            val now = LocalTime.now()
+            val start = LocalTime.parse(startTimeStr, formatter)
+            val end = LocalTime.parse(endTimeStr, formatter)
+
+            val isInRange = if (start.isBefore(end) || start == end) {
+                // 일반적인 경우: 06:00 ~ 21:00
+                now in start..end
+            } else {
+                // 자정을 넘기는 경우: 22:00 ~ 06:00
+                now >= start || now <= end
+            }
+
+            Log.d(TAG, "시간 범위 체크: now=$now, range=$startTimeStr~$endTimeStr, inRange=$isInRange")
+            isInRange
+        } catch (e: Exception) {
+            Log.e(TAG, "시간 범위 체크 실패", e)
+            true  // 오류 시 계속 수집
         }
     }
 
@@ -284,7 +329,8 @@ class LocationCollectionService : Service() {
 
         private const val INTERVAL_NORMAL_MS = 10 * 60 * 1000L      // 10분
         private const val INTERVAL_LOW_BATTERY_MS = 30 * 60 * 1000L // 30분
-        private const val GREETING_TIMEOUT_MS = 10 * 60 * 1000L     // 10분
+        private const val GREETING_TIMEOUT_MS = 3 * 60 * 1000L      // 3분
+        private const val DEFAULT_CONVERSATION_TIME = "21:00"       // 기본 대화 시간
 
         const val ACTION_STOP = "com.example.graduation_project.STOP_LOCATION_SERVICE"
 

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
@@ -226,6 +226,13 @@ class LocationCollectionService : Service() {
             return
         }
 
+        // 최소 간격 체크 (중복 수집 방지)
+        val elapsed = locationCollectionStorage.getElapsedSinceLastCollection()
+        if (elapsed < MIN_COLLECTION_INTERVAL_MS) {
+            Log.d(TAG, "최소 간격 미달 - 스킵 (${elapsed / 60000}분 경과, 최소 ${MIN_COLLECTION_INTERVAL_MS / 60000}분 필요)")
+            return
+        }
+
         try {
             val cancellationToken = CancellationTokenSource()
             val location = fusedLocationClient.getCurrentLocation(
@@ -235,6 +242,7 @@ class LocationCollectionService : Service() {
 
             if (location != null) {
                 locationStorageManager.saveLocation(location.latitude, location.longitude)
+                locationCollectionStorage.saveLastCollectionTime(System.currentTimeMillis())
                 Log.d(TAG, "위치 수집 완료: lat=${location.latitude}, lon=${location.longitude}")
             } else {
                 Log.w(TAG, "위치를 가져올 수 없음")
@@ -329,6 +337,7 @@ class LocationCollectionService : Service() {
 
         private const val INTERVAL_NORMAL_MS = 10 * 60 * 1000L      // 10분
         private const val INTERVAL_LOW_BATTERY_MS = 30 * 60 * 1000L // 30분
+        private const val MIN_COLLECTION_INTERVAL_MS = 9 * 60 * 1000L // 최소 9분 (중복 수집 방지)
         private const val GREETING_TIMEOUT_MS = 3 * 60 * 1000L      // 3분
         private const val DEFAULT_CONVERSATION_TIME = "21:00"       // 기본 대화 시간
 

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
@@ -69,10 +69,25 @@ class LocationCollectionStorage(context: Context) {
         return prefs.getBoolean(KEY_ENABLED, true)
     }
 
+    /**
+     * 아침 인사 알림 활성화 여부 저장
+     */
+    fun setMorningGreetingEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_MORNING_GREETING, enabled).apply()
+    }
+
+    /**
+     * 아침 인사 알림 활성화 여부 조회
+     */
+    fun isMorningGreetingEnabled(): Boolean {
+        return prefs.getBoolean(KEY_MORNING_GREETING, true)
+    }
+
     companion object {
         private const val PREFS_NAME = "location_collection_prefs"
         private const val KEY_START_TIME = "start_time"
         private const val KEY_ENABLED = "enabled"
+        private const val KEY_MORNING_GREETING = "morning_greeting_enabled"
 
         const val DEFAULT_START_TIME = "06:00"
         private const val DEFAULT_HOUR = 6

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
@@ -69,10 +69,34 @@ class LocationCollectionStorage(context: Context) {
         return prefs.getBoolean(KEY_ENABLED, true)
     }
 
+    /**
+     * 마지막 위치 수집 시간 저장 (epoch milliseconds)
+     */
+    fun saveLastCollectionTime(timeMillis: Long) {
+        prefs.edit().putLong(KEY_LAST_COLLECTION_TIME, timeMillis).apply()
+    }
+
+    /**
+     * 마지막 위치 수집 시간 조회
+     * @return epoch milliseconds, 없으면 0
+     */
+    fun getLastCollectionTime(): Long {
+        return prefs.getLong(KEY_LAST_COLLECTION_TIME, 0L)
+    }
+
+    /**
+     * 마지막 수집으로부터 경과 시간 (밀리초)
+     */
+    fun getElapsedSinceLastCollection(): Long {
+        val lastTime = getLastCollectionTime()
+        return if (lastTime > 0) System.currentTimeMillis() - lastTime else Long.MAX_VALUE
+    }
+
     companion object {
         private const val PREFS_NAME = "location_collection_prefs"
         private const val KEY_START_TIME = "start_time"
         private const val KEY_ENABLED = "enabled"
+        private const val KEY_LAST_COLLECTION_TIME = "last_collection_time"
 
         const val DEFAULT_START_TIME = "06:00"
         private const val DEFAULT_HOUR = 6

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionStorage.kt
@@ -69,25 +69,10 @@ class LocationCollectionStorage(context: Context) {
         return prefs.getBoolean(KEY_ENABLED, true)
     }
 
-    /**
-     * 아침 인사 알림 활성화 여부 저장
-     */
-    fun setMorningGreetingEnabled(enabled: Boolean) {
-        prefs.edit().putBoolean(KEY_MORNING_GREETING, enabled).apply()
-    }
-
-    /**
-     * 아침 인사 알림 활성화 여부 조회
-     */
-    fun isMorningGreetingEnabled(): Boolean {
-        return prefs.getBoolean(KEY_MORNING_GREETING, true)
-    }
-
     companion object {
         private const val PREFS_NAME = "location_collection_prefs"
         private const val KEY_START_TIME = "start_time"
         private const val KEY_ENABLED = "enabled"
-        private const val KEY_MORNING_GREETING = "morning_greeting_enabled"
 
         const val DEFAULT_START_TIME = "06:00"
         private const val DEFAULT_HOUR = 6

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.example.graduation_project.presentation.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.os.PowerManager
 import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -104,10 +105,25 @@ fun SettingsScreen(
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 viewModel.refreshPermissionStatus()
+                viewModel.refreshBatteryOptimizationStatus()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // 배터리 최적화 해제 요청 처리
+    LaunchedEffect(uiState.shouldRequestBatteryOptimization) {
+        if (uiState.shouldRequestBatteryOptimization) {
+            val powerManager = context.getSystemService(PowerManager::class.java)
+            if (!powerManager.isIgnoringBatteryOptimizations(context.packageName)) {
+                val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                }
+                context.startActivity(intent)
+            }
+            viewModel.dismissBatteryOptimizationRequest()
+        }
     }
 
     LaunchedEffect(uiState.savedMessage) {
@@ -390,6 +406,20 @@ fun SettingsScreen(
                         isGranted = uiState.hasBackgroundLocationPermission,
                         grantedText = "항상 허용됨",
                         deniedText = "허용 필요"
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 배터리 최적화 상태
+                    PermissionStatusRow(
+                        label = "배터리 최적화",
+                        isGranted = uiState.isBatteryOptimizationDisabled,
+                        grantedText = "제한 없음",
+                        deniedText = "제한됨 (터치하여 해제)",
+                        onClick = {
+                            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                                data = Uri.parse("package:${context.packageName}")
+                            }
+                            context.startActivity(intent)
+                        }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 위치 수집 상태 토글

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -263,11 +263,6 @@ fun SettingsScreen(
                     )
                     PreferenceRow("대화 시간", uiState.conversationTime, enabled = enabled) { editingField = "conversationTime" }
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
-                    AlarmToggleRow(
-                        enabled = uiState.alarmEnabled,
-                        onToggle = { viewModel.setAlarmEnabled(it) }
-                    )
-                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow(
                         label = "음성 설정",
                         value = "${String.format("%.1f", uiState.voiceSpeed)}x · ${
@@ -281,6 +276,17 @@ fun SettingsScreen(
                     ) { editingField = "voiceSettings" }
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("선호 대화 주제", uiState.preferredTopics, enabled = enabled) { editingField = "preferredTopics" }
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 마이크 권한 상태 표시 (필수 권한)
+                    MicrophonePermissionRow(
+                        isGranted = PermissionChecker.hasMicrophonePermission(context),
+                        onClick = {
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                data = Uri.fromParts("package", context.packageName, null)
+                            }
+                            context.startActivity(intent)
+                        }
+                    )
                 }
             }
 
@@ -408,7 +414,7 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            // ===== 앱 설정 섹션 =====
+            // ===== 알람 및 권한 설정 섹션 =====
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -419,15 +425,45 @@ fun SettingsScreen(
                 Column {
                     CardHeader(
                         icon = Icons.Outlined.Notifications,
-                        title = "앱 설정",
+                        title = "알람 및 권한 설정",
                         iconTint = colors.textSecondary
                     )
-                    // 알림 권한 표시
+                    // 대화 시간 알림 토글
+                    NotificationToggleRow(
+                        label = "대화 시간 알림",
+                        description = "설정한 대화 시간에 알림",
+                        enabled = uiState.alarmEnabled,
+                        hasNotificationPermission = uiState.hasNotificationPermission,
+                        onToggle = { viewModel.setAlarmEnabled(it) }
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 아침 인사 알림 토글
+                    NotificationToggleRow(
+                        label = "아침 인사 알림",
+                        description = "위치 수집 시작 시 알림",
+                        enabled = uiState.morningGreetingEnabled,
+                        hasNotificationPermission = uiState.hasNotificationPermission,
+                        onToggle = { viewModel.setMorningGreetingEnabled(it) }
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 알림 권한 상태 및 설정
                     PermissionStatusRow(
                         label = "알림 권한",
                         isGranted = uiState.hasNotificationPermission,
                         grantedText = "허용됨",
-                        deniedText = "허용 필요"
+                        deniedText = "허용 필요 (터치하여 설정)",
+                        onClick = {
+                            val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                                }
+                            } else {
+                                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                                    data = Uri.fromParts("package", context.packageName, null)
+                                }
+                            }
+                            context.startActivity(intent)
+                        }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 앱 권한 설정
@@ -623,9 +659,63 @@ private fun PermissionStatusRow(
     }
 }
 
+/**
+ * 마이크 권한 상태 표시 (필수 권한 - 대화 기능에 필수)
+ */
 @Composable
-private fun AlarmToggleRow(
+private fun MicrophonePermissionRow(
+    isGranted: Boolean,
+    onClick: () -> Unit
+) {
+    val colors = LocalEchoColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("마이크 권한", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = "(필수)",
+                    fontSize = 12.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = colors.accentRed
+                )
+            }
+            Spacer(Modifier.height(3.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = if (isGranted) Icons.Filled.Check else Icons.Outlined.Warning,
+                    contentDescription = null,
+                    tint = if (isGranted) colors.accentBlue else colors.accentRed,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = if (isGranted) "허용됨" else "허용 필요 - 대화 기능 사용 불가",
+                    fontSize = 16.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = if (isGranted) colors.accentBlue else colors.accentRed
+                )
+            }
+        }
+        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
+    }
+}
+
+/**
+ * 알림 토글 Row (알림 권한 없으면 비활성화)
+ */
+@Composable
+private fun NotificationToggleRow(
+    label: String,
+    description: String,
     enabled: Boolean,
+    hasNotificationPermission: Boolean,
     onToggle: (Boolean) -> Unit
 ) {
     val colors = LocalEchoColors.current
@@ -636,18 +726,27 @@ private fun AlarmToggleRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text("대화 시간 알림", fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+            Text(label, fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
             Spacer(Modifier.height(3.dp))
             Text(
-                text = if (enabled) "매일 알림을 받습니다" else "알림 꺼짐",
+                text = when {
+                    !hasNotificationPermission -> "알림 권한 필요"
+                    enabled -> description
+                    else -> "알림 꺼짐"
+                },
                 fontSize = 17.sp,
                 fontFamily = OutfitFontFamily,
-                color = if (enabled) colors.textPrimary else colors.textTertiary
+                color = when {
+                    !hasNotificationPermission -> colors.accentRed
+                    enabled -> colors.textPrimary
+                    else -> colors.textTertiary
+                }
             )
         }
         Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
+            checked = enabled && hasNotificationPermission,
+            onCheckedChange = { onToggle(it) },
+            enabled = hasNotificationPermission,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = Color.White,
                 checkedTrackColor = colors.accentGreen,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -434,6 +435,13 @@ fun SettingsScreen(
                         value = uiState.locationCollectionStartTime,
                         enabled = enabled
                     ) { editingField = "locationStartTime" }
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 위치 데이터 확인 (디버그)
+                    NavigationRow(
+                        label = "수집된 위치 데이터",
+                        description = "오늘 수집된 GPS 포인트 확인",
+                        onClick = { viewModel.loadLocationDebugData() }
+                    )
                 }
             }
 
@@ -587,6 +595,16 @@ fun SettingsScreen(
             current = uiState.locationCollectionStartTime,
             onSelected = { viewModel.setLocationCollectionStartTime(it); dismiss() },
             onDismiss = { dismiss() }
+        )
+    }
+
+    // 위치 데이터 디버그 다이얼로그
+    uiState.locationDebugData?.let { debugData ->
+        LocationDebugDialog(
+            debugData = debugData,
+            isServiceRunning = uiState.isLocationCollectionRunning,
+            onDismiss = { viewModel.dismissLocationDebugData() },
+            onRefresh = { viewModel.loadLocationDebugData() }
         )
     }
 }
@@ -1124,4 +1142,178 @@ private fun NavigationRow(
         }
         Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
     }
+}
+
+/**
+ * 위치 데이터 디버그 다이얼로그
+ */
+@Composable
+private fun LocationDebugDialog(
+    debugData: LocationDebugData,
+    isServiceRunning: Boolean,
+    onDismiss: () -> Unit,
+    onRefresh: () -> Unit
+) {
+    val colors = LocalEchoColors.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = colors.bgCard,
+        title = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    Icons.Outlined.LocationOn,
+                    contentDescription = null,
+                    tint = colors.accentBlue,
+                    modifier = Modifier.size(24.dp)
+                )
+                Text(
+                    "위치 데이터",
+                    fontFamily = OutfitFontFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.textPrimary
+                )
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 400.dp)
+            ) {
+                // 요약 정보
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    color = colors.bgMuted
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text("오늘 수집", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                            Text("${debugData.todayCount}개", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textPrimary, fontWeight = FontWeight.SemiBold)
+                        }
+                        Spacer(Modifier.height(4.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text("마지막 수집", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                            Text(debugData.lastCollectionTime ?: "-", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textPrimary)
+                        }
+                        Spacer(Modifier.height(4.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text("서비스 상태", fontSize = 14.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(8.dp)
+                                        .background(
+                                            color = if (isServiceRunning) colors.accentGreen else colors.textTertiary,
+                                            shape = CircleShape
+                                        )
+                                )
+                                Spacer(Modifier.width(6.dp))
+                                Text(
+                                    if (isServiceRunning) "수집 중" else "중지됨",
+                                    fontSize = 14.sp,
+                                    fontFamily = OutfitFontFamily,
+                                    color = if (isServiceRunning) colors.accentGreen else colors.textTertiary
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+
+                // 포인트 목록
+                if (debugData.points.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "수집된 데이터가 없습니다",
+                            fontSize = 14.sp,
+                            fontFamily = OutfitFontFamily,
+                            color = colors.textTertiary
+                        )
+                    }
+                } else {
+                    Text(
+                        "수집 포인트",
+                        fontSize = 12.sp,
+                        fontFamily = OutfitFontFamily,
+                        color = colors.textSecondary,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        debugData.points.forEach { point ->
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(8.dp),
+                                color = colors.bgMuted.copy(alpha = 0.5f)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        "#${point.id}",
+                                        fontSize = 12.sp,
+                                        fontFamily = OutfitFontFamily,
+                                        color = colors.textTertiary,
+                                        modifier = Modifier.width(32.dp)
+                                    )
+                                    Text(
+                                        "${String.format("%.4f", point.latitude)}, ${String.format("%.4f", point.longitude)}",
+                                        fontSize = 13.sp,
+                                        fontFamily = OutfitFontFamily,
+                                        color = colors.textPrimary,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Text(
+                                        point.time,
+                                        fontSize = 12.sp,
+                                        fontFamily = OutfitFontFamily,
+                                        color = colors.textSecondary
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = onRefresh) {
+                    Text("새로고침", fontFamily = OutfitFontFamily, color = colors.accentBlue)
+                }
+                TextButton(onClick = onDismiss) {
+                    Text("닫기", fontFamily = OutfitFontFamily, color = colors.textSecondary)
+                }
+            }
+        }
+    )
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -261,6 +261,11 @@ fun SettingsScreen(
                         icon = Icons.AutoMirrored.Outlined.Chat,
                         title = "대화 설정"
                     )
+                    // 마이크 권한 상태 표시 (필수 권한) - 최상단
+                    MicrophonePermissionStatusRow(
+                        isGranted = PermissionChecker.hasMicrophonePermission(context)
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("대화 시간", uiState.conversationTime, enabled = enabled) { editingField = "conversationTime" }
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow(
@@ -276,17 +281,6 @@ fun SettingsScreen(
                     ) { editingField = "voiceSettings" }
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     PreferenceRow("선호 대화 주제", uiState.preferredTopics, enabled = enabled) { editingField = "preferredTopics" }
-                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
-                    // 마이크 권한 상태 표시 (필수 권한)
-                    MicrophonePermissionRow(
-                        isGranted = PermissionChecker.hasMicrophonePermission(context),
-                        onClick = {
-                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                data = Uri.fromParts("package", context.packageName, null)
-                            }
-                            context.startActivity(intent)
-                        }
-                    )
                 }
             }
 
@@ -359,18 +353,19 @@ fun SettingsScreen(
                         title = "건강 정보",
                         iconTint = colors.accentRed
                     )
-                    PreferenceRow(
-                        label = "선호 수면 시간",
-                        value = uiState.preferredSleepHours?.let { "${it}시간" },
-                        enabled = enabled
-                    ) { editingField = "sleepHours" }
-                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 건강 데이터 권한 - 최상단
                     PermissionStatusRow(
                         label = "건강 데이터 권한",
                         isGranted = uiState.hasHealthConnectPermission,
                         grantedText = "허용됨",
                         deniedText = "허용 필요"
                     )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    PreferenceRow(
+                        label = "선호 수면 시간",
+                        value = uiState.preferredSleepHours?.let { "${it}시간" },
+                        enabled = enabled
+                    ) { editingField = "sleepHours" }
                 }
             }
 
@@ -428,24 +423,6 @@ fun SettingsScreen(
                         title = "알람 및 권한 설정",
                         iconTint = colors.textSecondary
                     )
-                    // 대화 시간 알림 토글
-                    NotificationToggleRow(
-                        label = "대화 시간 알림",
-                        description = "설정한 대화 시간에 알림",
-                        enabled = uiState.alarmEnabled,
-                        hasNotificationPermission = uiState.hasNotificationPermission,
-                        onToggle = { viewModel.setAlarmEnabled(it) }
-                    )
-                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
-                    // 아침 인사 알림 토글
-                    NotificationToggleRow(
-                        label = "아침 인사 알림",
-                        description = "위치 수집 시작 시 알림",
-                        enabled = uiState.morningGreetingEnabled,
-                        hasNotificationPermission = uiState.hasNotificationPermission,
-                        onToggle = { viewModel.setMorningGreetingEnabled(it) }
-                    )
-                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 알림 권한 상태 및 설정
                     PermissionStatusRow(
                         label = "알림 권한",
@@ -466,7 +443,7 @@ fun SettingsScreen(
                         }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
-                    // 앱 권한 설정
+                    // 앱 권한 설정 - 권한 페이지로 직접 이동
                     NavigationRow(
                         label = "앱 권한 설정",
                         description = "모든 권한을 한 곳에서 관리",
@@ -660,18 +637,16 @@ private fun PermissionStatusRow(
 }
 
 /**
- * 마이크 권한 상태 표시 (필수 권한 - 대화 기능에 필수)
+ * 마이크 권한 상태 표시 (필수 권한 - 표시만, 클릭 불가)
  */
 @Composable
-private fun MicrophonePermissionRow(
-    isGranted: Boolean,
-    onClick: () -> Unit
+private fun MicrophonePermissionStatusRow(
+    isGranted: Boolean
 ) {
     val colors = LocalEchoColors.current
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
             .padding(horizontal = 20.dp, vertical = 20.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -703,60 +678,12 @@ private fun MicrophonePermissionRow(
                 )
             }
         }
-        Icon(Icons.AutoMirrored.Outlined.KeyboardArrowRight, contentDescription = null, tint = colors.textTertiary)
     }
 }
 
 /**
- * 알림 토글 Row (알림 권한 없으면 비활성화)
+ * 위치 수집 상태 토글
  */
-@Composable
-private fun NotificationToggleRow(
-    label: String,
-    description: String,
-    enabled: Boolean,
-    hasNotificationPermission: Boolean,
-    onToggle: (Boolean) -> Unit
-) {
-    val colors = LocalEchoColors.current
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 20.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(label, fontSize = 15.sp, fontFamily = OutfitFontFamily, color = colors.textSecondary)
-            Spacer(Modifier.height(3.dp))
-            Text(
-                text = when {
-                    !hasNotificationPermission -> "알림 권한 필요"
-                    enabled -> description
-                    else -> "알림 꺼짐"
-                },
-                fontSize = 17.sp,
-                fontFamily = OutfitFontFamily,
-                color = when {
-                    !hasNotificationPermission -> colors.accentRed
-                    enabled -> colors.textPrimary
-                    else -> colors.textTertiary
-                }
-            )
-        }
-        Switch(
-            checked = enabled && hasNotificationPermission,
-            onCheckedChange = { onToggle(it) },
-            enabled = hasNotificationPermission,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = colors.accentGreen,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = colors.bgMuted
-            )
-        )
-    }
-}
-
 @Composable
 private fun LocationCollectionToggleRow(
     isRunning: Boolean,
@@ -779,7 +706,7 @@ private fun LocationCollectionToggleRow(
                         .size(10.dp)
                         .background(
                             color = if (isRunning) colors.accentGreen else colors.textTertiary,
-                            shape = androidx.compose.foundation.shape.CircleShape
+                            shape = CircleShape
                         )
                 )
                 Spacer(Modifier.width(8.dp))
@@ -804,6 +731,7 @@ private fun LocationCollectionToggleRow(
         )
     }
 }
+
 
 @Composable
 private fun TextFieldDialog(

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -108,7 +108,11 @@ class SettingsViewModel(
             _uiState.update { it.copy(hasHealthConnectPermission = hasHealthConnectPermission) }
 
             when (val result = userRepository.getPreferences()) {
-                is ApiResult.Success -> _uiState.update { applyPrefs(it, result.data).copy(isLoading = false) }
+                is ApiResult.Success -> {
+                    _uiState.update { applyPrefs(it, result.data).copy(isLoading = false) }
+                    // 대화 시간 로드 후 위치 수집 상태 확인
+                    checkAndUpdateLocationCollectionStatus()
+                }
                 is ApiResult.Error -> _uiState.update { it.copy(isLoading = false) }
             }
         }
@@ -142,6 +146,9 @@ class SettingsViewModel(
         if (!previousBackgroundPermission && currentBackgroundPermission) {
             LocationScheduler.enableLocationCollection(context)
         }
+
+        // 위치 수집 상태 확인 (범위 밖이면 자동 중지)
+        checkAndUpdateLocationCollectionStatus()
     }
 
     /**
@@ -160,7 +167,7 @@ class SettingsViewModel(
     }
 
     /**
-     * 위치 수집 시작/중지 토글
+     * 위치 수집 시작/중지 토글 (수동 제어 - 시간 범위 무관)
      */
     fun toggleLocationCollection() {
         val context = getApplication<Application>()
@@ -283,6 +290,30 @@ class SettingsViewModel(
 
         val message = if (enabled) "아침 인사 알림이 설정되었습니다" else "아침 인사 알림이 해제되었습니다"
         _uiState.update { it.copy(savedMessage = message) }
+    }
+
+    /**
+     * 위치 수집 상태 확인 및 자동 조정
+     * - 현재 시간이 수집 범위(시작 시간 ~ 대화 시간) 밖이면 서비스 자동 중지
+     * - 범위 내이고 권한이 있으면 서비스 자동 시작
+     */
+    private fun checkAndUpdateLocationCollectionStatus() {
+        val context = getApplication<Application>()
+        val startTime = _uiState.value.locationCollectionStartTime
+        val conversationTime = _uiState.value.conversationTime
+
+        // 대화 시간이 설정되지 않은 경우 체크 불가
+        if (conversationTime.isNullOrBlank()) {
+            return
+        }
+
+        val isInRange = isCurrentTimeInRange(startTime, conversationTime)
+
+        if (LocationCollectionService.isRunning && !isInRange) {
+            // 범위 밖인데 서비스가 실행 중이면 중지
+            LocationCollectionService.stop(context)
+            _uiState.update { it.copy(isLocationCollectionRunning = false) }
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.graduation_project.presentation.settings
 
 import android.app.Application
+import android.os.PowerManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -51,6 +52,9 @@ data class SettingsUiState(
     val hasBackgroundLocationPermission: Boolean = false,
     val hasHealthConnectPermission: Boolean = false,
     val hasNotificationPermission: Boolean = true,
+    val isBatteryOptimizationDisabled: Boolean = false,
+    // 배터리 최적화 해제 요청 이벤트 (UI에서 처리)
+    val shouldRequestBatteryOptimization: Boolean = false,
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val savedMessage: String? = null,
@@ -89,6 +93,7 @@ class SettingsViewModel(
         val hasLocation = PermissionChecker.hasForegroundLocationPermission(context)
         val hasBackgroundLocation = PermissionChecker.hasBackgroundLocationPermission(context)
         val hasNotification = PermissionChecker.hasNotificationPermission(context)
+        val isBatteryOptimizationDisabled = checkBatteryOptimizationDisabled()
 
         _uiState.update {
             it.copy(
@@ -98,7 +103,8 @@ class SettingsViewModel(
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = hasLocation,
                 hasBackgroundLocationPermission = hasBackgroundLocation,
-                hasNotificationPermission = hasNotification
+                hasNotificationPermission = hasNotification,
+                isBatteryOptimizationDisabled = isBatteryOptimizationDisabled
             )
         }
 
@@ -126,13 +132,15 @@ class SettingsViewModel(
         val context = getApplication<Application>()
         val previousBackgroundPermission = _uiState.value.hasBackgroundLocationPermission
         val currentBackgroundPermission = PermissionChecker.hasBackgroundLocationPermission(context)
+        val isBatteryOptimizationDisabled = checkBatteryOptimizationDisabled()
 
         _uiState.update {
             it.copy(
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = PermissionChecker.hasForegroundLocationPermission(context),
                 hasBackgroundLocationPermission = currentBackgroundPermission,
-                hasNotificationPermission = PermissionChecker.hasNotificationPermission(context)
+                hasNotificationPermission = PermissionChecker.hasNotificationPermission(context),
+                isBatteryOptimizationDisabled = isBatteryOptimizationDisabled
             )
         }
 
@@ -142,9 +150,13 @@ class SettingsViewModel(
             _uiState.update { it.copy(hasHealthConnectPermission = hasHealthConnectPermission) }
         }
 
-        // 위치 권한이 새로 허용되었으면 서비스 시작
+        // 위치 권한이 새로 허용되었으면 서비스 시작 + 배터리 최적화 해제 요청
         if (!previousBackgroundPermission && currentBackgroundPermission) {
             LocationScheduler.enableLocationCollection(context)
+            // 배터리 최적화가 아직 해제되지 않았으면 요청
+            if (!isBatteryOptimizationDisabled) {
+                _uiState.update { it.copy(shouldRequestBatteryOptimization = true) }
+            }
         }
 
         // 위치 수집 상태 확인 (범위 밖이면 자동 중지)
@@ -177,6 +189,10 @@ class SettingsViewModel(
         } else {
             LocationCollectionService.start(context)
             _uiState.update { it.copy(isLocationCollectionRunning = true, savedMessage = "위치 수집이 시작되었습니다") }
+            // 배터리 최적화가 아직 해제되지 않았으면 요청
+            if (!checkBatteryOptimizationDisabled()) {
+                _uiState.update { it.copy(shouldRequestBatteryOptimization = true) }
+            }
         }
     }
 
@@ -336,6 +352,30 @@ class SettingsViewModel(
         } catch (e: Exception) {
             false
         }
+    }
+
+    /**
+     * 배터리 최적화가 해제되어 있는지 확인
+     */
+    private fun checkBatteryOptimizationDisabled(): Boolean {
+        val context = getApplication<Application>()
+        val powerManager = context.getSystemService(PowerManager::class.java)
+        return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /**
+     * 배터리 최적화 요청 이벤트 클리어 (UI에서 처리 후 호출)
+     */
+    fun dismissBatteryOptimizationRequest() {
+        _uiState.update { it.copy(shouldRequestBatteryOptimization = false) }
+    }
+
+    /**
+     * 배터리 최적화 상태 새로고침
+     */
+    fun refreshBatteryOptimizationStatus() {
+        val isDisabled = checkBatteryOptimizationDisabled()
+        _uiState.update { it.copy(isBatteryOptimizationDisabled = isDisabled) }
     }
 
     companion object {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -12,9 +12,12 @@ import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.health.HealthConnectManager
+import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
+import com.example.graduation_project.data.location.LocationStorageManager
+import com.example.graduation_project.domain.model.LocationPoint
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.repository.UserRepository
 import com.example.graduation_project.domain.health.HealthConnectAvailability
@@ -57,7 +60,28 @@ data class SettingsUiState(
     val isLoading: Boolean = true,
     val isSaving: Boolean = false,
     val savedMessage: String? = null,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    // 위치 데이터 디버그
+    val locationDebugData: LocationDebugData? = null
+)
+
+/**
+ * 위치 데이터 디버그 정보
+ */
+data class LocationDebugData(
+    val todayCount: Int,
+    val lastCollectionTime: String?,
+    val points: List<LocationPointDisplay>
+)
+
+/**
+ * 위치 포인트 표시용 데이터
+ */
+data class LocationPointDisplay(
+    val id: Int,
+    val latitude: Double,
+    val longitude: Double,
+    val time: String
 )
 
 class SettingsViewModel(
@@ -68,12 +92,57 @@ class SettingsViewModel(
     private val alarmStorage = ConversationAlarmStorage(application)
     private val locationStorage = LocationCollectionStorage(application)
     private val healthConnectManager = HealthConnectManager(application)
+    private val locationStorageManager = LocationStorageManager(
+        AppDatabase.getInstance(application).locationPointDao()
+    )
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     init {
         loadSettings()
+    }
+
+    /**
+     * 위치 데이터 로드 (디버그용)
+     */
+    fun loadLocationDebugData() {
+        viewModelScope.launch {
+            try {
+                val points = locationStorageManager.getTodayLocations()
+                val lastCollectionTime = locationStorage.getLastCollectionTime()
+
+                val debugData = LocationDebugData(
+                    todayCount = points.size,
+                    lastCollectionTime = if (lastCollectionTime > 0) {
+                        java.time.Instant.ofEpochMilli(lastCollectionTime)
+                            .atZone(java.time.ZoneId.systemDefault())
+                            .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"))
+                    } else null,
+                    points = points.mapIndexed { index, point ->
+                        LocationPointDisplay(
+                            id = points.size - index,
+                            latitude = point.latitude,
+                            longitude = point.longitude,
+                            time = point.timestamp
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"))
+                        )
+                    }.reversed()
+                )
+
+                _uiState.update { it.copy(locationDebugData = debugData) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(errorMessage = "위치 데이터 로드 실패: ${e.message}") }
+            }
+        }
+    }
+
+    /**
+     * 위치 데이터 디버그 다이얼로그 닫기
+     */
+    fun dismissLocationDebugData() {
+        _uiState.update { it.copy(locationDebugData = null) }
     }
 
     private fun loadSettings() {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -10,11 +10,13 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.health.HealthConnectManager
 import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.repository.UserRepository
+import com.example.graduation_project.domain.health.HealthConnectAvailability
 import com.example.graduation_project.presentation.permission.PermissionChecker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +40,9 @@ data class SettingsUiState(
     val voiceTone: String = "warm",
     val conversationTime: String? = null,
     val preferredSleepHours: Int? = null,
+    // 알림 설정
     val alarmEnabled: Boolean = false,
+    val morningGreetingEnabled: Boolean = true,
     // 위치 수집 설정
     val locationCollectionStartTime: String = "06:00",
     val isLocationCollectionRunning: Boolean = false,
@@ -60,6 +64,7 @@ class SettingsViewModel(
 
     private val alarmStorage = ConversationAlarmStorage(application)
     private val locationStorage = LocationCollectionStorage(application)
+    private val healthConnectManager = HealthConnectManager(application)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
@@ -77,25 +82,31 @@ class SettingsViewModel(
         // 위치 수집 시간 로드
         val locationStartTime = locationStorage.getStartTime()
 
+        // 아침 인사 알림 설정 로드
+        val morningGreetingEnabled = locationStorage.isMorningGreetingEnabled()
+
         // 권한 상태 확인
         val hasLocation = PermissionChecker.hasForegroundLocationPermission(context)
         val hasBackgroundLocation = PermissionChecker.hasBackgroundLocationPermission(context)
-        val hasHealthConnect = PermissionChecker.isHealthConnectAvailable(context)
         val hasNotification = PermissionChecker.hasNotificationPermission(context)
 
         _uiState.update {
             it.copy(
                 alarmEnabled = alarmEnabled,
+                morningGreetingEnabled = morningGreetingEnabled,
                 locationCollectionStartTime = locationStartTime,
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = hasLocation,
                 hasBackgroundLocationPermission = hasBackgroundLocation,
-                hasHealthConnectPermission = hasHealthConnect,
                 hasNotificationPermission = hasNotification
             )
         }
 
         viewModelScope.launch {
+            // Health Connect 권한 확인 (실제 권한 허용 여부)
+            val hasHealthConnectPermission = checkHealthConnectPermission()
+            _uiState.update { it.copy(hasHealthConnectPermission = hasHealthConnectPermission) }
+
             when (val result = userRepository.getPreferences()) {
                 is ApiResult.Success -> _uiState.update { applyPrefs(it, result.data).copy(isLoading = false) }
                 is ApiResult.Error -> _uiState.update { it.copy(isLoading = false) }
@@ -117,14 +128,34 @@ class SettingsViewModel(
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = PermissionChecker.hasForegroundLocationPermission(context),
                 hasBackgroundLocationPermission = currentBackgroundPermission,
-                hasHealthConnectPermission = PermissionChecker.isHealthConnectAvailable(context),
                 hasNotificationPermission = PermissionChecker.hasNotificationPermission(context)
             )
+        }
+
+        // Health Connect 권한 확인 (비동기)
+        viewModelScope.launch {
+            val hasHealthConnectPermission = checkHealthConnectPermission()
+            _uiState.update { it.copy(hasHealthConnectPermission = hasHealthConnectPermission) }
         }
 
         // 위치 권한이 새로 허용되었으면 서비스 시작
         if (!previousBackgroundPermission && currentBackgroundPermission) {
             LocationScheduler.enableLocationCollection(context)
+        }
+    }
+
+    /**
+     * Health Connect 권한 확인 (SDK 설치 + 실제 권한 허용 여부)
+     */
+    private suspend fun checkHealthConnectPermission(): Boolean {
+        return try {
+            val availability = healthConnectManager.checkAvailability()
+            if (availability != HealthConnectAvailability.Available) {
+                return false
+            }
+            healthConnectManager.checkGrantedPermissions()
+        } catch (e: Exception) {
+            false
         }
     }
 
@@ -240,6 +271,17 @@ class SettingsViewModel(
         updateAlarmSchedule(time)
 
         val message = if (enabled) "알림이 설정되었습니다" else "알림이 해제되었습니다"
+        _uiState.update { it.copy(savedMessage = message) }
+    }
+
+    /**
+     * 아침 인사 알림 활성화/비활성화 설정
+     */
+    fun setMorningGreetingEnabled(enabled: Boolean) {
+        locationStorage.setMorningGreetingEnabled(enabled)
+        _uiState.update { it.copy(morningGreetingEnabled = enabled) }
+
+        val message = if (enabled) "아침 인사 알림이 설정되었습니다" else "아침 인사 알림이 해제되었습니다"
         _uiState.update { it.copy(savedMessage = message) }
     }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -43,7 +43,6 @@ data class SettingsUiState(
     val preferredSleepHours: Int? = null,
     // 알림 설정
     val alarmEnabled: Boolean = false,
-    val morningGreetingEnabled: Boolean = true,
     // 위치 수집 설정
     val locationCollectionStartTime: String = "06:00",
     val isLocationCollectionRunning: Boolean = false,
@@ -86,9 +85,6 @@ class SettingsViewModel(
         // 위치 수집 시간 로드
         val locationStartTime = locationStorage.getStartTime()
 
-        // 아침 인사 알림 설정 로드
-        val morningGreetingEnabled = locationStorage.isMorningGreetingEnabled()
-
         // 권한 상태 확인
         val hasLocation = PermissionChecker.hasForegroundLocationPermission(context)
         val hasBackgroundLocation = PermissionChecker.hasBackgroundLocationPermission(context)
@@ -98,7 +94,6 @@ class SettingsViewModel(
         _uiState.update {
             it.copy(
                 alarmEnabled = alarmEnabled,
-                morningGreetingEnabled = morningGreetingEnabled,
                 locationCollectionStartTime = locationStartTime,
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = hasLocation,
@@ -294,17 +289,6 @@ class SettingsViewModel(
         updateAlarmSchedule(time)
 
         val message = if (enabled) "알림이 설정되었습니다" else "알림이 해제되었습니다"
-        _uiState.update { it.copy(savedMessage = message) }
-    }
-
-    /**
-     * 아침 인사 알림 활성화/비활성화 설정
-     */
-    fun setMorningGreetingEnabled(enabled: Boolean) {
-        locationStorage.setMorningGreetingEnabled(enabled)
-        _uiState.update { it.copy(morningGreetingEnabled = enabled) }
-
-        val message = if (enabled) "아침 인사 알림이 설정되었습니다" else "아침 인사 알림이 해제되었습니다"
         _uiState.update { it.copy(savedMessage = message) }
     }
 


### PR DESCRIPTION
## Summary
- 알림 권한 통합 및 건강데이터 권한 표시 개선
- 위치 수집 자동 중지 및 알람 재예약 개선
- 배터리 최적화 해제 요청 기능 추가
- 위치 수집 중복 방지 및 디버그 기능 추가

## Changes

### 알림 권한 통합
- 마이크 권한 상태 표시 (필수 권한)
- 건강 데이터 권한 상태 표시 개선

### 위치 수집 개선
- 대화 시간 지나면 서비스 자동 종료
- 알림 타임아웃 10분 → 3분 (아침 인사, 대화 종료)
- 최소 수집 간격(9분) 체크로 중복 수집 방지
- 마지막 수집 시간 저장/조회 기능

### 배터리 최적화
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 권한 추가
- 위치 권한 허용 시 / 위치 수집 ON 토글 시 자동 요청
- 설정 화면에 배터리 최적화 상태 표시

### 디버그 기능
- 설정 > 위치 수집 > 수집된 위치 데이터 확인
- 오늘 수집 개수, 마지막 수집 시간, 서비스 상태 표시
- 수집된 GPS 포인트 목록 실시간 확인

## Test plan
- [ ] 위치 권한 허용 시 배터리 최적화 해제 요청 확인
- [ ] 위치 수집 ON 토글 시 배터리 최적화 해제 요청 확인
- [ ] 대화 시간 이후 위치 수집 서비스 자동 종료 확인
- [ ] 위치 데이터 디버그 다이얼로그 표시 확인
- [ ] 10분 간격 수집 시 중복 방지 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)