### PR TITLE
fix(startup): 위치 권한 없는 상태에서 앱 시작 시 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -43,6 +43,7 @@ import com.example.graduation_project.presentation.onboarding.OnboardingScreen
 import com.example.graduation_project.presentation.settings.SettingsScreen
 import com.example.graduation_project.presentation.settings.DisplaySettingsViewModel
 import com.example.graduation_project.data.location.LocationScheduler
+import com.example.graduation_project.presentation.permission.PermissionChecker
 import com.example.graduation_project.BuildConfig
 import com.example.graduation_project.ui.theme.EchoAccentGreen
 import com.example.graduation_project.ui.theme.Graduation_projectTheme
@@ -66,8 +67,10 @@ class MainActivity : ComponentActivity() {
         val currentVersionCode = BuildConfig.VERSION_CODE.toLong()
 
         if (savedVersionCode != currentVersionCode) {
-            // 재설치 또는 업데이트 감지 → 알람 재예약
-            LocationScheduler.enableLocationCollection(this)
+            // 위치 권한이 있을 때만 서비스 시작 (없으면 Android 14+에서 SecurityException)
+            if (PermissionChecker.hasForegroundLocationPermission(this)) {
+                LocationScheduler.enableLocationCollection(this)
+            }
             prefs.edit().putLong("last_version_code", currentVersionCode).apply()
         }
     }


### PR DESCRIPTION
## Summary

- Android 14+에서 앱 재설치/업데이트 직후 위치 권한이 없는 상태에서 `foregroundServiceType=location` Foreground Service를 시작하면 `SecurityException`이 발생하는 크래시 수정
- `rescheduleAlarmsIfReinstalled()`에서 `LocationCollectionService.start()` 호출 전 `PermissionChecker.hasForegroundLocationPermission()` 확인 추가
- 권한이 없는 경우 서비스 시작을 건너뜀 (알람 재예약 버전 기록은 정상 저장됨)

## 크래시 재현 조건

1. 앱을 새로 설치하거나 재설치 (위치 권한 미부여 상태)
2. Android 14 (API 34) 이상 기기
3. 앱 실행 시 `MainActivity.onCreate()` → `rescheduleAlarmsIfReinstalled()` → `LocationCollectionService.start()` → `SecurityException`

## Test plan

- [ ] 위치 권한 미부여 상태에서 앱 설치 후 실행 → 크래시 없이 정상 시작 확인
- [ ] 위치 권한 부여 상태에서 앱 설치 후 실행 → 위치 수집 서비스 정상 시작 확인
- [ ] Android 14 기기에서 재설치 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)