### PR TITLE
feat(location): 위치 수집 토글 시간 범위 제한 기능 추가

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
@@ -125,37 +125,58 @@ object LocationScheduler {
 
     /**
      * 위치 수집 활성화
-     * - 대화 시간 전이면 즉시 서비스 시작 (권한 허용 직후 바로 수집 시작)
-     * - 대화 시간 이후면 다음날 알람만 스케줄링
+     * - 시작 시간 ~ 대화 시간 범위 내이면 즉시 서비스 시작
+     * - 범위 밖이면 다음날 알람만 스케줄링
      */
     fun enableLocationCollection(context: Context) {
-        val alarmStorage = ConversationAlarmStorage(context)
-
-        // 대화 시간 가져오기 (기본값: 21:00)
-        val conversationTime = alarmStorage.getConversationTime() ?: "21:00"
-        val endHour = try { conversationTime.split(":")[0].toInt() } catch (e: Exception) { 9 }
-        val endMinute = try { conversationTime.split(":")[1].toInt() } catch (e: Exception) { 0 }
-
-        // 현재 시간 확인
-        val now = Calendar.getInstance()
-        val currentHour = now.get(Calendar.HOUR_OF_DAY)
-        val currentMinute = now.get(Calendar.MINUTE)
-        val currentMinutes = currentHour * 60 + currentMinute
-        val endMinutes = endHour * 60 + endMinute
-
-        // 대화 시간 전인지 확인 (대화 시간 전이면 아직 오늘 대화가 안 끝났으므로 수집 필요)
-        val isBeforeConversationTime = currentMinutes < endMinutes
-
-        if (isBeforeConversationTime) {
-            // 대화 시간 전 → 즉시 서비스 시작 (권한 허용 직후 바로 수집)
-            Log.d(TAG, "대화 시간($endHour:$endMinute) 전 - 위치 수집 즉시 시작")
+        if (isCurrentTimeInCollectionRange(context)) {
+            Log.d(TAG, "수집 시간 범위 내 - 위치 수집 즉시 시작")
             LocationCollectionService.start(context)
         } else {
-            // 대화 시간 이후 → 오늘 대화는 이미 끝났으므로 내일부터 수집
-            Log.d(TAG, "대화 시간($endHour:$endMinute) 이후 - 내일 아침부터 수집 시작 예정")
+            Log.d(TAG, "수집 시간 범위 밖 - 다음 알람 시간부터 수집 시작 예정")
         }
 
         scheduleMorningAlarm(context)
         Log.d(TAG, "위치 수집 활성화 완료")
+    }
+
+    /**
+     * 현재 시간이 위치 수집 범위(시작 시간 ~ 대화 시간) 내인지 확인
+     */
+    fun isCurrentTimeInCollectionRange(context: Context): Boolean {
+        val locationStorage = LocationCollectionStorage(context)
+        val alarmStorage = ConversationAlarmStorage(context)
+
+        val startTime = locationStorage.getStartTime()
+        val conversationTime = alarmStorage.getConversationTime() ?: "21:00"
+
+        return try {
+            val now = Calendar.getInstance()
+            val currentHour = now.get(Calendar.HOUR_OF_DAY)
+            val currentMinute = now.get(Calendar.MINUTE)
+            val currentMinutes = currentHour * 60 + currentMinute
+
+            val startHour = startTime.split(":")[0].toInt()
+            val startMinuteVal = startTime.split(":")[1].toInt()
+            val startMinutes = startHour * 60 + startMinuteVal
+
+            val endHour = conversationTime.split(":")[0].toInt()
+            val endMinuteVal = conversationTime.split(":")[1].toInt()
+            val endMinutes = endHour * 60 + endMinuteVal
+
+            val isInRange = if (startMinutes <= endMinutes) {
+                // 일반적인 경우: 06:00 ~ 21:00
+                currentMinutes in startMinutes..endMinutes
+            } else {
+                // 자정을 넘기는 경우: 22:00 ~ 06:00
+                currentMinutes >= startMinutes || currentMinutes <= endMinutes
+            }
+
+            Log.d(TAG, "시간 범위 체크: now=$currentHour:$currentMinute, range=$startTime~$conversationTime, inRange=$isInRange")
+            isInRange
+        } catch (e: Exception) {
+            Log.e(TAG, "시간 범위 체크 실패", e)
+            false
+        }
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -427,6 +427,9 @@ fun SettingsScreen(
                     LocationCollectionToggleRow(
                         isRunning = uiState.isLocationCollectionRunning,
                         hasPermission = uiState.hasBackgroundLocationPermission,
+                        isToggleEnabled = uiState.isLocationToggleEnabled,
+                        startTime = uiState.locationCollectionStartTime,
+                        endTime = uiState.conversationTime ?: "21:00",
                         onToggle = { viewModel.toggleLocationCollection() }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
@@ -731,14 +734,22 @@ private fun MicrophonePermissionStatusRow(
 
 /**
  * 위치 수집 상태 토글
+ * - 시간 범위 내에서만 토글 활성화
+ * - 범위 밖에서는 비활성화 + 안내 메시지 표시
  */
 @Composable
 private fun LocationCollectionToggleRow(
     isRunning: Boolean,
     hasPermission: Boolean,
+    isToggleEnabled: Boolean,
+    startTime: String,
+    endTime: String,
     onToggle: () -> Unit
 ) {
     val colors = LocalEchoColors.current
+    // 권한이 없거나 시간 범위 밖이면 비활성화
+    val isEnabled = hasPermission && isToggleEnabled
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -765,16 +776,30 @@ private fun LocationCollectionToggleRow(
                     color = if (isRunning) colors.accentGreen else colors.textTertiary
                 )
             }
+            // 시간 범위 밖일 때 안내 메시지
+            if (hasPermission && !isToggleEnabled) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "$startTime ~ $endTime 사이에만 사용 가능",
+                    fontSize = 13.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = colors.textTertiary
+                )
+            }
         }
         Switch(
             checked = isRunning,
             onCheckedChange = { onToggle() },
-            enabled = hasPermission,
+            enabled = isEnabled,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = Color.White,
                 checkedTrackColor = colors.accentGreen,
                 uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = colors.bgMuted
+                uncheckedTrackColor = colors.bgMuted,
+                disabledCheckedThumbColor = Color.White.copy(alpha = 0.6f),
+                disabledCheckedTrackColor = colors.accentGreen.copy(alpha = 0.4f),
+                disabledUncheckedThumbColor = Color.White.copy(alpha = 0.6f),
+                disabledUncheckedTrackColor = colors.bgMuted.copy(alpha = 0.4f)
             )
         )
     }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -49,6 +49,7 @@ data class SettingsUiState(
     // 위치 수집 설정
     val locationCollectionStartTime: String = "06:00",
     val isLocationCollectionRunning: Boolean = false,
+    val isLocationToggleEnabled: Boolean = false,  // 시간 범위 내일 때만 토글 활성화
     // 권한 상태
     val hasLocationPermission: Boolean = false,
     val hasBackgroundLocationPermission: Boolean = false,
@@ -165,6 +166,7 @@ class SettingsViewModel(
                 alarmEnabled = alarmEnabled,
                 locationCollectionStartTime = locationStartTime,
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
+                isLocationToggleEnabled = LocationScheduler.isCurrentTimeInCollectionRange(context),
                 hasLocationPermission = hasLocation,
                 hasBackgroundLocationPermission = hasBackgroundLocation,
                 hasNotificationPermission = hasNotification,
@@ -201,6 +203,7 @@ class SettingsViewModel(
         _uiState.update {
             it.copy(
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
+                isLocationToggleEnabled = LocationScheduler.isCurrentTimeInCollectionRange(context),
                 hasLocationPermission = PermissionChecker.hasForegroundLocationPermission(context),
                 hasBackgroundLocationPermission = currentBackgroundPermission,
                 hasNotificationPermission = PermissionChecker.hasNotificationPermission(context),
@@ -243,10 +246,17 @@ class SettingsViewModel(
     }
 
     /**
-     * 위치 수집 시작/중지 토글 (수동 제어 - 시간 범위 무관)
+     * 위치 수집 시작/중지 토글 (시간 범위 내에서만 가능)
      */
     fun toggleLocationCollection() {
         val context = getApplication<Application>()
+
+        // 시간 범위 밖이면 토글 불가
+        if (!LocationScheduler.isCurrentTimeInCollectionRange(context)) {
+            _uiState.update { it.copy(errorMessage = "현재 시간은 위치 수집 범위 밖입니다") }
+            return
+        }
+
         if (LocationCollectionService.isRunning) {
             LocationCollectionService.stop(context)
             _uiState.update { it.copy(isLocationCollectionRunning = false, savedMessage = "위치 수집이 중지되었습니다") }
@@ -364,19 +374,14 @@ class SettingsViewModel(
     /**
      * 위치 수집 상태 확인 및 자동 조정
      * - 현재 시간이 수집 범위(시작 시간 ~ 대화 시간) 밖이면 서비스 자동 중지
-     * - 범위 내이고 권한이 있으면 서비스 자동 시작
+     * - 토글 활성화 상태도 함께 업데이트
      */
     private fun checkAndUpdateLocationCollectionStatus() {
         val context = getApplication<Application>()
-        val startTime = _uiState.value.locationCollectionStartTime
-        val conversationTime = _uiState.value.conversationTime
+        val isInRange = LocationScheduler.isCurrentTimeInCollectionRange(context)
 
-        // 대화 시간이 설정되지 않은 경우 체크 불가
-        if (conversationTime.isNullOrBlank()) {
-            return
-        }
-
-        val isInRange = isCurrentTimeInRange(startTime, conversationTime)
+        // 토글 활성화 상태 업데이트
+        _uiState.update { it.copy(isLocationToggleEnabled = isInRange) }
 
         if (LocationCollectionService.isRunning && !isInRange) {
             // 범위 밖인데 서비스가 실행 중이면 중지


### PR DESCRIPTION
## Summary
- 권한 허용 시 시작 시간 ~ 대화 시간 전체 범위 체크 추가
- 시간 범위 밖에서는 위치 수집 토글 비활성화
- 비활성화 시 안내 메시지 표시 ("06:00 ~ 21:00 사이에만 사용 가능")

## Changes
- `LocationScheduler.kt`: `isCurrentTimeInCollectionRange()` 함수 추가
- `SettingsViewModel.kt`: `isLocationToggleEnabled` 상태 관리 추가
- `SettingsScreen.kt`: 토글 UI 비활성화 + 안내 메시지 표시

## 동작
| 조건 | 토글 상태 |
|------|----------|
| 권한 없음 | 비활성화 |
| 시간 범위 밖 | 비활성화 + 안내 메시지 |
| 권한 있음 + 범위 내 | 활성화 |

## Test plan
- [ ] 시간 범위 내에서 토글 ON/OFF 정상 동작 확인
- [ ] 시간 범위 밖에서 토글 비활성화 및 안내 메시지 확인
- [ ] 권한 허용 시 범위 체크 후 서비스 시작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)