### PR TITLE
fix(auth): EncryptedSharedPreferences 예외 미처리로 인한 앱 시작 크래시 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
@@ -8,8 +8,10 @@ import androidx.security.crypto.MasterKey
  * Access/Refresh Token을 EncryptedSharedPreferences에 안전하게 저장.
  *
  * - 첫 호출 시 Keystore 초기화 비용이 큼 → ViewModel/Repository에서 IO 디스패처 호출 권장.
+ * - EncryptedSharedPreferences 초기화/복호화 실패 시(업데이트, 알파 버전 버그 등)
+ *   손상된 파일을 삭제하고 null을 반환하여 크래시 대신 로그아웃으로 처리.
  */
-class TokenStorage(context: Context) {
+class TokenStorage(private val context: Context) {
 
     private val masterKey by lazy {
         MasterKey.Builder(context)
@@ -27,19 +29,46 @@ class TokenStorage(context: Context) {
         )
     }
 
-    fun saveTokens(accessToken: String, refreshToken: String) {
-        prefs.edit()
-            .putString(KEY_ACCESS_TOKEN, accessToken)
-            .putString(KEY_REFRESH_TOKEN, refreshToken)
-            .apply()
+    fun getAccessToken(): String? = try {
+        prefs.getString(KEY_ACCESS_TOKEN, null)
+    } catch (e: Exception) {
+        deletePrefsFile()
+        null
     }
 
-    fun getAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+    fun getRefreshToken(): String? = try {
+        prefs.getString(KEY_REFRESH_TOKEN, null)
+    } catch (e: Exception) {
+        deletePrefsFile()
+        null
+    }
 
-    fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+    fun saveTokens(accessToken: String, refreshToken: String) {
+        try {
+            prefs.edit()
+                .putString(KEY_ACCESS_TOKEN, accessToken)
+                .putString(KEY_REFRESH_TOKEN, refreshToken)
+                .apply()
+        } catch (e: Exception) {
+            deletePrefsFile()
+        }
+    }
 
     fun clear() {
-        prefs.edit().clear().apply()
+        try {
+            prefs.edit().clear().apply()
+        } catch (e: Exception) {
+            deletePrefsFile()
+        }
+    }
+
+    private fun deletePrefsFile() {
+        try {
+            val file = java.io.File(
+                context.filesDir.parent + "/shared_prefs/$PREF_NAME.xml"
+            )
+            file.delete()
+        } catch (e: Exception) { /* ignore */ }
     }
 
     companion object {


### PR DESCRIPTION
## Summary

- `TokenStorage`의 모든 `EncryptedSharedPreferences` 접근 메서드에 try-catch 추가
- 예외 발생 시 손상된 prefs 파일을 삭제하고 null 반환 → 크래시 대신 로그아웃 처리
- `context` 파라미터를 `private val`로 변경하여 `deletePrefsFile()` 내부 사용

## 크래시 원인

`security-crypto:1.1.0-alpha06` 알파 버전의 알려진 버그로:
- **신규 설치**: `EncryptedSharedPreferences.create()` 초기화 실패 가능 (일부 Android 버전)
- **업데이트**: 기존 암호화 데이터 복호화 실패 (`AEADBadTagException`)
- try-catch 없음 → 앱 즉시 종료

## 수정 동작

1. 예외 발생 → `deletePrefsFile()`로 손상된 파일 삭제
2. 다음 접근 시 Kotlin lazy가 재시도 → 새 파일로 정상 초기화
3. 사용자는 재설치 없이 재로그인만 하면 정상 사용 가능

## Test plan

- [ ] 앱 완전 삭제 후 재설치 → 로그인 화면 정상 표시 확인 (크래시 없음)
- [ ] 로그인 상태에서 앱 업데이트(덮어쓰기) → 크래시 없이 로그인 화면 이동 확인
- [ ] 로그인 후 앱 재실행 → 로그인 상태 유지 확인 (정상 케이스 회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)