### PR TITLE
fix: 앱 재설치/업데이트 후 온보딩 강제 진입 및 권한 요청 누락 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -71,7 +71,10 @@ class MainActivity : ComponentActivity() {
             if (PermissionChecker.hasForegroundLocationPermission(this)) {
                 LocationScheduler.enableLocationCollection(this)
             }
-            prefs.edit().putLong("last_version_code", currentVersionCode).apply()
+            prefs.edit()
+                .putLong("last_version_code", currentVersionCode)
+                .putBoolean("needs_permission_recheck", true)
+                .apply()
         }
     }
 
@@ -194,11 +197,11 @@ private fun AppNavHost(navigateTo: String? = null, displayViewModel: DisplaySett
                 LoginScreen(
                     onLoginSuccess = {
                         coroutineScope.launch {
-                            val completed = when (val result = userRepository.getOnboardingStatus()) {
-                                is ApiResult.Success -> result.data.completed
-                                is ApiResult.Error -> false
+                            val destination = when (val result = userRepository.getOnboardingStatus()) {
+                                is ApiResult.Success -> if (result.data.completed) EchoTab.HOME.route else Routes.ONBOARDING
+                                // 네트워크/서버 오류 시 CHECKING으로 이동해 재시도 — 온보딩 강제 진입 방지
+                                is ApiResult.Error -> Routes.CHECKING
                             }
-                            val destination = if (completed) EchoTab.HOME.route else Routes.ONBOARDING
                             navController.navigate(destination) {
                                 popUpTo(Routes.LOGIN) { inclusive = true }
                             }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -139,8 +139,24 @@ class OnboardingViewModel(
 
                     _uiState.update { it.copy(isLoading = false, isCompleted = true) }
                 }
-                is ApiResult.Error -> _uiState.update {
-                    it.copy(isLoading = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
+                is ApiResult.Error -> {
+                    // 저장 오류 발생 시, 네트워크 타임아웃 등으로 서버에 이미 저장됐을 수 있으므로 상태 재확인
+                    when (val statusResult = userRepository.getOnboardingStatus()) {
+                        is ApiResult.Success -> if (statusResult.data.completed) {
+                            val time = state.conversationTime.ifBlank { null }
+                            alarmStorage.saveConversationTime(time)
+                            alarmStorage.setAlarmEnabled(state.alarmEnabled)
+                            if (state.alarmEnabled && time != null) {
+                                ConversationAlarmScheduler.scheduleAlarm(getApplication(), time)
+                            }
+                            _uiState.update { it.copy(isLoading = false, isCompleted = true) }
+                        } else {
+                            _uiState.update { it.copy(isLoading = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.") }
+                        }
+                        is ApiResult.Error -> _uiState.update {
+                            it.copy(isLoading = false, errorMessage = "서버에 문제가 생겼습니다. 잠시 후 다시 시도해주세요.")
+                        }
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
@@ -21,6 +21,11 @@ import androidx.health.connect.client.HealthConnectClient
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.presentation.health.openHealthConnectSettings
 
+private const val APP_STATE_PREFS = "app_state"
+private const val PERMISSION_STATE_PREFS = "permission_state"
+private const val KEY_PERMISSION_FLOW_COMPLETED = "permission_flow_completed"
+private const val KEY_NEEDS_PERMISSION_RECHECK = "needs_permission_recheck"
+
 /**
  * 권한 요청 단계
  */
@@ -44,6 +49,8 @@ fun UnifiedPermissionHandler(
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
+    val appStatePrefs = context.getSharedPreferences(APP_STATE_PREFS, Context.MODE_PRIVATE)
+    val permPrefs = context.getSharedPreferences(PERMISSION_STATE_PREFS, Context.MODE_PRIVATE)
 
     // 현재 권한 요청 단계
     var currentStep by remember { mutableStateOf(PermissionStep.INTRO) }
@@ -54,9 +61,13 @@ fun UnifiedPermissionHandler(
     var showNotificationSettingsDialog by remember { mutableStateOf(false) }
     var showHealthConnectSettingsDialog by remember { mutableStateOf(false) }
 
-    // 이미 권한 처리를 완료했는지 (앱 재시작 시 다시 안 물어봄)
+    // 앱 업데이트/재설치(버전 코드 변경) 시 권한 재확인 필요 여부
+    val needsRecheck = appStatePrefs.getBoolean(KEY_NEEDS_PERMISSION_RECHECK, false)
+    // 이전에 권한 플로우를 완료한 적 있는지 (SharedPreferences에 영구 저장)
+    val previouslyCompleted = permPrefs.getBoolean(KEY_PERMISSION_FLOW_COMPLETED, false)
+
     var hasCompletedOnboarding by remember {
-        mutableStateOf(PermissionChecker.hasMicrophonePermission(context))
+        mutableStateOf(previouslyCompleted && !needsRecheck)
     }
 
     // 마이크 권한 요청 런처
@@ -112,6 +123,8 @@ fun UnifiedPermissionHandler(
     ) { _ ->
         currentStep = PermissionStep.COMPLETED
         hasCompletedOnboarding = true
+        permPrefs.edit().putBoolean(KEY_PERMISSION_FLOW_COMPLETED, true).apply()
+        appStatePrefs.edit().putBoolean(KEY_NEEDS_PERMISSION_RECHECK, false).apply()
         onAllPermissionsHandled()
     }
 
@@ -167,11 +180,15 @@ fun UnifiedPermissionHandler(
                     } else {
                         currentStep = PermissionStep.COMPLETED
                         hasCompletedOnboarding = true
+                        permPrefs.edit().putBoolean(KEY_PERMISSION_FLOW_COMPLETED, true).apply()
+                        appStatePrefs.edit().putBoolean(KEY_NEEDS_PERMISSION_RECHECK, false).apply()
                         onAllPermissionsHandled()
                     }
                 } else {
                     currentStep = PermissionStep.COMPLETED
                     hasCompletedOnboarding = true
+                    permPrefs.edit().putBoolean(KEY_PERMISSION_FLOW_COMPLETED, true).apply()
+                    appStatePrefs.edit().putBoolean(KEY_NEEDS_PERMISSION_RECHECK, false).apply()
                     onAllPermissionsHandled()
                 }
             }
@@ -246,6 +263,8 @@ fun UnifiedPermissionHandler(
                 showHealthConnectSettingsDialog = false
                 currentStep = PermissionStep.COMPLETED
                 hasCompletedOnboarding = true
+                permPrefs.edit().putBoolean(KEY_PERMISSION_FLOW_COMPLETED, true).apply()
+                appStatePrefs.edit().putBoolean(KEY_NEEDS_PERMISSION_RECHECK, false).apply()
             },
             onOpenSettings = {
                 openHealthConnectSettings(context)


### PR DESCRIPTION
## Summary

- 로그인 후 `getOnboardingStatus()` API 실패 시 이미 온보딩을 완료한 사용자도 온보딩 화면으로 강제 진입하던 문제 수정 → 오류 시 CHECKING 라우트로 이동해 자동 재시도
- 온보딩 저장(`updatePreferences`) 실패 시 서버에 이미 저장됐을 수 있으므로 `getOnboardingStatus()` 재확인 후 `completed=true`이면 성공으로 처리 (타임아웃/네트워크 불안정으로 인한 오탐 방지)
- 앱 업데이트/재설치 시 마이크 권한만으로 권한 플로우 완료를 판단하던 로직 수정 → SharedPreferences에 완료 여부 영구 저장, 버전 코드 변경 시 권한 재확인 강제

## Test plan

- [ ] 기존 사용자 계정으로 앱 재설치 후 로그인 → 홈 화면으로 이동하는지 확인
- [ ] 새 계정으로 온보딩 입력 완료 시 서버 오류가 발생해도 `completed=true` 확인 후 홈으로 이동하는지 확인
- [ ] 앱 업데이트 후 `ConversationScreen` 진입 시 미허용 권한(위치, 알림 등) 요청 다이얼로그가 표시되는지 확인
- [ ] 정상 사용자(모든 권한 허용)는 대화 화면 진입 시 권한 요청 없이 바로 사용 가능한지 확인 (회귀 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)