### PR TITLE
chore: develop 분기 동기화 및 dead code 정리

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -48,8 +48,6 @@ import com.example.graduation_project.presentation.settings.SettingsScreen
 import com.example.graduation_project.presentation.settings.DisplaySettingsViewModel
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.location.MorningAlarmReceiver
-import com.example.graduation_project.BuildConfig
-import com.example.graduation_project.presentation.permission.PermissionChecker
 import com.example.graduation_project.presentation.permission.SamsungBatterySettingsDialog
 import com.example.graduation_project.util.DeviceUtil
 import com.example.graduation_project.ui.theme.EchoAccentGreen
@@ -72,25 +70,6 @@ class MainActivity : ComponentActivity() {
 
     // 권한 다이얼로그 표시 여부 (알림에서 앱 열었을 때)
     private var shouldShowPermissionDialog = mutableStateOf(false)
-    /**
-     * 앱 재설치 감지 후 알람 재예약
-     * - 버전 코드가 변경되었거나 처음 실행 시에만 알람 재예약
-     */
-    private fun rescheduleAlarmsIfReinstalled() {
-        val prefs = getSharedPreferences("app_state", MODE_PRIVATE)
-        val savedVersionCode = prefs.getLong("last_version_code", -1)
-        val currentVersionCode = BuildConfig.VERSION_CODE.toLong()
-
-        if (savedVersionCode != currentVersionCode) {
-            if (PermissionChecker.hasForegroundLocationPermission(this)) {
-                LocationScheduler.enableLocationCollection(this)
-            }
-            prefs.edit()
-                .putLong("last_version_code", currentVersionCode)
-                .putBoolean("needs_permission_recheck", true)
-                .apply()
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
## Summary
- 로컬 develop에서 `fix/location-precision-analysis` 브랜치를 머지한 커밋(`2cb8893`)이 origin에 push되지 않은 상태에서, 동일 브랜치가 GitHub PR #338로 별도 머지되어 로컬/origin develop이 갈라졌습니다.
- `git pull origin develop`로 두 히스토리를 병합하며 `MainActivity.kt`의 docstring 충돌을 해결했습니다 (origin 쪽 docstring 채택, 로직 변경 없음).
- PR #337/#338 머지 과정에서 정의만 남고 호출부가 빠진 죽은 코드 `rescheduleAlarmsIfReinstalled()`와 관련 import(`BuildConfig`, `PermissionChecker`)를 제거했습니다 (`ed816e1`에서 `handlePermissionDialogIntent` 방식으로 이미 대체된 로직).

## Test plan
- [x] `./gradlew :app:compileLocalDebugKotlin` 컴파일 통과 확인
- [ ] 실질적 로직 변경 없음 (병합 충돌 해결 + 미사용 코드 제거)