### PR TITLE
fix: 화면 회전 시 대화가 초기화되는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -78,8 +79,8 @@ class MainActivity : ComponentActivity() {
         // 알림에서 권한 다이얼로그 표시 요청 확인
         handlePermissionDialogIntent(intent)
 
-        // 알림 딥링크 처리
-        val navigateTo = intent.getStringExtra("navigate_to")
+        // 알림 딥링크 처리 (회전 등 재생성 시 재실행 방지 위해 콜드 스타트에만 적용)
+        val navigateTo = if (savedInstanceState == null) intent.getStringExtra("navigate_to") else null
 
         setContent {
             val displaySettings by displayViewModel.settings.collectAsState()
@@ -279,10 +280,12 @@ private fun AppNavHost(
 
     // EncryptedSharedPreferences 초기화는 Android Keystore를 사용하므로
     // 메인 스레드에서 동기 호출 시 ANR/크래시 발생. IO 스레드에서 비동기 처리.
-    var startDestination by remember { mutableStateOf<String?>(null) }
+    var startDestination by rememberSaveable { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
-        val hasToken = withContext(Dispatchers.IO) { authRepository.hasAccessToken() }
-        startDestination = if (hasToken) Routes.CHECKING else Routes.LOGIN
+        if (startDestination == null) {
+            val hasToken = withContext(Dispatchers.IO) { authRepository.hasAccessToken() }
+            startDestination = if (hasToken) Routes.CHECKING else Routes.LOGIN
+        }
     }
 
     // 알림에서 홈 화면으로 이동 요청 시 처리

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -307,6 +307,10 @@ class ConversationViewModel(
         if (_uiState.value.conversationState is ConversationState.Ended) {
             resetToIdle()
         }
+        // 이미 대화가 진행 중이면(Listening/Recording/Sending/Playing 등) 재시작하지 않음.
+        // canTransitionTo(Sending)만으로는 endConversation()/sendMessage()를 위해 열어둔
+        // Listening/Recording → Sending 전이까지 통과시켜버려 재진입을 막지 못함.
+        if (_uiState.value.conversationState !is ConversationState.Idle) return
         viewModelScope.launch {
             isServerRetryInProgress = false
             // Idle → Sending (이미 Sending이면 중복 요청으로 간주하고 차단)


### PR DESCRIPTION
## Summary
- 대화 중 화면을 회전하면 `AppNavHost`의 `startDestination`이 `remember`로만 저장되어 있어 Activity 재생성 시 재계산되고, 그 사이 `NavHost`가 잠깐 컴포지션에서 빠지며 백스택과 `ConversationViewModel`이 파괴되어 대화가 처음부터 재시작되던 문제를 수정했습니다.
- `startDestination`을 `rememberSaveable`로 유지하고 이미 결정된 경우 재계산을 생략, 알림 딥링크(`navigate_to`)는 콜드 스타트에만 적용하도록 변경했습니다.
- `ConversationViewModel.startConversation()`에 `Idle` 상태가 아니면 재시작하지 않는 가드를 추가해 방어적으로 이중 안전장치를 마련했습니다.
- 참고: OS의 메모리 부족으로 인한 프로세스 강제 종료 후 복구(SavedStateHandle 기반 영구 저장) 시나리오는 심각도/발생빈도 대비 수정 비용이 높아 이번 스코프에서 제외했습니다. 필요 시 별도 이슈로 진행 예정입니다.

## Test plan
- [x] `./gradlew compileLocalDebugKotlin compileProdDebugKotlin` 빌드 성공
- [x] `ConversationViewModelTest` 7건 전부 통과
- [x] 전체 유닛테스트 중 `LocationSchedulerTest` 1건 실패는 수정 전 baseline에서도 동일하게 실패하는 무관한 flaky 테스트임을 확인
- [x] 실기기에서 대화 중 화면 회전 시 대화가 끊기지 않는 것을 수동 확인 (QA 담당자 확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)