### PR TITLE
fix: 정확한 알람 권한 누락으로 대화 알림이 늦게 오는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
@@ -27,6 +27,15 @@ private const val KEY_PERMISSION_FLOW_COMPLETED = "permission_flow_completed"
 private const val KEY_NEEDS_PERMISSION_RECHECK = "needs_permission_recheck"
 
 /**
+ * 정확한 알람 권한이 없으면 시스템 설정으로 안내 (Android 12+)
+ */
+private fun requestExactAlarmPermissionIfNeeded(context: Context) {
+    if (!PermissionChecker.hasExactAlarmPermission(context)) {
+        PermissionChecker.openExactAlarmSettings(context)
+    }
+}
+
+/**
  * 권한 요청 단계
  */
 enum class PermissionStep {
@@ -111,8 +120,8 @@ fun UnifiedPermissionHandler(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
         // 알림 권한 허용 시 정확한 알람 권한도 요청
-        if (granted && !PermissionChecker.hasExactAlarmPermission(context)) {
-            PermissionChecker.openExactAlarmSettings(context)
+        if (granted) {
+            requestExactAlarmPermissionIfNeeded(context)
         }
         currentStep = PermissionStep.HEALTH_CONNECT
     }
@@ -164,11 +173,13 @@ fun UnifiedPermissionHandler(
             PermissionStep.NOTIFICATION -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     if (PermissionChecker.hasNotificationPermission(context)) {
+                        requestExactAlarmPermissionIfNeeded(context)
                         currentStep = PermissionStep.HEALTH_CONNECT
                     } else {
                         notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                     }
                 } else {
+                    requestExactAlarmPermissionIfNeeded(context)
                     currentStep = PermissionStep.HEALTH_CONNECT
                 }
             }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsScreen.kt
@@ -505,6 +505,15 @@ fun SettingsScreen(
                         }
                     )
                     HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
+                    // 정확한 알람 권한 상태 (Android 12+, 대화 시간 알림을 정확한 시각에 받기 위해 필요)
+                    PermissionStatusRow(
+                        label = "정확한 알람 권한",
+                        isGranted = uiState.hasExactAlarmPermission,
+                        grantedText = "허용됨",
+                        deniedText = "허용 필요 (터치하여 설정)",
+                        onClick = { PermissionChecker.openExactAlarmSettings(context) }
+                    )
+                    HorizontalDivider(color = colors.borderSubtle, modifier = Modifier.padding(horizontal = 20.dp))
                     // 앱 권한 설정 - 권한 페이지로 직접 이동
                     NavigationRow(
                         label = "앱 권한 설정",

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -62,6 +62,7 @@ data class SettingsUiState(
     val hasBackgroundLocationPermission: Boolean = false,
     val hasHealthConnectPermission: Boolean = false,
     val hasNotificationPermission: Boolean = true,
+    val hasExactAlarmPermission: Boolean = true,
     val isBatteryOptimizationDisabled: Boolean = false,
     // 배터리 최적화 해제 요청 이벤트 (UI에서 처리)
     val shouldRequestBatteryOptimization: Boolean = false,
@@ -255,6 +256,7 @@ class SettingsViewModel(
         val hasLocation = PermissionChecker.hasForegroundLocationPermission(context)
         val hasBackgroundLocation = PermissionChecker.hasBackgroundLocationPermission(context)
         val hasNotification = PermissionChecker.hasNotificationPermission(context)
+        val hasExactAlarm = PermissionChecker.hasExactAlarmPermission(context)
         val isBatteryOptimizationDisabled = checkBatteryOptimizationDisabled()
 
         _uiState.update {
@@ -265,6 +267,7 @@ class SettingsViewModel(
                 hasLocationPermission = hasLocation,
                 hasBackgroundLocationPermission = hasBackgroundLocation,
                 hasNotificationPermission = hasNotification,
+                hasExactAlarmPermission = hasExactAlarm,
                 isBatteryOptimizationDisabled = isBatteryOptimizationDisabled
             )
         }
@@ -301,6 +304,7 @@ class SettingsViewModel(
                 hasLocationPermission = PermissionChecker.hasForegroundLocationPermission(context),
                 hasBackgroundLocationPermission = currentBackgroundPermission,
                 hasNotificationPermission = PermissionChecker.hasNotificationPermission(context),
+                hasExactAlarmPermission = PermissionChecker.hasExactAlarmPermission(context),
                 isBatteryOptimizationDisabled = isBatteryOptimizationDisabled
             )
         }

--- a/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
@@ -68,6 +68,7 @@ class SettingsViewModelTest {
         every { PermissionChecker.hasForegroundLocationPermission(any()) } returns false
         every { PermissionChecker.hasBackgroundLocationPermission(any()) } returns false
         every { PermissionChecker.hasNotificationPermission(any()) } returns true
+        every { PermissionChecker.hasExactAlarmPermission(any()) } returns true
         every { LocationCollectionService.isRunning } returns false
         every { LocationScheduler.enableLocationCollection(any()) } returns true
     }
@@ -125,6 +126,43 @@ class SettingsViewModelTest {
         assertFalse(
             "삼성 기기가 아니면 삼성 다이얼로그 이벤트가 발생하지 않아야 함",
             viewModel.uiState.value.shouldShowSamsungBatteryDialog
+        )
+    }
+
+    // ===== 정확한 알람 권한 (2개) =====
+
+    @Test
+    fun `loadSettings이_정확한_알람_권한_상태를_반영한다`() = runTest {
+        // Given: 정확한 알람 권한 없음
+        every { PermissionChecker.hasExactAlarmPermission(any()) } returns false
+
+        // When: ViewModel 생성 (init에서 loadSettings 호출)
+        val viewModel = SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 정확한 알람 권한 없음 상태가 반영됨
+        assertFalse(
+            "정확한 알람 권한이 없으면 hasExactAlarmPermission이 false여야 함",
+            viewModel.uiState.value.hasExactAlarmPermission
+        )
+    }
+
+    @Test
+    fun `refreshPermissionStatus가_정확한_알람_권한_최신_상태를_반영한다`() = runTest {
+        // Given: 정확한 알람 권한 있음 상태로 시작
+        every { PermissionChecker.hasExactAlarmPermission(any()) } returns true
+        val viewModel = SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When: 정확한 알람 권한이 해제된 뒤 재확인
+        every { PermissionChecker.hasExactAlarmPermission(any()) } returns false
+        viewModel.refreshPermissionStatus()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 최신 상태(false)가 반영됨
+        assertFalse(
+            "정확한 알람 권한이 해제되면 refreshPermissionStatus 후 false로 갱신되어야 함",
+            viewModel.uiState.value.hasExactAlarmPermission
         )
     }
 


### PR DESCRIPTION
## Summary
- 알림 권한(`POST_NOTIFICATIONS`)이 이미 허용된 경로(권한 재점검 흐름, API 31-32)에서는 정확한 알람 권한(`SCHEDULE_EXACT_ALARM`) 체크를 건너뛰던 버그를 수정 — 3곳(알림 신규 허용 콜백 / 이미 허용된 분기 / API 31-32 분기) 모두에서 `requestExactAlarmPermissionIfNeeded` 헬퍼를 통해 정확한 알람 권한을 확인·요청하도록 통일
- 설정 화면 "알람 및 권한 설정" 카드에 "정확한 알람 권한" 상태 행을 추가해, 권한이 나중에 꺼지거나 애초에 거부된 경우에도 언제든 확인 후 재요청 가능하도록 함
- `SettingsViewModelTest`에 회귀 테스트 2개 추가 (`loadSettings`/`refreshPermissionStatus`가 정확한 알람 권한 상태를 반영하는지)

## Test plan
- [x] `./gradlew testLocalDebugUnitTest --tests SettingsViewModelTest` 통과 (기존 5개 + 신규 2개)
- [x] `./gradlew assembleLocalDebug`, `assembleProdDebug` 빌드 통과
- [x] 에뮬레이터(API 36) 실기기 검증: 설정 화면에 새 행 노출 → 탭 시 시스템 "Alarms & reminders" 설정으로 이동 → 권한 허용 후 복귀 시 "허용됨"으로 자동 갱신 확인 (ON_RESUME 훅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)