### PR TITLE
fix: 가로모드에서 대화 종료 버튼이 화면 밖으로 밀려나는 문제 해결

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -1,5 +1,6 @@
 package com.example.graduation_project.presentation.conversation
 
+import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,7 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -28,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -102,6 +106,7 @@ private fun ConversationScreenContent(
     onRetryClick: () -> Unit = {}
 ) {
     val colors = LocalEchoColors.current
+    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     Scaffold(
         containerColor = colors.bgPage,
         snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -110,16 +115,16 @@ private fun ConversationScreenContent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(horizontal = 32.dp),
+                .padding(horizontal = 32.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(Modifier.weight(1f))
-
-            // 캐릭터 이미지 영역
+            // 캐릭터 이미지 영역 (가로모드에서는 축소하여 버튼이 가려지지 않도록 함)
             CharacterWebpSection(
                 state = uiState.conversationState,
                 error = uiState.currentError,
-                modifier = Modifier.size(240.dp)
+                modifier = Modifier.size(if (isLandscape) 140.dp else 240.dp)
             )
 
             Spacer(Modifier.height(32.dp))
@@ -131,7 +136,7 @@ private fun ConversationScreenContent(
                 currentUserSpeech = uiState.currentUserSpeech
             )
 
-            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.height(32.dp))
 
             // 하단 버튼 영역
             BottomActionSection(


### PR DESCRIPTION
## Summary
- `ConversationScreenContent`(대화 화면)의 Column에 `verticalScroll`이 없어, 가로모드처럼 세로 공간이 부족한 상황에서 고정 크기 요소(캐릭터 이미지 240dp 등)가 화면을 넘치면서 "대화 종료" 버튼이 화면 밖으로 밀려나 보이지 않던 버그를 수정
- `Modifier.verticalScroll(rememberScrollState())`를 추가해 안전장치로 확보 (로그인/회원가입/설정/온보딩 화면과 동일한 기존 패턴)
- `weight(1f)` 스페이서는 `verticalScroll`과 함께 쓰면 런타임 크래시가 나는 Compose 제약이 있어, `Arrangement.Center`로 교체 (`LoginScreen.kt`와 동일한 패턴)
- 가로모드일 때는 캐릭터 이미지 크기를 240dp → 140dp로 축소해, 스크롤 없이도 버튼이 바로 보이도록 함 (텍스트는 상태 피드백이라 그대로 유지)

## Test plan
- [x] `./gradlew testLocalDebugUnitTest` 통과
- [x] `./gradlew assembleProdDebug` 빌드 통과
- [x] 에뮬레이터(API 36) 실기기 검증: 세로모드 정상 표시 → 가로모드 회전 시 캐릭터 이미지 축소 + "대화 종료" 버튼 스크롤 없이 바로 보임 확인 → 다시 세로모드 복귀 시 원래 크기(240dp)로 정상 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)