### PR TITLE
fix: 위치 수집 스케줄링 버그 4개 수정 (자정 넘김, 권한 변경, 자동복구, 정확도)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
@@ -28,17 +28,16 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         Log.d(TAG, "대화 알람 수신")
 
-        // 위치 권한 확인
+        // 위치 권한 확인 (알림 문구 분기용으로만 사용)
         val hasLocationPermission = hasBackgroundLocationPermission(context)
 
-        if (hasLocationPermission) {
-            // 위치 수집 서비스 종료 (대화 시간에 자동 종료)
-            LocationCollectionService.stop(context)
-            Log.d(TAG, "위치 수집 서비스 종료")
+        // 위치 수집 서비스 종료 (대화 시간에 자동 종료) - 권한 여부와 무관하게 항상 시도
+        LocationCollectionService.stop(context)
+        Log.d(TAG, "위치 수집 서비스 종료")
 
-            // 다음날 위치 수집 알람 스케줄링
-            LocationScheduler.scheduleMorningAlarm(context)
-        }
+        // 다음날 위치 수집 알람 재스케줄링 - 권한 여부와 무관하게 항상 재예약
+        // (권한 미충족 시에는 알람이 울려도 MorningAlarmReceiver → checkPrerequisites에서 서비스 시작만 스킵됨)
+        LocationScheduler.scheduleMorningAlarm(context)
 
         // 알림 표시 (권한 상태에 따라 다른 내용)
         showNotification(context, hasLocationPermission)

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationCollectionService.kt
@@ -213,7 +213,7 @@ class LocationCollectionService : Service() {
             // 타임아웃 설정 (30초)
             val location = withTimeout(LOCATION_TIMEOUT_MS) {
                 fusedLocationClient.getCurrentLocation(
-                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                    Priority.PRIORITY_HIGH_ACCURACY,
                     cancellationToken.token
                 ).await()
             }

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationScheduler.kt
@@ -46,6 +46,18 @@ object LocationScheduler {
     private const val LOW_BATTERY_NOTIFICATION_COOLDOWN_MS = 60 * 60 * 1000L // 1시간
 
     /**
+     * 시작/종료 시간(분 단위) 기준으로 현재 시간이 범위 내인지 확인.
+     * 시작 시간이 종료 시간보다 늦으면 자정을 넘기는 범위로 간주 (예: 23:00 ~ 06:00).
+     */
+    internal fun isTimeInRange(currentMinutes: Int, startMinutes: Int, endMinutes: Int): Boolean {
+        return if (startMinutes <= endMinutes) {
+            currentMinutes in startMinutes until endMinutes
+        } else {
+            currentMinutes >= startMinutes || currentMinutes < endMinutes
+        }
+    }
+
+    /**
      * 사용자 설정 시간에 알람 스케줄링
      *
      * 현재 시간이 설정 시간 이후면 다음날에 예약.
@@ -182,7 +194,7 @@ object LocationScheduler {
         val endMinutes = endHour * 60 + endMinute
 
         // 위치 수집 시간 범위 내인지 확인
-        val isInCollectionTimeRange = currentMinutes in startMinutes until endMinutes
+        val isInCollectionTimeRange = isTimeInRange(currentMinutes, startMinutes, endMinutes)
 
         if (isInCollectionTimeRange) {
             // 시간 범위 내 → 즉시 서비스 시작
@@ -222,7 +234,7 @@ object LocationScheduler {
         val endMinutes = endHour * 60 + endMinute
 
         // 위치 수집 시간 범위 내인지 확인
-        val isInCollectionTimeRange = currentMinutes in startMinutes until endMinutes
+        val isInCollectionTimeRange = isTimeInRange(currentMinutes, startMinutes, endMinutes)
 
         if (isInCollectionTimeRange) {
             // 시간 범위 내 → 즉시 서비스 시작
@@ -458,7 +470,7 @@ object LocationScheduler {
         val startMinutes = startHour * 60 + startMinute
         val endMinutes = endHour * 60 + endMinute
 
-        val isInRange = currentMinutes in startMinutes until endMinutes
+        val isInRange = isTimeInRange(currentMinutes, startMinutes, endMinutes)
         Log.d(TAG, "시간 범위 체크: 현재=${currentMinutes}분, 범위=${startMinutes}~${endMinutes}분, 결과=$isInRange")
         return isInRange
     }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -489,6 +489,10 @@ class SettingsViewModel(
             // 범위 밖인데 서비스가 실행 중이면 중지
             LocationCollectionService.stop(context)
             _uiState.update { it.copy(isLocationCollectionRunning = false) }
+        } else if (!LocationCollectionService.isRunning && isInRange) {
+            // 범위 내인데 서비스가 실행 중이 아니면 자동 시작 (권한 등은 enableLocationCollection이 재확인)
+            LocationScheduler.enableLocationCollection(context)
+            _uiState.update { it.copy(isLocationCollectionRunning = LocationCollectionService.isRunning) }
         }
     }
 

--- a/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiverTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiverTest.kt
@@ -1,0 +1,95 @@
+package com.example.graduation_project.data.alarm
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import com.example.graduation_project.data.location.LocationCollectionService
+import com.example.graduation_project.data.location.LocationScheduler
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class ConversationAlarmReceiverTest {
+
+    private lateinit var context: Application
+    private lateinit var receiver: ConversationAlarmReceiver
+
+    @Before
+    fun setUp() {
+        val realContext = RuntimeEnvironment.getApplication()
+        context = spyk(realContext)
+        receiver = ConversationAlarmReceiver()
+
+        mockkObject(LocationCollectionService)
+        every { LocationCollectionService.stop(any()) } returns Unit
+        mockkObject(LocationScheduler)
+        every { LocationScheduler.scheduleMorningAlarm(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `onReceive_위치권한_있으면_서비스종료_및_다음날알람_재예약`() {
+        // Given: 위치 권한 있음
+        grantLocationPermission()
+
+        // When
+        receiver.onReceive(context, Intent())
+
+        // Then
+        verify { LocationCollectionService.stop(any()) }
+        verify { LocationScheduler.scheduleMorningAlarm(any()) }
+    }
+
+    @Test
+    fun `onReceive_위치권한_없어도_다음날알람_재예약됨`() {
+        // Given: 위치 권한 없음 (사용자가 낮에 권한을 낮춘 경우를 재현)
+        denyLocationPermission()
+
+        // When
+        receiver.onReceive(context, Intent())
+
+        // Then: 권한이 없어도 서비스 종료 시도 + 다음날 알람은 반드시 재예약되어야 함
+        verify { LocationCollectionService.stop(any()) }
+        verify { LocationScheduler.scheduleMorningAlarm(any()) }
+    }
+
+    private fun grantLocationPermission() {
+        mockkStatic(ContextCompat::class)
+        every {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        } returns PackageManager.PERMISSION_GRANTED
+        every {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        } returns PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun denyLocationPermission() {
+        mockkStatic(ContextCompat::class)
+        every {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        } returns PackageManager.PERMISSION_GRANTED
+        every {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        } returns PackageManager.PERMISSION_DENIED
+    }
+}

--- a/android/app/src/test/java/com/example/graduation_project/data/location/LocationSchedulerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/location/LocationSchedulerTest.kt
@@ -264,6 +264,35 @@ class LocationSchedulerTest {
         assertEquals(currentHour < 21, result)
     }
 
+    // ===== isTimeInRange 자정 넘김 (3개) =====
+
+    @Test
+    fun `isTimeInRange_시작이_종료보다_늦고_현재가_시작_이후면_true`() {
+        // Given: start=23:00(1380분), end=06:00(360분), current=23:30(1410분)
+        val result = LocationScheduler.isTimeInRange(1410, 1380, 360)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isTimeInRange_시작이_종료보다_늦고_현재가_종료_이전이면_true`() {
+        // Given: start=23:00(1380분), end=06:00(360분), current=02:00(120분)
+        val result = LocationScheduler.isTimeInRange(120, 1380, 360)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isTimeInRange_시작이_종료보다_늦고_현재가_그_사이면_false`() {
+        // Given: start=23:00(1380분), end=06:00(360분), current=12:00(720분) → 범위 밖
+        val result = LocationScheduler.isTimeInRange(720, 1380, 360)
+
+        // Then
+        assertFalse(result)
+    }
+
     // ===== enableLocationCollection (3개) =====
 
     @Test

--- a/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
@@ -9,6 +9,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowPowerManager
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.location.LocationCollectionService
+import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.repository.UserRepository
@@ -19,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -126,6 +128,24 @@ class SettingsViewModelTest {
             "삼성 기기가 아니면 삼성 다이얼로그 이벤트가 발생하지 않아야 함",
             viewModel.uiState.value.shouldShowSamsungBatteryDialog
         )
+    }
+
+    // ===== checkAndUpdateLocationCollectionStatus 자동 시작 (1개) =====
+
+    @Test
+    fun `checkAndUpdateLocationCollectionStatus가_범위내이고_미실행중이면_enableLocationCollection_호출`() {
+        // Given: 대화 시간이 설정되어 있고(23:59), 수집 시작 시간(00:00)~대화 시간 사이가 사실상 하루 전체를
+        // 덮도록 해서 실제 현재 시각과 무관하게 "범위 내"가 되도록 함. 서비스는 미실행 상태(기본 스텁).
+        LocationCollectionStorage(context).saveStartTime("00:00")
+        coEvery { mockUserRepository.getPreferences() } returns
+            ApiResult.Success(UserPreferences(conversationTime = "23:59"))
+
+        // When: ViewModel 생성 (init에서 loadSettings() → checkAndUpdateLocationCollectionStatus() 호출)
+        SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 범위 내인데 서비스가 실행 중이 아니므로 자동 시작 시도
+        verify { LocationScheduler.enableLocationCollection(any()) }
     }
 
     // ===== 헬퍼 메서드 =====


### PR DESCRIPTION
## Summary
"대화하다 보면 한 장소만 기록되는 것 같다"는 문의를 계기로 위치 수집(`data/location/*`) 서브시스템을 조사해 서로 맞물린 버그 4개를 발견하고 수정함.

- `LocationScheduler.kt`: 3곳에서 중복되던 `currentMinutes in startMinutes until endMinutes`가 자정을 넘기는 범위(시작 시간이 종료 시간보다 늦는 경우, 예: 23:00~06:00)에서 항상 빈 범위가 되어 하루 종일 수집이 시작되지 않던 버그를 `isTimeInRange()` 헬퍼로 통합해 수정. 같은 파일 안에서 이미 올바르게 구현되어 있던 `SettingsViewModel.isCurrentTimeInRange()`와 대조되던 부분.
- `ConversationAlarmReceiver.kt`: `LocationScheduler.scheduleMorningAlarm()` 호출이 위치 권한 체크 블록 안에 있어서, 낮에 위치 권한을 낮추면 그날 밤 이후로 다음날 알람이 영영 재예약되지 않던 버그 수정 (재부팅 전까지 조용히 복구 안 됨).
- `SettingsViewModel.kt`: `checkAndUpdateLocationCollectionStatus()`의 docstring에는 "범위 내이고 권한 있으면 자동 시작"이라 적혀 있었지만 실제로는 "범위 밖이면 자동 중지"만 구현되어 있던 절반짜리 자동복구 로직에 누락된 분기 추가.
- `LocationCollectionService.kt`: 위치 정확도를 `PRIORITY_BALANCED_POWER_ACCURACY` → `PRIORITY_HIGH_ACCURACY`로 상향해, `StayPointDetectorImpl`의 50m 클러스터링 반경과 맞물려 실제로 다른 장소가 부정확한 위치 때문에 하나로 뭉치는 문제 완화 (배터리 15% 미만 시 30분 간격으로 늦추는 기존 절전 로직은 유지).

StayPoint 클러스터링 알고리즘 자체(Haversine 거리 계산 포함)는 정확하게 구현되어 있어 수정 대상이 아님.

## Test plan
- [x] `./gradlew testLocalDebugUnitTest` 전체 스위트 통과 (신규 테스트 포함: `LocationSchedulerTest` 자정 넘김 3케이스, 신규 `ConversationAlarmReceiverTest` 2케이스, `SettingsViewModelTest` 자동시작 1케이스)
- [x] `./gradlew assembleProdDebug` 빌드 통과
- [x] 에뮬레이터(API 36) 실기기 검증: 설정 화면에서 위치 수집 시작 시간을 23:00으로 변경 → 크래시 없이 정상 저장 및 알람 재예약 로그 확인 (`LocationScheduler: 위치 수집 알람 스케줄링 완료`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)