### PR TITLE
fix: Health Connect 건강 데이터 정확성 버그 3개 수정 (중복 합산, 수면 모순, 미설치 오분류)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
@@ -3,6 +3,7 @@ package com.example.graduation_project.data.health
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.DistanceRecord
@@ -10,6 +11,7 @@ import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import com.example.graduation_project.domain.health.HealthConnectAvailability
@@ -19,6 +21,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
+import java.util.Locale
 
 /**
  * Health Connect SDK 초기화 및 가용성 확인 담당.
@@ -45,16 +48,11 @@ class HealthConnectManager(private val context: Context) {
     /**
      * Health Connect SDK 가용성 확인.
      */
-    fun checkAvailability(): HealthConnectAvailability {
-        return when (HealthConnectClient.getSdkStatus(context, HEALTH_CONNECT_PACKAGE)) {
-            HealthConnectClient.SDK_AVAILABLE ->
-                HealthConnectAvailability.Available
-            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED ->
-                HealthConnectAvailability.NotInstalled
-            else ->
-                HealthConnectAvailability.NotSupported
-        }
-    }
+    fun checkAvailability(): HealthConnectAvailability =
+        mapSdkStatus(
+            HealthConnectClient.getSdkStatus(context, HEALTH_CONNECT_PACKAGE),
+            Build.VERSION.SDK_INT
+        )
 
     /**
      * 현재 부여된 권한이 REQUIRED_PERMISSIONS를 모두 포함하는지 확인.
@@ -67,8 +65,7 @@ class HealthConnectManager(private val context: Context) {
 
     /**
      * 어제 정오(12:00) → 오늘 정오(12:00) 범위의 수면 데이터 읽기.
-     * - minutes: 전체 세션 합산 수면 시간(분)
-     * - startTime: 가장 긴 세션(주 수면)의 시작 시각 "HH:mm" → 서버 낮잠 분류용
+     * - 주 수면 세션(최장 세션) 하나만 요약 (계산 로직은 summarizeSleepSessions 참고)
      */
     suspend fun readYesterdaySleep(): SleepSummary {
         val client = HealthConnectClient.getOrCreate(context)
@@ -80,29 +77,17 @@ class HealthConnectManager(private val context: Context) {
         val response = client.readRecords(
             ReadRecordsRequest(SleepSessionRecord::class, TimeRangeFilter.between(rangeStart, rangeEnd))
         )
-        if (response.records.isEmpty()) return SleepSummary(null, null, null)
 
-        val totalMinutes = response.records.sumOf { record ->
-            (record.endTime.toEpochMilli() - record.startTime.toEpochMilli()) / 60_000L
-        }.toInt()
-
-        val mainSession = response.records.maxByOrNull { record ->
-            record.endTime.toEpochMilli() - record.startTime.toEpochMilli()
-        }
-        val startTimeStr = mainSession?.let {
-            val localTime = it.startTime.atZone(zone).toLocalTime()
-            String.format("%02d:%02d", localTime.hour, localTime.minute)
-        }
-        val wakeUpTimeStr = mainSession?.let {
-            val localTime = it.endTime.atZone(zone).toLocalTime()
-            String.format("%02d:%02d", localTime.hour, localTime.minute)
-        }
-
-        return SleepSummary(minutes = totalMinutes, startTime = startTimeStr, wakeUpTime = wakeUpTimeStr)
+        return summarizeSleepSessions(
+            response.records.map { it.startTime to it.endTime },
+            zone
+        )
     }
 
     /**
      * 오늘 자정(00:00) → 현재 범위의 걸음 수 합산.
+     * aggregate()는 여러 앱(워치+폰)이 기록한 중복 데이터를 자동 제거함
+     * (raw 레코드 단순 합산 시 동일 걸음이 두 번 집계될 수 있음)
      */
     suspend fun readTodaySteps(): Int? {
         val client = HealthConnectClient.getOrCreate(context)
@@ -110,12 +95,13 @@ class HealthConnectManager(private val context: Context) {
         val startTime = LocalDate.now(zone).atStartOfDay(zone).toInstant()
         val endTime = Instant.now()
 
-        val response = client.readRecords(
-            ReadRecordsRequest(StepsRecord::class, TimeRangeFilter.between(startTime, endTime))
+        val response = client.aggregate(
+            AggregateRequest(
+                metrics = setOf(StepsRecord.COUNT_TOTAL),
+                timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+            )
         )
-        if (response.records.isEmpty()) return null
-
-        return response.records.sumOf { it.count }.toInt()
+        return response[StepsRecord.COUNT_TOTAL]?.toInt()
     }
 
     /**
@@ -149,12 +135,15 @@ class HealthConnectManager(private val context: Context) {
         startTime: Instant,
         endTime: Instant
     ): Double? {
-        val response = client.readRecords(
-            ReadRecordsRequest(DistanceRecord::class, TimeRangeFilter.between(startTime, endTime))
+        // aggregate()로 중복 출처(워치+폰) 데이터 자동 제거
+        val response = client.aggregate(
+            AggregateRequest(
+                metrics = setOf(DistanceRecord.DISTANCE_TOTAL),
+                timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+            )
         )
-        if (response.records.isEmpty()) return null
-        val totalKm = response.records.sumOf { it.distance.inKilometers }
-        return if (totalKm > 0.0) totalKm else null
+        val totalKm = response[DistanceRecord.DISTANCE_TOTAL]?.inKilometers
+        return if (totalKm != null && totalKm > 0.0) totalKm else null
     }
 
     /**
@@ -218,4 +207,38 @@ class HealthConnectManager(private val context: Context) {
         val resolved = context.packageManager.resolveActivity(playStoreIntent, 0)
         context.startActivity(if (resolved != null) playStoreIntent else webIntent)
     }
+}
+
+/**
+ * 수면 세션 목록에서 주 수면 세션(최장 세션) 하나를 골라 요약.
+ * - 시간과 시작/기상 시각이 같은 세션을 가리키도록 해 서버의 낮잠/야간 분류와 일관성 유지
+ * - 낮잠, 워치+폰 중복 세션이 야간 수면 시간에 합산되는 문제도 함께 방지
+ */
+internal fun summarizeSleepSessions(
+    sessions: List<Pair<Instant, Instant>>,
+    zone: ZoneId
+): SleepSummary {
+    val main = sessions.maxByOrNull { (start, end) -> end.toEpochMilli() - start.toEpochMilli() }
+        ?: return SleepSummary(null, null, null)
+    val (start, end) = main
+    val minutes = ((end.toEpochMilli() - start.toEpochMilli()) / 60_000L).toInt()
+
+    fun Instant.toHHmm(): String {
+        val localTime = atZone(zone).toLocalTime()
+        return String.format(Locale.ROOT, "%02d:%02d", localTime.hour, localTime.minute)
+    }
+
+    return SleepSummary(minutes = minutes, startTime = start.toHHmm(), wakeUpTime = end.toHHmm())
+}
+
+/**
+ * SDK 상태 → 가용성 매핑.
+ * SDK_UNAVAILABLE/PROVIDER_UPDATE_REQUIRED의 경계가 라이브러리 버전에 따라 애매하므로,
+ * HC 앱 설치가 가능한 API 28(P) 이상에서는 미가용이면 무조건 설치/업데이트 유도로 처리.
+ * (API 34+는 HC가 플랫폼 내장이라 항상 SDK_AVAILABLE)
+ */
+internal fun mapSdkStatus(status: Int, sdkInt: Int): HealthConnectAvailability = when {
+    status == HealthConnectClient.SDK_AVAILABLE -> HealthConnectAvailability.Available
+    sdkInt >= Build.VERSION_CODES.P -> HealthConnectAvailability.NotInstalled
+    else -> HealthConnectAvailability.NotSupported
 }

--- a/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/health/SleepSummary.kt
@@ -3,8 +3,10 @@ package com.example.graduation_project.domain.health
 /**
  * 수면 요약 도메인 모델.
  * 서버 낮잠/야간 수면 분류를 위해 수면 시작 시각을 함께 전달.
+ * 세 필드 모두 주 수면 세션(범위 내 최장 세션) 하나를 가리킴 —
+ * 시간과 시각이 같은 세션을 설명해야 서버 분류가 일관됨.
  *
- * @param minutes    총 수면 시간 (분), 데이터 없으면 null
+ * @param minutes    주 수면 세션의 수면 시간 (분), 데이터 없으면 null
  * @param startTime  주 수면 세션 시작 시각 "HH:mm" (로컬 타임존), 데이터 없으면 null
  *                   서버: startTime < "18:00" → 낮잠, ≥ "18:00" → 야간 수면
  * @param wakeUpTime 주 수면 세션 종료 시각 "HH:mm" (로컬 타임존), 데이터 없으면 null

--- a/android/app/src/test/java/com/example/graduation_project/data/health/HealthConnectManagerLogicTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/health/HealthConnectManagerLogicTest.kt
@@ -1,0 +1,111 @@
+package com.example.graduation_project.data.health
+
+import androidx.health.connect.client.HealthConnectClient
+import com.example.graduation_project.domain.health.HealthConnectAvailability
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * HealthConnectManager의 순수 계산 로직 단위 테스트.
+ * - summarizeSleepSessions: 주 수면 세션(최장 세션) 요약
+ * - mapSdkStatus: SDK 상태 → 가용성 방어적 매핑
+ */
+class HealthConnectManagerLogicTest {
+
+    private val zone: ZoneId = ZoneId.of("Asia/Seoul")
+
+    private fun at(year: Int, month: Int, day: Int, hour: Int, minute: Int): Instant =
+        LocalDateTime.of(year, month, day, hour, minute).atZone(zone).toInstant()
+
+    // ===== summarizeSleepSessions =====
+
+    @Test
+    fun `세션이 없으면 모든 필드가 null이다`() {
+        val result = summarizeSleepSessions(emptyList(), zone)
+
+        assertNull(result.minutes)
+        assertNull(result.startTime)
+        assertNull(result.wakeUpTime)
+    }
+
+    @Test
+    fun `단일 야간 세션이면 그 세션의 시간과 시각을 보고한다`() {
+        // 23:00 ~ 다음날 07:00 (8시간)
+        val sessions = listOf(
+            at(2026, 7, 3, 23, 0) to at(2026, 7, 4, 7, 0)
+        )
+
+        val result = summarizeSleepSessions(sessions, zone)
+
+        assertEquals(480, result.minutes)
+        assertEquals("23:00", result.startTime)
+        assertEquals("07:00", result.wakeUpTime)
+    }
+
+    @Test
+    fun `낮잠이 있어도 주 수면 세션만 보고한다`() {
+        // 어제 오후 낮잠 3시간 + 야간 수면 6시간 → 야간(최장) 세션만 보고
+        // (기존 버그: minutes에 낮잠이 합산되어 "야간에 9시간 잤다"로 왜곡됨)
+        val sessions = listOf(
+            at(2026, 7, 3, 14, 0) to at(2026, 7, 3, 17, 0),  // 낮잠 3시간
+            at(2026, 7, 3, 23, 30) to at(2026, 7, 4, 5, 30)  // 야간 6시간
+        )
+
+        val result = summarizeSleepSessions(sessions, zone)
+
+        assertEquals(360, result.minutes)
+        assertEquals("23:30", result.startTime)
+        assertEquals("05:30", result.wakeUpTime)
+    }
+
+    @Test
+    fun `워치와 폰이 같은 밤을 중복 기록해도 최장 세션 하나만 보고한다`() {
+        // 같은 밤을 두 출처가 기록 (워치가 조금 더 길게 기록)
+        // (기존 버그: 두 세션이 합산되어 수면 시간이 약 2배로 보고됨)
+        val sessions = listOf(
+            at(2026, 7, 3, 23, 0) to at(2026, 7, 4, 6, 30),  // 워치: 7.5시간
+            at(2026, 7, 3, 23, 10) to at(2026, 7, 4, 6, 20)  // 폰: 7시간 10분
+        )
+
+        val result = summarizeSleepSessions(sessions, zone)
+
+        assertEquals(450, result.minutes)  // 7.5시간 (합산 아님)
+        assertEquals("23:00", result.startTime)
+        assertEquals("06:30", result.wakeUpTime)
+    }
+
+    // ===== mapSdkStatus =====
+
+    @Test
+    fun `SDK_AVAILABLE이면 Available이다`() {
+        val result = mapSdkStatus(HealthConnectClient.SDK_AVAILABLE, 28)
+
+        assertEquals(HealthConnectAvailability.Available, result)
+    }
+
+    @Test
+    fun `API 28 이상에서 업데이트 필요 상태면 NotInstalled로 설치 유도한다`() {
+        val result = mapSdkStatus(HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED, 28)
+
+        assertEquals(HealthConnectAvailability.NotInstalled, result)
+    }
+
+    @Test
+    fun `API 28 이상에서 SDK_UNAVAILABLE이어도 NotInstalled로 설치 유도한다`() {
+        // 핵심 수정 검증: 기존에는 NotSupported로 분류되어 설치 유도 다이얼로그가 영영 안 떴음
+        val result = mapSdkStatus(HealthConnectClient.SDK_UNAVAILABLE, 28)
+
+        assertEquals(HealthConnectAvailability.NotInstalled, result)
+    }
+
+    @Test
+    fun `API 28 미만이면 NotSupported다`() {
+        val result = mapSdkStatus(HealthConnectClient.SDK_UNAVAILABLE, 27)
+
+        assertEquals(HealthConnectAvailability.NotSupported, result)
+    }
+}


### PR DESCRIPTION
## Summary
대화 시작 시 서버로 전송되는 건강 데이터(수면/걸음수/운동)의 정확성 버그 3개를 수정함. 경도인지장애 어르신의 건강 상태를 AI가 잘못 파악하게 만들 수 있는 데이터 품질 문제.

1. **걸음수/운동거리 중복 합산** — `readTodaySteps()`/`readExerciseDistanceKm()`가 `readRecords()` raw 레코드를 단순 합산해서, 갤럭시 워치(삼성헬스)와 폰이 같은 시간대를 각각 기록하면 동일 걸음이 두 번 집계되어 **약 2배로 부풀던** 문제. Android 공식 문서가 명시적으로 권고하는 `aggregate()` API(`StepsRecord.COUNT_TOTAL`/`DistanceRecord.DISTANCE_TOTAL`)로 전환 — 데이터 출처 우선순위 기반으로 중복이 자동 제거됨.
2. **수면 데이터 의미 모순** — `minutes`는 범위 내 전체 세션 합산(어제 오후 낮잠 + 워치/폰 중복 세션 포함)인데 `startTime`/`wakeUpTime`은 최장 세션 것만 사용해서, 서버의 낮잠/야간 분류(`startTime < "18:00"`)가 왜곡되던 문제 (예: 낮잠 3h + 야간 6h → "야간에 9시간 잤다"로 보고). **주 수면 세션(최장 세션) 하나의 시간+시각을 함께 보고**하도록 변경 — 낮잠 혼입과 중복 세션 문제가 동시에 해결됨.
3. **HC 미설치 기기 오분류** — `SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED`만 `NotInstalled`로 매핑해서, 라이브러리가 미설치 기기에서 `SDK_UNAVAILABLE`을 돌려주는 경우 `NotSupported`로 오분류되어 설치 유도 다이얼로그가 영영 안 뜰 수 있던 문제. 공식 문서상 두 상수의 경계가 애매하므로 방어적 매핑으로 수정: **API 28(P) 이상 + 미가용이면 상수와 무관하게 설치 유도**, API 28 미만만 NotSupported.

수면 요약/가용성 매핑 로직을 순수 함수(`summarizeSleepSessions`, `mapSdkStatus`)로 분리해 HC 클라이언트 의존 없이 유닛테스트 가능하게 함. `String.format`에 `Locale.ROOT` 명시 개선 포함.

## Test plan
- [x] 신규 `HealthConnectManagerLogicTest` 8개 통과 (수면: 빈 목록/단일 세션/낮잠 무시/중복 세션 4케이스, 가용성 매핑 4케이스)
- [x] `./gradlew testLocalDebugUnitTest` 전체 스위트 통과
- [x] `./gradlew assembleProdDebug` 빌드 통과
- [x] 에뮬레이터(API 36) 스모크: 대화 시작 정상 동작, HC 권한 미허용 시 `healthData` 전 필드 null 전송(graceful degradation) 회귀 없음 확인
- [ ] 실기기(갤럭시 워치 연동) 값 검증은 추후 수행 — 에뮬레이터에는 실제 걸음/수면 데이터가 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)