### PR TITLE
feat: HTTPS 전환 (NGINX 리버스 프록시 대응 서버/Android 설정)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
         }
         create("prod") {
             dimension = "server"
-            buildConfigField("String", "BASE_URL", "\"http://3.35.8.201:8080\"")
+            buildConfigField("String", "BASE_URL", "\"https://echo-service.duckdns.org\"")
         }
     }
 

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -41,6 +41,9 @@ supertone:
   model: sona_speech_2
   api-key: ${SUPERTONE_API_KEY}
 
+server:
+  forward-headers-strategy: native
+
 logging:
   level:
     com.example.echo.location: DEBUG


### PR DESCRIPTION
## 개요
서버-앱 통신을 평문 HTTP → HTTPS로 전환하기 위한 코드 변경.
EC2 인프라(NGINX 리버스 프록시 + DuckDNS + Let's Encrypt)는 이미 구성 완료됐고, 이 PR은 그에 맞춘 **애플리케이션 설정 2건**입니다.

인프라 목표: `http://3.35.8.201:8080` → `https://echo-service.duckdns.org`

## 변경 사항
### 1. 서버 (`application-prod.yaml`)
- `server.forward-headers-strategy: native` 추가
- NGINX가 TLS 종료 후 평문으로 프록시하므로, `X-Forwarded-Proto` 헤더를 신뢰하도록 설정 → Spring이 HTTPS 스킴을 올바로 인식 (리다이렉트/Swagger URL 정확성)

### 2. Android (`app/build.gradle.kts`)
- `prod` 플레이버 BASE_URL: `http://3.35.8.201:8080` → `https://echo-service.duckdns.org` (443 기본 포트)
- `local` 플레이버(`http://10.0.2.2:8080`)는 변경 없음

## 인프라 완료 상태 (참고, 이 PR 범위 밖)
- NGINX `echo.conf` 리버스 프록시 (443 → 127.0.0.1:8080, `client_max_body_size 20m`, `proxy_read_timeout 120s`)
- Let's Encrypt 인증서 + `certbot-renew.timer` 자동갱신 활성화
- 외부 브라우저 `https://echo-service.duckdns.org/actuator/health` → UP 확인

## 배포 후 후속 작업
- [ ] main 머지 → CI/CD로 서버 반영
- [ ] Android prod 빌드 롤아웃 후 로그인/대화 HTTPS 정상 확인
- [ ] 검증 완료 후 EC2 보안그룹 8080 인바운드 삭제 (평문 경로 차단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)