### PR TITLE
fix: 설정 화면/대화 알람 상태 버그 4개 수정 (화면 잠김, 로그아웃 정리, 서버 동기화, 저장 롤백)

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -47,6 +47,7 @@ import com.example.graduation_project.presentation.home.HomeScreen
 import com.example.graduation_project.presentation.onboarding.OnboardingScreen
 import com.example.graduation_project.presentation.settings.SettingsScreen
 import com.example.graduation_project.presentation.settings.DisplaySettingsViewModel
+import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.location.MorningAlarmReceiver
 import com.example.graduation_project.presentation.permission.SamsungBatterySettingsDialog
@@ -137,6 +138,14 @@ private fun AppNavHost(
     val userRepository = remember { UserRepository() }
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
+
+    // 로그아웃 공통 처리: 사용자별 알람/위치 수집 정리 후 토큰 삭제
+    // (미정리 시 로그아웃 후에도 대화 알람이 계속 울리고 위치가 계속 수집됨)
+    val performLogout: suspend () -> Unit = {
+        ConversationAlarmScheduler.cancelAndClear(context)
+        LocationScheduler.disableLocationCollection(context)
+        withContext(Dispatchers.IO) { authRepository.logout() }
+    }
 
     // 권한 다이얼로그 상태
     var showConfirmDialog by remember { mutableStateOf(false) }
@@ -424,7 +433,7 @@ private fun AppNavHost(
                     displayViewModel = displayViewModel,
                     onLogout = {
                         coroutineScope.launch {
-                            withContext(Dispatchers.IO) { authRepository.logout() }
+                            performLogout()
                             navController.navigate(Routes.LOGIN) {
                                 popUpTo(0) { inclusive = true }
                             }
@@ -438,7 +447,7 @@ private fun AppNavHost(
                 ConversationScreen(
                     onLogout = {
                         coroutineScope.launch {
-                            withContext(Dispatchers.IO) { authRepository.logout() }
+                            performLogout()
                             navController.navigate(Routes.LOGIN) {
                                 popUpTo(0) { inclusive = true }
                             }

--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmScheduler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmScheduler.kt
@@ -109,6 +109,18 @@ object ConversationAlarmScheduler {
     }
 
     /**
+     * 로그아웃 시 호출: 알람 취소 + 저장된 설정 삭제 + 표시 중인 알림 제거.
+     * (미정리 시 로그아웃한 사용자에게 알람이 계속 울리고,
+     *  같은 기기의 다음 사용자가 이전 사용자의 알람 설정을 물려받음)
+     */
+    fun cancelAndClear(context: Context) {
+        cancelAlarm(context)
+        ConversationAlarmStorage(context).clear()
+        ConversationAlarmReceiver.cancelNotification(context)
+        Log.d(TAG, "대화 알람 및 저장 설정 전체 정리 완료")
+    }
+
+    /**
      * 저장된 설정으로 알람 재스케줄링 (부팅 시 사용)
      */
     fun rescheduleFromStorage(context: Context) {

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -277,12 +277,24 @@ class SettingsViewModel(
             when (val result = userRepository.getPreferences()) {
                 is ApiResult.Success -> {
                     _uiState.update { applyPrefs(it, result.data).copy(isLoading = false) }
+                    // 서버 대화 시간과 로컬 알람 저장소 동기화 (다른 기기에서 변경한 경우 반영)
+                    syncAlarmWithServerTime(result.data.conversationTime)
                     // 대화 시간 로드 후 위치 수집 상태 확인
                     checkAndUpdateLocationCollectionStatus()
                 }
                 is ApiResult.Error -> _uiState.update { it.copy(isLoading = false) }
             }
         }
+    }
+
+    /**
+     * 서버의 대화 시간과 로컬 알람 저장소가 다르면 동기화하고 알람을 재예약.
+     * (다른 기기에서 시간을 변경한 경우 UI 표시 시간과 실제 알람 발화 시간이 어긋나는 것 방지)
+     */
+    private fun syncAlarmWithServerTime(serverTime: String?) {
+        if (serverTime == alarmStorage.getConversationTime()) return
+        alarmStorage.saveConversationTime(serverTime)
+        updateAlarmSchedule(serverTime)  // 비활성화 상태거나 time=null이면 내부에서 cancelAlarm
     }
 
     /**
@@ -412,16 +424,25 @@ class SettingsViewModel(
 
                     // 현재 시간이 위치 수집 범위 내이면 자동으로 서비스 시작
                     val locationStartTime = _uiState.value.locationCollectionStartTime
+                    var autoStarted = false
                     if (!savedTime.isNullOrBlank() && isCurrentTimeInRange(locationStartTime, savedTime)) {
                         val context = getApplication<Application>()
                         if (!LocationCollectionService.isRunning && _uiState.value.hasBackgroundLocationPermission) {
                             LocationCollectionService.start(context)
-                            _uiState.update { it.copy(isLocationCollectionRunning = true, savedMessage = "저장되었습니다. 위치 수집이 자동으로 시작되었습니다") }
-                            return@launch
+                            autoStarted = true
                         }
                     }
 
-                    _uiState.update { applyPrefs(it, result.data).copy(isSaving = false, savedMessage = "저장되었습니다") }
+                    // 자동 시작 여부와 무관하게 항상 isSaving 해제 + 서버 응답 반영
+                    // (자동 시작 분기에서 early return 하면 isSaving이 true로 남아 설정 화면 전체가 잠김)
+                    _uiState.update {
+                        applyPrefs(it, result.data).copy(
+                            isSaving = false,
+                            isLocationCollectionRunning = autoStarted || it.isLocationCollectionRunning,
+                            savedMessage = if (autoStarted) "저장되었습니다. 위치 수집이 자동으로 시작되었습니다"
+                                           else "저장되었습니다"
+                        )
+                    }
                 }
                 is ApiResult.Error -> _uiState.update {
                     it.copy(isSaving = false, errorMessage = "저장에 실패했습니다. 다시 시도해주세요.")
@@ -445,23 +466,39 @@ class SettingsViewModel(
     }
 
     fun setAlarmEnabled(enabled: Boolean) {
-        alarmStorage.setAlarmEnabled(enabled)
-        _uiState.update { it.copy(alarmEnabled = enabled) }
+        val time = _uiState.value.conversationTime
 
-        var time = _uiState.value.conversationTime
-
-        // 시간이 설정되지 않은 경우 기본 시간(09:00) 설정
+        // 시간이 설정되지 않은 상태에서 켜는 경우: 기본 시간(21:00)을 서버에 먼저 저장
+        // 서버 저장이 실패하면 아무것도 켜지 않고 안내 (서버-로컬-UI 불일치로 인한 유령 알람 방지)
         if (enabled && time.isNullOrBlank()) {
-            time = DEFAULT_CONVERSATION_TIME
-            alarmStorage.saveConversationTime(time)
-            _uiState.update { it.copy(conversationTime = time) }
-
-            // 서버에도 기본 시간 저장
             viewModelScope.launch {
-                userRepository.updateConversationTime(time)
+                when (userRepository.updateConversationTime(DEFAULT_CONVERSATION_TIME)) {
+                    is ApiResult.Success -> {
+                        alarmStorage.setAlarmEnabled(true)
+                        alarmStorage.saveConversationTime(DEFAULT_CONVERSATION_TIME)
+                        _uiState.update {
+                            it.copy(
+                                alarmEnabled = true,
+                                conversationTime = DEFAULT_CONVERSATION_TIME,
+                                savedMessage = "알림이 설정되었습니다"
+                            )
+                        }
+                        updateAlarmSchedule(DEFAULT_CONVERSATION_TIME)
+                    }
+                    is ApiResult.Error -> _uiState.update {
+                        it.copy(
+                            alarmEnabled = false,
+                            errorMessage = "알림을 설정하지 못했습니다. 잠시 후 다시 시도해주세요."
+                        )
+                    }
+                }
             }
+            return
         }
 
+        // 시간이 이미 있는 켜기/끄기: 서버 변경 불필요, 로컬만 갱신
+        alarmStorage.setAlarmEnabled(enabled)
+        _uiState.update { it.copy(alarmEnabled = enabled) }
         updateAlarmSchedule(time)
 
         val message = if (enabled) "알림이 설정되었습니다" else "알림이 해제되었습니다"

--- a/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmSchedulerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmSchedulerTest.kt
@@ -1,0 +1,50 @@
+package com.example.graduation_project.data.alarm
+
+import android.app.AlarmManager
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAlarmManager
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class ConversationAlarmSchedulerTest {
+
+    private lateinit var context: Application
+    private lateinit var shadowAlarmManager: ShadowAlarmManager
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        shadowAlarmManager = shadowOf(alarmManager)
+    }
+
+    @Test
+    fun `cancelAndClear_알람취소_및_저장소를_모두_정리한다`() {
+        // Given: 알람 설정 저장 + 알람 예약 (로그인 상태 재현)
+        val storage = ConversationAlarmStorage(context)
+        storage.saveConversationTime("21:00")
+        storage.setAlarmEnabled(true)
+        ConversationAlarmScheduler.scheduleAlarm(context, "21:00")
+        assertTrue("알람이 예약되어야 함", shadowAlarmManager.scheduledAlarms.isNotEmpty())
+
+        // When: 로그아웃 정리
+        ConversationAlarmScheduler.cancelAndClear(context)
+
+        // Then: 알람 취소 + 저장소 클리어 (로그아웃한 사용자에게 알람이 울리지 않아야 함)
+        assertTrue("알람이 취소되어야 함", shadowAlarmManager.scheduledAlarms.isEmpty())
+        assertNull("대화 시간이 삭제되어야 함", ConversationAlarmStorage(context).getConversationTime())
+        assertFalse("알람 활성화 플래그가 초기화되어야 함", ConversationAlarmStorage(context).isAlarmEnabled())
+    }
+}

--- a/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
@@ -7,18 +7,25 @@ import android.os.PowerManager
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowPowerManager
+import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
+import com.example.graduation_project.data.alarm.ConversationAlarmStorage
+import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.location.LocationCollectionService
+import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.data.model.UserPreferences
 import com.example.graduation_project.data.repository.UserRepository
 import com.example.graduation_project.presentation.permission.PermissionChecker
 import com.example.graduation_project.util.DeviceUtil
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,6 +33,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -63,6 +71,7 @@ class SettingsViewModelTest {
         mockkObject(LocationScheduler)
         mockkObject(LocationCollectionService)
         mockkObject(DeviceUtil)
+        mockkObject(ConversationAlarmScheduler)
 
         // 기본값 설정
         every { PermissionChecker.hasForegroundLocationPermission(any()) } returns false
@@ -70,6 +79,8 @@ class SettingsViewModelTest {
         every { PermissionChecker.hasNotificationPermission(any()) } returns true
         every { LocationCollectionService.isRunning } returns false
         every { LocationScheduler.enableLocationCollection(any()) } returns true
+        every { ConversationAlarmScheduler.scheduleAlarm(any(), any()) } just Runs
+        every { ConversationAlarmScheduler.cancelAlarm(any()) } just Runs
     }
 
     @After
@@ -126,6 +137,93 @@ class SettingsViewModelTest {
             "삼성 기기가 아니면 삼성 다이얼로그 이벤트가 발생하지 않아야 함",
             viewModel.uiState.value.shouldShowSamsungBatteryDialog
         )
+    }
+
+    // ===== 대화 시간 저장 (isSaving 복귀) =====
+
+    @Test
+    fun `updateConversationTime_위치수집_자동시작_경로에서도_isSaving이_false로_복귀한다`() = runTest {
+        // Given: 배경 위치 권한 있음 + 서비스 미실행 + 현재 시간이 수집 범위(00:00~23:59) 내
+        every { PermissionChecker.hasBackgroundLocationPermission(any()) } returns true
+        every { LocationCollectionService.start(any()) } just Runs
+        LocationCollectionStorage(context).saveStartTime("00:00")
+        coEvery { mockUserRepository.updateConversationTime(any()) } returns
+            ApiResult.Success(UserPreferences(conversationTime = "23:59"))
+
+        val viewModel = SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When: 대화 시간 변경 (자동 시작 분기로 진입)
+        viewModel.updateConversationTime("23:59")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 자동 시작 경로에서도 isSaving이 해제되고 응답 값이 UI에 반영되어야 함
+        // (기존 버그: early return으로 isSaving=true가 남아 설정 화면 전체가 잠김)
+        assertFalse("isSaving이 해제되어야 함", viewModel.uiState.value.isSaving)
+        assertEquals("23:59", viewModel.uiState.value.conversationTime)
+        assertTrue(viewModel.uiState.value.isLocationCollectionRunning)
+    }
+
+    // ===== 서버-로컬 알람 시간 동기화 =====
+
+    @Test
+    fun `loadSettings가_서버_대화시간과_로컬저장소가_다르면_동기화하고_재예약한다`() = runTest {
+        // Given: 로컬에는 20:00으로 저장 + 알람 활성화, 서버는 21:30 반환 (다른 기기에서 변경한 상황)
+        val alarmStorage = ConversationAlarmStorage(context)
+        alarmStorage.saveConversationTime("20:00")
+        alarmStorage.setAlarmEnabled(true)
+        coEvery { mockUserRepository.getPreferences() } returns
+            ApiResult.Success(UserPreferences(conversationTime = "21:30"))
+
+        // When: ViewModel 생성 (init에서 loadSettings 호출)
+        SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 로컬 저장소가 서버 값으로 동기화되고 알람이 재예약되어야 함
+        assertEquals("21:30", alarmStorage.getConversationTime())
+        verify { ConversationAlarmScheduler.scheduleAlarm(any(), "21:30") }
+    }
+
+    // ===== 알람 켜기 기본시간 서버 저장 =====
+
+    @Test
+    fun `알람켜기_기본시간_서버저장_실패시_롤백하고_오류를_표시한다`() = runTest {
+        // Given: 대화 시간 미설정 + 서버 저장 실패 (오프라인 등)
+        coEvery { mockUserRepository.updateConversationTime(any()) } returns
+            ApiResult.Error(ApiException.NetworkError())
+
+        val viewModel = SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When: 알람 토글 ON
+        viewModel.setAlarmEnabled(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 아무것도 켜지지 않고 오류 안내 (서버-로컬-UI 불일치로 인한 유령 알람 방지)
+        assertFalse(viewModel.uiState.value.alarmEnabled)
+        assertFalse(ConversationAlarmStorage(context).isAlarmEnabled())
+        assertTrue(viewModel.uiState.value.errorMessage != null)
+        verify(exactly = 0) { ConversationAlarmScheduler.scheduleAlarm(any(), any()) }
+    }
+
+    @Test
+    fun `알람켜기_기본시간_서버저장_성공시_로컬저장_및_알람예약한다`() = runTest {
+        // Given: 대화 시간 미설정 + 서버 저장 성공
+        coEvery { mockUserRepository.updateConversationTime(any()) } returns
+            ApiResult.Success(UserPreferences(conversationTime = "21:00"))
+
+        val viewModel = SettingsViewModel(context, mockUserRepository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When: 알람 토글 ON
+        viewModel.setAlarmEnabled(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 기본 시간(21:00)으로 로컬 저장 + 알람 예약
+        assertTrue(viewModel.uiState.value.alarmEnabled)
+        assertEquals("21:00", ConversationAlarmStorage(context).getConversationTime())
+        assertTrue(ConversationAlarmStorage(context).isAlarmEnabled())
+        verify { ConversationAlarmScheduler.scheduleAlarm(any(), "21:00") }
     }
 
     // ===== 헬퍼 메서드 =====


### PR DESCRIPTION
## 개요

설정 화면(SettingsViewModel)과 대화 알람 스케줄링 집중 탐색에서 발견된 상태 관리 버그 4개를 수정합니다.

## 수정 내용

### 1. 대화 시간 저장 시 설정 화면 영구 잠김
`updateConversationTime()`의 성공 경로 중 "위치 수집 자동 시작" 분기가 `isSaving = false` 없이 `return@launch` 하여, 대화 시간을 바꿨을 뿐인데 설정 화면의 모든 편집 행이 클릭 불가가 됐습니다 (화면 재진입 전까지). 이 분기는 `applyPrefs`도 건너뛰어 방금 저장한 시간이 UI에 반영되지 않는 부수 버그도 있었습니다.
→ early return 제거, 모든 경로에서 `isSaving` 해제 + 서버 응답 반영. 자동 시작 여부는 스낵바 문구로 구분.

### 2. 로그아웃해도 알람이 영원히 울림
`AuthRepository.logout()`은 토큰만 지우므로, 로그아웃한 사용자에게 매일 대화 알림이 계속 오고 재부팅 시 `BootReceiver`가 재예약하며, 같은 기기의 다음 사용자가 이전 사용자의 알람을 물려받았습니다. 위치 수집(아침 알람 + 실행 중 서비스)도 로그아웃 후 계속 동작하는 프라이버시 문제가 있었습니다.
→ `ConversationAlarmScheduler.cancelAndClear()` 신설 (알람 취소 + 저장소 클리어 + 표시 중 알림 제거), `MainActivity`의 로그아웃 핸들러 2곳을 공용 `performLogout`으로 통일하여 대화 알람 + 위치 수집(`LocationScheduler.disableLocationCollection`) 정리 후 로그아웃.

### 3. 서버-로컬 알람 시간 불일치
`loadSettings()`가 서버 `conversationTime`으로 UI만 갱신하고 로컬 알람 저장소/예약된 알람은 안 건드려서, 다른 기기에서 시간을 바꾸면 UI 표시 시간과 실제 알람 발화 시간이 어긋났습니다 (재부팅 시 낡은 시간으로 복원).
→ `syncAlarmWithServerTime()` 추가: 서버 값과 로컬 저장소가 다르면 동기화 + 알람 재예약.

### 4. 알람 켜기 시 fire-and-forget 서버 저장
`setAlarmEnabled()`의 기본 시간(21:00) 분기가 서버 저장 결과를 무시해서, 오프라인이면 로컬 알람은 21시에 울리는데 서버/UI는 "시간 미설정"인 유령 알람이 됐습니다.
→ 서버 저장을 await하고 실패 시 아무것도 켜지 않고 롤백 + "다시 시도해주세요" 안내 (서버-로컬-UI 3자 일치 보장). 주석 "기본 시간(09:00)" → "21:00" 정정.

## 테스트

- 신규 단위 테스트 5개 (SettingsViewModelTest 4개 + ConversationAlarmSchedulerTest 1개), 전체 스위트 그린
- `./gradlew assembleProdDebug` 빌드 확인
- 에뮬레이터(API 36, prod 서버) 실기 검증:
  - 자동 시작 분기 실주행: "저장되었습니다. 위치 수집이 자동으로 시작되었습니다" 스낵바 + `LocationCollectionService 생성` 로그 확인 후 **설정 행들이 계속 클릭 가능** (버그 1)
  - 로그아웃 직후 `dumpsys alarm`에서 대화/아침/위치수집 알람 전부 소멸 + `conversation_alarm_prefs` `<map />` 클리어 + 위치 서비스 중지 로그 확인 (버그 2)
  - 로컬 저장소에 낡은 시간(21:00)을 심고 재시작 → 설정 로드 시 서버 값(23:30)으로 알람 재예약되는 것을 `dumpsys alarm`으로 확인 (버그 3)
  - 재로그인 후 유령 알람 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)