### PR TITLE
fix(android): 평문 통신을 로컬 에뮬레이터 도메인으로 제한

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
     <application
         android:name=".App"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- 에뮬레이터에서 로컬 서버(10.0.2.2 = 호스트 PC 루프백)로 테스트할 때만 평문 HTTP 허용 -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+
+    <!-- 그 외 모든 도메인(prod 등)은 HTTPS만 허용 -->
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
## Summary
- `usesCleartextTraffic="true"`가 local/prod 빌드 전체에 걸려 있어, prod가 HTTPS로 전환된 이후에도 앱 레벨에서 평문 통신을 막아주는 안전장치가 없었음 (보안 점검 B1)
- `network_security_config.xml`을 추가해 `10.0.2.2`(에뮬레이터 로컬 서버)에만 cleartext를 허용하고, 그 외 모든 도메인은 HTTPS만 허용하도록 강제
- Manifest의 `usesCleartextTraffic` 속성은 제거하고 `networkSecurityConfig`로 대체

## Test plan
- [x] `./gradlew :app:assembleLocalDebug` 빌드 성공 확인
- [x] local 플레이버로 실행해 에뮬레이터(Medium_Phone_API_35)에서 `10.0.2.2:8080` 통신이 cleartext 정책에 막히지 않고 소켓까지 정상 연결되는 것을 logcat으로 확인 (로컬 서버 미기동 상태라 응답은 없었으나, `CLEARTEXT_NOT_PERMITTED` 예외 없이 `TrafficStats: tagSocket` 로그까지 도달 → 정책 예외 정상 동작)
- [x] prod 플레이버로 실행해 실제 운영 서버(`https://echo-service.duckdns.org`)와 HTTPS 통신 후 `200 OK` 응답 수신 확인 (nginx, `Strict-Transport-Security` 헤더 포함)

```
--> GET http://10.0.2.2:8080/api/users/me/onboarding-status
TrafficStats: tagSocket(...)                              # cleartext 차단 없이 소켓 연결됨

--> GET https://echo-service.duckdns.org/api/users/me/onboarding-status
<-- 200 https://echo-service.duckdns.org/... (2503ms)
Strict-Transport-Security: max-age=31536000 ; includeSubDomains
{"completed":true}
```

두 플레이버 모두 회귀 없이 정상 동작 확인 완료.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>