### PR TITLE
fix(android): refresh 실패 시 일시적 오류에는 토큰 보존

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/api/TokenAuthenticator.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/TokenAuthenticator.kt
@@ -9,6 +9,7 @@ import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
+import retrofit2.HttpException
 
 class TokenAuthenticator(
     private val tokenStorage: TokenStorage,
@@ -37,8 +38,16 @@ class TokenAuthenticator(
                     val tokenResponse = authApi.refresh(RefreshRequest(refreshToken))
                     tokenStorage.saveTokens(tokenResponse.accessToken, tokenResponse.refreshToken)
                     tokenResponse.accessToken
+                } catch (e: HttpException) {
+                    // 서버가 refresh 토큰을 명시적으로 거부한 경우(만료/무효)에만 로그아웃 처리.
+                    // 그 외 서버 오류(5xx 등)는 토큰을 보존해 이후 재시도가 가능하도록 함.
+                    if (e.code() == 401 || e.code() == 403) {
+                        tokenStorage.clear()
+                    }
+                    null
                 } catch (e: Exception) {
-                    tokenStorage.clear()
+                    // 네트워크 오류/타임아웃 등 일시적 실패 - 토큰을 지우지 않아
+                    // 연결 복구 후 정상 로그인 상태를 유지한다.
                     null
                 }
             }

--- a/android/app/src/test/java/com/example/graduation_project/data/api/TokenAuthenticatorTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/api/TokenAuthenticatorTest.kt
@@ -1,0 +1,121 @@
+package com.example.graduation_project.data.api
+
+import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.model.TokenResponse
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import java.io.IOException
+
+/**
+ * TokenAuthenticator 단위 테스트
+ *
+ * 핵심 검증: refresh 실패 유형에 따라 토큰을 지울지/보존할지 구분한다.
+ * - 서버가 refresh 토큰을 명시적으로 거부(401/403)한 경우에만 로그아웃(clear)
+ * - 네트워크 오류(IOException)나 서버 오류(5xx)는 토큰 보존 (일시적 실패)
+ */
+class TokenAuthenticatorTest {
+
+    private lateinit var tokenStorage: TokenStorage
+    private lateinit var authApi: AuthApi
+    private lateinit var authenticator: TokenAuthenticator
+
+    private val oldAccessToken = "old-access-token"
+    private val storedRefreshToken = "stored-refresh-token"
+
+    @Before
+    fun setUp() {
+        tokenStorage = mockk(relaxed = true)
+        authApi = mockk()
+        authenticator = TokenAuthenticator(tokenStorage, authApi)
+
+        // refresh 경로로 진입하도록: 저장된 access 토큰 == 요청에 쓰인 토큰
+        every { tokenStorage.getAccessToken() } returns oldAccessToken
+        every { tokenStorage.getRefreshToken() } returns storedRefreshToken
+    }
+
+    private fun unauthorizedResponse(): Response {
+        val request = Request.Builder()
+            .url("https://example.com/api/resource")
+            .header("Authorization", "Bearer $oldAccessToken")
+            .build()
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(401)
+            .message("Unauthorized")
+            .build()
+    }
+
+    private fun httpException(code: Int): HttpException {
+        val errorBody = "".toResponseBody(null)
+        return HttpException(retrofit2.Response.error<Any>(code, errorBody))
+    }
+
+    @Test
+    fun `refresh 성공 시 새 토큰 저장하고 재요청에 새 토큰 부착`() {
+        coEvery { authApi.refresh(any()) } returns TokenResponse(
+            accessToken = "new-access-token",
+            refreshToken = "new-refresh-token"
+        )
+        every { tokenStorage.saveTokens(any(), any()) } just Runs
+
+        val result = authenticator.authenticate(null, unauthorizedResponse())
+
+        assertEquals("Bearer new-access-token", result?.header("Authorization"))
+        verify { tokenStorage.saveTokens("new-access-token", "new-refresh-token") }
+        verify(exactly = 0) { tokenStorage.clear() }
+    }
+
+    @Test
+    fun `refresh 토큰 만료(401) 시 토큰을 지운다`() {
+        coEvery { authApi.refresh(any()) } throws httpException(401)
+
+        val result = authenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(result)
+        verify(exactly = 1) { tokenStorage.clear() }
+    }
+
+    @Test
+    fun `refresh 토큰 거부(403) 시 토큰을 지운다`() {
+        coEvery { authApi.refresh(any()) } throws httpException(403)
+
+        val result = authenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(result)
+        verify(exactly = 1) { tokenStorage.clear() }
+    }
+
+    @Test
+    fun `네트워크 오류 시 토큰을 보존한다`() {
+        coEvery { authApi.refresh(any()) } throws IOException("timeout")
+
+        val result = authenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(result)
+        verify(exactly = 0) { tokenStorage.clear() }
+    }
+
+    @Test
+    fun `서버 오류(500) 시 토큰을 보존한다`() {
+        coEvery { authApi.refresh(any()) } throws httpException(500)
+
+        val result = authenticator.authenticate(null, unauthorizedResponse())
+
+        assertNull(result)
+        verify(exactly = 0) { tokenStorage.clear() }
+    }
+}


### PR DESCRIPTION
## 배경

버그 탐색 중 발견한 클라이언트 인증 버그를 수정합니다.

`TokenAuthenticator`는 access 토큰이 401을 받으면 refresh를 시도하는데, refresh 요청이 실패하면 **예외 종류를 구분하지 않고 무조건** `tokenStorage.clear()`를 호출해 왔습니다. 그 결과 다음과 같은 일시적 오류에도 사용자가 로그아웃됩니다.

- 대화 중 네트워크가 잠깐 끊기거나 타임아웃(`IOException`)
- 서버 일시 장애(`5xx`)

이 경우 토큰 자체는 여전히 유효한데도 삭제되어, 네트워크가 복구돼도 재로그인 전까지 앱을 쓸 수 없습니다.

## 변경 내용

`refresh` 실패를 예외 유형으로 분기합니다.

- **HTTP 401 / 403** (서버가 refresh 토큰을 명시적으로 거부 = 만료/무효) → `clear()` 호출, 로그아웃
- **HTTP 5xx / IOException** (일시적 실패) → 토큰 보존, `null`만 반환해 현재 요청만 실패시키고 다음 기회에 재시도

## 검증

`TokenAuthenticatorTest`를 추가해 다섯 경로를 커버했고 전부 통과합니다.

- refresh 성공 → 새 토큰 저장 + 재요청에 부착
- 401 / 403 → 토큰 삭제
- IOException(네트워크) / 500 → 토큰 보존

```
./gradlew testLocalDebugUnitTest --tests "com.example.graduation_project.data.api.TokenAuthenticatorTest"
BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)