### PR TITLE
fix(server): 대화 오케스트레이션에서 @Transactional 제거해 커넥션 고갈 방지

### DIFF
--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -17,7 +17,6 @@ import com.example.echo.voice.service.VoiceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -34,7 +33,6 @@ public class ConversationService {
     private final DiaryService diaryService;
     private final HealthDataService healthDataService;
 
-    @Transactional
     public ConversationStartResponse startConversation(Long userId, HealthData healthData, RawLocationData rawLocationData) {
         // 0. 건강 데이터 저장 (Android에서 수신한 경우)
         if (healthData != null) {
@@ -64,7 +62,6 @@ public class ConversationService {
                 .build();
     }
 
-    @Transactional
     public ConversationResponse processUserMessage(Long userId, MultipartFile audioFile) {
         // 1. 컨텍스트 조회
         UserContext context = contextService.getContext(userId);
@@ -107,7 +104,6 @@ public class ConversationService {
                 .build();
     }
 
-    @Transactional
     public void endConversation(Long userId) {
         log.info("대화 종료 시작 - userId: {}", userId);
 


### PR DESCRIPTION
## 문제 정의

`ConversationService`의 세 메서드(`startConversation`, `processUserMessage`, `endConversation`)가 `@Transactional`로 감싸져 있으면서, 그 안에서 수 초~수십 초 걸리는 외부 API(STT/OpenAI/TTS)를 호출합니다. 이로 인해 느린 외부 응답 동안 DB 커넥션을 점유하여 커넥션 풀 고갈의 원인이 됩니다.

## 조사 결과

각 메서드별 DB 작업 분석:

### startConversation (37행 @Transactional 제거 전)
- **유일한 DB 쓰기**: `healthDataService.saveHealthData(userId, healthData)` (41행)
- **현황**: `HealthDataService.saveHealthData`는 이미 자체 메서드에서 `@Transactional` 선언 (HealthDataService.java:176, 187행)
- **결론**: 메서드 레벨 트랜잭션 불필요

### processUserMessage (67행 @Transactional 제거 전)
- **DB 작업**: 없음
- **컨텍스트 관리**: 인메모리 `ConcurrentHashMap`에서 읽기/쓰기 (ContextService)
- **히스토리**: 인메모리 리스트에 추가만 수행
- **결론**: DB 트랜잭션이 감쌀 작업이 없음

### endConversation (110행 @Transactional 제거 전)
- **일기 생성**: `diaryService.generateAndSaveDiary(context)` (121행) - 현재 TODO 상태 (no-op, DB 쓰기 없음), 자체 try/catch로 감싸짐
- **컨텍스트 정리**: `contextService.finalizeContext(userId)` - 인메모리 정리만 수행
- **결론**: 트랜잭션이 감쌀 DB 작업이 없음

## 수정 내용

- `startConversation`, `processUserMessage`, `endConversation` 메서드의 `@Transactional` 애너테이션 제거 (3개)
- 사용되지 않는 import `org.springframework.transaction.annotation.Transactional` 제거
- 메서드 본문, 다른 파일은 변경 없음

## 검증

**빌드 검증 통과**:
- `./gradlew compileJava` 실행 결과: BUILD SUCCESSFUL
- 트랜잭션 경계 변경은 런타임 동작에만 영향이므로 단위 테스트는 효과 없음
- 컴파일 통과는 구문/타입 정확성 보장

## 기대 효과

- DB 커넥션 점유 시간 단축 (외부 API 호출 동안 트랜잭션 미점유)
- 커넥션 풀 고갈 위험 감소
- 실제 DB 작업은 데이터 접근 계층(HealthDataService 등)에서 각각의 `@Transactional`로 원자성 보장

🤖 Generated with [Claude Code](https://claude.com/claude-code)