### PR TITLE
fix(server): OpenAI/STT Feign 클라이언트에 read 타임아웃 상한(30s) 설정

### DIFF
--- a/server/src/main/java/com/example/echo/voice/config/OpenAIFeignConfig.java
+++ b/server/src/main/java/com/example/echo/voice/config/OpenAIFeignConfig.java
@@ -23,4 +23,9 @@ public class OpenAIFeignConfig {
             requestTemplate.header("Authorization", "Bearer " + apiKey);
         };
     }
+
+    @Bean
+    public feign.Request.Options openAIRequestOptions() {
+        return new feign.Request.Options(10_000, 30_000); // connect 10s, read 30s
+    }
 }


### PR DESCRIPTION
## 문제

OpenAI Chat 및 Whisper STT 클라이언트는 `OpenAIFeignConfig`를 공유하지만, 해당 설정에 타임아웃이 없어 Feign 기본값(read 60초)이 적용되어 있습니다. 느린 응답(특히 Whisper)이 스레드 및 DB 커넥션을 최대 60초 동안 점유하므로, 동시 사용자가 증가하면 커넥션 풀 고갈 위험이 있습니다.

## 해결책

`OpenAIFeignConfig`에 `feign.Request.Options` 빈을 추가하여 명시적 타임아웃 상한을 설정합니다.

- connect: 10초 (기존 Feign 기본값 유지)
- **read: 30초** (기본 60초에서 하향 조정)

이는 `AzureTtsFeignConfig` 및 `SupertoneFeignConfig`와 동일한 값으로, 코드베이스의 일관성을 유지합니다.

## 설정 전후

**설정 전 (이 커밋 이전):**
```java
// OpenAIFeignConfig에 Request.Options 빈 없음
// ⟹ Feign 기본값: connect 10s / read 60s 적용
```

**설정 후 (이 커밋):**
```java
@Bean
public feign.Request.Options openAIRequestOptions() {
    return new feign.Request.Options(10_000, 30_000); // connect 10s, read 30s
}
```

## 검증

- **빌드 검증**: `./gradlew compileJava` → BUILD SUCCESSFUL ✓
- **테스트**: 설정 변경이므로 단위 테스트는 비현실적입니다. Feign 클라이언트 설정 로드 자체는 Spring 부팅 시에 검증되며, 실제 타임아웃 값은 런타임에 외부 API 호출 시 적용됩니다.
- **참고 사항**: 수정 파일은 `OpenAIFeignConfig.java`만이고, `OpenAIClient` 및 `STTClient` 인터페이스는 이 설정을 자동으로 참조하므로 추가 수정이 불필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)