### PR TITLE
fix(server): conversationHistory를 CopyOnWriteArrayList로 교체해 동시성 안전 확보

### DIFF
--- a/server/src/main/java/com/example/echo/context/domain/UserContext.java
+++ b/server/src/main/java/com/example/echo/context/domain/UserContext.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Data
 @Builder
@@ -23,7 +23,7 @@ public class UserContext {
     private LocalDate date;
 
     @Builder.Default
-    private List<ConversationTurn> conversationHistory = new ArrayList<>();
+    private List<ConversationTurn> conversationHistory = new CopyOnWriteArrayList<>();
 
     private EnrichedHealthData enrichedHealthData;
     private UserPreferences preferences;

--- a/server/src/main/java/com/example/echo/context/service/ContextService.java
+++ b/server/src/main/java/com/example/echo/context/service/ContextService.java
@@ -18,8 +18,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Slf4j
 @Service
@@ -82,7 +82,7 @@ public class ContextService {
         UserContext context = UserContext.builder()
                 .userId(userId)
                 .date(LocalDate.now())
-                .conversationHistory(new ArrayList<>())
+                .conversationHistory(new CopyOnWriteArrayList<>())
                 .enrichedHealthData(enrichedHealthData)
                 .preferences(preferences)
                 .todayWeather(weather)

--- a/server/src/test/java/com/example/echo/context/service/ContextServiceTest.java
+++ b/server/src/test/java/com/example/echo/context/service/ContextServiceTest.java
@@ -20,6 +20,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -304,6 +309,74 @@ class ContextServiceTest {
             // when & then (예외 발생하지 않아야 함)
             assertThatCode(() -> contextService.finalizeContext(nonExistentUserId))
                     .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("concurrentAddConversationTurn 메서드 - 동시성 테스트")
+    class ConcurrentAddConversationTurn {
+
+        @Test
+        @DisplayName("성공: 동시성 환경에서 모든 대화 턴이 정확히 추가된다")
+        void success_addsAllTurnsInConcurrentEnvironment() throws InterruptedException {
+            // given
+            given(userService.getPreferences(userId)).willReturn(mockPreferences);
+            given(healthDataService.buildEnrichedHealthData(eq(mockHealthData), eq(userId), any()))
+                    .willReturn(mockEnrichedHealthData);
+            given(weatherClient.getCurrentWeather(null, null)).willReturn(mockWeatherData);
+
+            contextService.initializeContext(userId, mockHealthData);
+            int totalThreads = 10;
+            int turnsPerThread = 100;
+            int expectedTurns = totalThreads * turnsPerThread;
+
+            ExecutorService executorService = Executors.newFixedThreadPool(totalThreads);
+            CountDownLatch latch = new CountDownLatch(totalThreads);
+            List<Exception> exceptions = new ArrayList<>();
+
+            // when
+            for (int i = 0; i < totalThreads; i++) {
+                final int threadId = i;
+                executorService.submit(() -> {
+                    try {
+                        for (int j = 0; j < turnsPerThread; j++) {
+                            contextService.addConversationTurn(
+                                    userId,
+                                    "스레드 " + threadId + " 메시지 " + j,
+                                    "스레드 " + threadId + " 응답 " + j
+                            );
+                        }
+                    } catch (Exception e) {
+                        synchronized (exceptions) {
+                            exceptions.add(e);
+                        }
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 완료될 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            // 예외가 발생하지 않았는지 확인
+            assertThat(exceptions).isEmpty();
+
+            // 정확히 1000개의 턴이 추가되었는지 확인
+            UserContext context = contextService.getContext(userId);
+            assertThat(context.getConversationHistory()).hasSize(expectedTurns);
+
+            // 모든 턴이 순회 가능한지 확인 (CopyOnWriteArrayList의 안전한 순회 검증)
+            int count = 0;
+            for (var turn : context.getConversationHistory()) {
+                assertThat(turn.getUserMessage()).isNotNull();
+                assertThat(turn.getAiResponse()).isNotNull();
+                assertThat(turn.getTimestamp()).isNotNull();
+                count++;
+            }
+            assertThat(count).isEqualTo(expectedTurns);
         }
     }
 }


### PR DESCRIPTION
## 문제

같은 사용자의 요청이 겹치면 `conversationHistory` 필드가 평범한 `ArrayList`이므로
비동기화 add/순회로 인해 `ConcurrentModificationException`이나 대화 턴 유실이 발생할 수 있습니다.

## 해결 방법

`conversationHistory`를 `CopyOnWriteArrayList`로 교체하여 스레드 안전성을 확보했습니다.

### `CopyOnWriteArrayList` 선택 근거

이 리스트는 **쓰기가 드물고 읽기/순회가 상대적으로 잦은** 사용 패턴에 최적입니다:
- **쓰기**: 대화 턴당 add 1회
- **읽기/순회**: AIService가 히스토리를 순회해 messages 배열 구성, retryTts가 마지막 요소 조회

`Collections.synchronizedList`와의 비교:
- synchronizedList: 순회 시 호출부마다 synchronized 블록이 필요해 변경 범위 확대
- **CopyOnWriteArrayList**: 스냅샷 순회로 호출부 무변경 가능 (이 프로젝트 구조 상 유리)

## 변경 사항

1. **`server/src/main/java/com/example/echo/context/domain/UserContext.java`** (26행)
   - `new ArrayList<>()` → `new CopyOnWriteArrayList<>()`
   - import: ArrayList 제거, CopyOnWriteArrayList 추가

2. **`server/src/main/java/com/example/echo/context/service/ContextService.java`** (85행)
   - `new ArrayList<>()` → `new CopyOnWriteArrayList<>()`
   - import: ArrayList 제거, CopyOnWriteArrayList 추가

3. **필드 타입/getter/호출부**: 변경 없음 (List 인터페이스 사용)

## 테스트

동시성 테스트를 `ContextServiceTest.java`에 추가했습니다:
- ExecutorService 10개 스레드
- 스레드당 100회씩 addConversationTurn 호출 (총 1,000 턴)
- 모든 턴이 정확히 추가되었는지 검증
- CopyOnWriteArrayList의 안전한 순회 검증
- 예외(ConcurrentModificationException) 미발생 검증

### 테스트 실행 결과
```
./gradlew test --tests "com.example.echo.context.service.ContextServiceTest"
BUILD SUCCESSFUL in 11s
```

모든 테스트 통과 (기존 8개 + 새 동시성 테스트 1개 = 9개 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)