### PR TITLE
fix(android): VadProcessor 재초기화 시 기존 인스턴스 close로 네이티브 누수 방지

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/voice/VadProcessor.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/voice/VadProcessor.kt
@@ -32,6 +32,9 @@ class VadProcessor(
      */
     fun initialize() {
         try {
+            // 재초기화 시 기존 네이티브 리소스를 먼저 해제 (누수 방지)
+            vad?.close()
+            vad = null
             vad = Vad.builder()
                 .setContext(context)
                 .setSampleRate(getSampleRate())


### PR DESCRIPTION
## 문제

초기화 성공 후 에러로 녹음이 끝나고 stop() 없이 start()가 다시 불리면(ConversationViewModel.startRecording → audioRecordManager.start 경로), `VadProcessor.initialize()`가 기존 VadSilero 인스턴스를 close하지 않고 덮어써 Silero VAD의 네이티브(ONNX) 리소스가 누적 누수되는 문제가 발생합니다.

## 수정 내용

`VadProcessor.kt`의 `initialize()` 메서드(33-46행)를 멱등하게 개선:
- 재초기화 전에 기존 `vad` 인스턴스를 `close()`로 정리
- 그 후 `vad = null`로 설정
- 마지막으로 새로운 VadSilero 빌더 체인 실행

이는 이미 존재하는 `close()` 헬퍼(62-65행)와 `isInitialized()` 메서드(60행)를 활용합니다.

## 테스트

**테스트 작성 불가 사유**: Silero VAD 라이브러리는 네이티브 ONNX 모델 바이너리를 로드하므로, JVM 환경(단위 테스트)에서는 `UnsatisfiedLinkError`가 발생합니다. MockK로 `Vad.builder()` static 메서드를 모킹하려 했으나 타입 추론 실패로 불가능합니다.

**대체 확인**: 메인 코드 컴파일 성공 확인
```bash
./gradlew compileLocalDebugKotlin
→ BUILD SUCCESSFUL
```

변경 사항은 최소한이며, 기존 코드 구조를 유지합니다.

## 참고

관련 발견 F6(VoiceRecordingManager scope 누수)도 있으나 별도 수정입니다. F5의 재초기화 경로 누수와 F6의 scope 누수는 발생 경로가 겹치지만 해결 방법이 다릅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)