### PR TITLE
fix(android): AudioRecordManager 재시작 시 이전 scope 취소로 collector 누수 방지

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/voice/AudioRecordManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/voice/AudioRecordManager.kt
@@ -87,6 +87,8 @@ class AudioRecordManager @VisibleForTesting internal constructor(
             return // 이미 활성 상태
         }
 
+        // 이전 실행의 scope가 남아 있으면 취소해 collector 누수 방지
+        scope?.cancel()
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
         _state.value = AudioRecordState.Preparing


### PR DESCRIPTION
## 문제

Completed/Error/Processing 상태에서 `stop()` 없이 `start()`가 다시 호출되면, 이전 CoroutineScope를 cancel하지 않고 덮어쓴다. 그 결과:
- `observeVadState()`에 등록된 StateFlow collector가 영구 누수된다
- collector가 중복 생성되면 `onReady()` 콜백이 중복 호출될 수 있다

이는 예를 들어 ConversationViewModel에서 녹음 중 에러 발생 후 stop()을 거치지 않고 재시작하는 경로에서 발생할 수 있다.

## 해결

`start()` 메서드 진입 시 새 scope를 생성하기 직전에 기존 `scope?.cancel()`을 호출한다. 이렇게 하면:
- 이전 scope의 모든 작업(collector 포함)이 정상 취소된다
- 누수 방지 및 중복 호출 방지 달성

## 수정 내용

`AudioRecordManager.kt` 90행 바로 위에 한 줄 추가:
```kotlin
// 이전 실행의 scope가 남아 있으면 취소해 collector 누수 방지
scope?.cancel()
scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
```

- kotlinx.coroutines.cancel은 이 파일에 이미 import되어 있음(16행)
- 가드 조건(82-88행)은 유지: Preparing/Listening/Recording 상태는 여전히 재진입 보호됨
- 이 수정은 통과되는 상태에서의 이전 scope 정리만 담당

## 테스트

단위 테스트 작성 시도 후, 다음 이유로 불가:

AudioRecordManager는 비동기 콜백(VadListener) 기반 상태 관리를 사용하고, VoiceRecordingManager와 AudioFileManager에 의존한다. JVM 테스트에서 이들 의존성을 모킹할 때:

1. VadListener를 MockK로 capture해서 상태 전환을 시뮬레이션해야 한다
2. observeVadState의 StateFlow collect가 scope 생성/취소와 함께 동작해야 한다
3. onSpeechEnd의 비동기 파일 저장 작업이 일관되게 완료되어야 한다
4. Dispatchers.Main과 Dispatchers.IO의 상호작용을 테스트 디스패처로 정확히 통제하기 어렵다

이러한 복잡성 때문에 신뢰할 수 있는 단위 테스트를 작성하기 어렵다. 대신 빌드가 정상임을 확인했다.

## 관련 발견

이 수정은 `docs/bug-hunt-results/T1.md`의 F6 항목에 해당하며, F5(VadProcessor 재초기화 누수)와는 별개의 수정이다. 두 발견 모두 "stop 없는 재시작" 경로에서 발생하지만, 리소스 누수 위치가 다르다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)