### PR TITLE
fix(android): 정상 stop()의 CancellationException을 에러로 변환하지 않도록 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/voice/VoiceRecordingManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/voice/VoiceRecordingManager.kt
@@ -6,6 +6,7 @@ import com.example.graduation_project.domain.voice.VadConfig
 import com.example.graduation_project.domain.voice.VadException
 import com.example.graduation_project.domain.voice.VadListener
 import com.example.graduation_project.domain.voice.VadState
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -102,6 +103,9 @@ class VoiceRecordingManager(
                     finalizeSpeech()
                 }
 
+            } catch (e: CancellationException) {
+                // 정상적인 stop()에 의한 취소 - 에러가 아니므로 그대로 전파
+                throw e
             } catch (e: VadException) {
                 _vadState.value = VadState.Error(e)
                 listener?.onError(e)


### PR DESCRIPTION
## 문제

VoiceRecordingManager의 `catch (e: Exception)` 핸들러가 `recordingJob?.cancel()` 호출 시 발생하는 CancellationException까지 잡아서, 정상적인 녹음 중지를 `VadState.Error` 전이와 `listener.onError()` 콜백으로 변환하던 문제.

## 해결

Kotlin 코루틴의 표준 사례에 따라 `CancellationException`을 별도로 처리하고 재던져 구조적 취소를 보존:
- `catch (e: CancellationException) { throw e }` 절을 추가
- 일반 `Exception` catch보다 앞에 배치하여 CancellationException이 정상적으로 전파되도록 함
- 85행의 `withTimeoutOrNull`은 자신의 TimeoutCancellationException을 내부에서 처리하므로, CancellationException 재던지기가 타임아웃 경로를 깨지 않음

## 기존 우회 코드

현재 ConversationViewModel(:177-179)에서 `wasAudioStoppedForBackground` 플래그로 백그라운드 경로만 우회하고 있습니다. 이번 PR에서 그 우회 코드는 건드리지 않으며, 추후 정리 대상입니다.

## 테스트

VoiceRecordingManager는 AudioRecorder(실제 AudioRecord)와 VadProcessor(native VAD)에 의존하며, mockkConstructor 기반 테스트가 불안정해 단위 테스트 작성을 시도했으나 실패했습니다. 대신 `./gradlew compileLocalDebugKotlin` 통과로 컴파일 검증을 완료했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)