### PR TITLE
fix(android): 설정에서 마이크 권한 허용 후 복귀 시 차단 다이얼로그가 사라지도록 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/permission/UnifiedPermissionHandler.kt
@@ -10,6 +10,7 @@ import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,6 +19,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.health.connect.client.HealthConnectClient
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.graduation_project.data.location.LocationScheduler
 import com.example.graduation_project.presentation.health.openHealthConnectSettings
 
@@ -77,6 +81,23 @@ fun UnifiedPermissionHandler(
 
     var hasCompletedOnboarding by remember {
         mutableStateOf(previouslyCompleted && !needsRecheck)
+    }
+
+    // 마이크 권한 보유 여부 (Compose 상태로 보관해, ON_RESUME 재확인 시 recomposition 유발)
+    var hasMicPermission by remember {
+        mutableStateOf(PermissionChecker.hasMicrophonePermission(context))
+    }
+
+    // 설정 앱에서 권한을 허용하고 돌아온 경우를 감지하기 위해 ON_RESUME마다 재확인
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                hasMicPermission = PermissionChecker.hasMicrophonePermission(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // 마이크 권한 요청 런처
@@ -209,8 +230,8 @@ fun UnifiedPermissionHandler(
 
     // 이미 온보딩 완료 또는 모든 필수 권한 있음
     if (hasCompletedOnboarding || currentStep == PermissionStep.COMPLETED) {
-        // 마이크 권한 체크 (필수)
-        if (!PermissionChecker.hasMicrophonePermission(context)) {
+        // 마이크 권한 체크 (필수) - Compose 상태를 읽어, ON_RESUME 재확인 시 recomposition되도록 함
+        if (!hasMicPermission) {
             MicrophonePermissionSettingsDialog(
                 onOpenSettings = { PermissionChecker.openAppSettings(context) }
             )


### PR DESCRIPTION
## 문제

`UnifiedPermissionHandler.kt`에서 온보딩 완료 상태에 마이크 권한이 없으면 닫기 버튼 없는 차단형 `MicrophonePermissionSettingsDialog`를 띄운다. 이 다이얼로그가 뜬 상태에서 사용자가 "설정" 버튼으로 시스템 설정 앱에 가서 마이크 권한을 **허용**하고 앱으로 돌아와도, 권한 판정이 `PermissionChecker.hasMicrophonePermission(context)`라는 일반 함수 호출이라 Compose의 recomposition을 유발하지 않는다. 그 결과 다이얼로그가 계속 떠 있어 사용자가 앱을 강제 종료해야만 빠져나올 수 있었다. (권한을 **회수**하는 경우는 OS가 프로세스를 종료시키므로 문제가 되지 않는다 — 이 버그는 "허용" 후 복귀 경로에서만 발생한다.)

근거: `docs/bug-hunt-results/T8.md` 발견 #1의 검증 노트 참조.

## 수정

- 마이크 권한 보유 여부를 `mutableStateOf`로 Compose 상태(`hasMicPermission`)로 들도록 변경.
- `HealthConnectPermissionHandler.kt`가 이미 쓰고 있는 것과 동일한 패턴(`LocalLifecycleOwner` + `DisposableEffect(lifecycleOwner)` + `LifecycleEventObserver`)을 그대로 적용해, `ON_RESUME`마다 `hasMicPermission`을 다시 계산.
- 차단 다이얼로그 분기(`hasCompletedOnboarding || currentStep == PermissionStep.COMPLETED`)가 이 상태를 읽도록 변경 → 설정에서 권한을 허용하고 복귀하면 `ON_RESUME`에서 상태가 갱신되어 recomposition이 일어나고 다이얼로그가 사라지며 `content()`가 정상 렌더링된다.
- 범위: `UnifiedPermissionHandler.kt`만 수정. 권한 요청 상태머신(`PermissionStep`), 다른 권한(위치/알림/헬스커넥트) 로직, 다른 파일은 건드리지 않았다.

## 수동 확인 절차

Compose UI + Activity 생명주기(ON_RESUME)에 의존하는 변경이라 순수 단위 테스트로는 검증이 어려워(실제 Activity 재개 이벤트, 실제 권한 부여 트리거가 필요) 아래 수동 절차로 확인한다:

1. 마이크 권한을 거부한 상태로 앱을 실행 → 온보딩 완료 상태라면 차단 다이얼로그(설정 안내)가 표시됨을 확인.
2. 다이얼로그의 "설정으로 이동" 버튼을 눌러 시스템 설정 앱으로 이동 → 마이크 권한을 **허용**으로 변경.
3. 뒤로 가기/앱 스위처로 앱에 복귀(`ON_RESUME` 트리거) → 다이얼로그가 사라지고 정상 화면(`content()`)이 렌더링되는지 확인.
4. (회귀 확인) 반대로 설정에서 마이크 권한을 **회수**하는 경우는 OS가 프로세스를 종료시키므로 별도 확인 불필요 — 재실행 시 처음부터 정상적으로 재평가됨.

계측 테스트(androidTest)는 실제 시스템 설정 앱 왕복 및 권한 부여를 자동화해야 해 이번 환경에서는 신뢰성 있게 작성하기 어려워 생략했다.

## 빌드 검증

```
cd android && ./gradlew compileLocalDebugKotlin
```
→ `BUILD SUCCESSFUL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)