### PR TITLE
feat: OpenRouter로 AI 채팅 마이그레이션 + 매일 모델 자동 로테이션

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -42,7 +42,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **ORM**: Spring Data JPA
 - **HTTP 클라이언트**: Spring Cloud OpenFeign 2025.0.0
 - **캐싱**: Caffeine (프롬프트 템플릿 캐싱)
-- **외부 API**: OpenAI (GPT-4o-mini, Whisper:STT), Azure Cognitive Services TTS
+- **외부 API**: OpenRouter (채팅, 매일 다른 모델로 자동 로테이션), OpenAI (Whisper:STT), Azure Cognitive Services TTS
 - **API 문서**: springdoc-openapi 2.3.0 (Swagger UI 적용, http://localhost:8080/swagger-ui.html)
 
 ## 아키텍처
@@ -67,7 +67,7 @@ ConversationController
 |--------|--------------------------------------------------------------------------|
 | `conversation` | 대화 세션 오케스트레이션 (컨트롤러, 서비스)                                                |
 | `voice` | STT/TTS 처리 (STT: OpenAI Whisper, TTS: Azure Cognitive Services) |
-| `ai` | OpenAI Chat Completion API 호출 (GPT-4o-mini)                                              |
+| `ai` | OpenRouter Chat Completion API 호출 (매일 자동으로 다른 모델 로테이션)                                              |
 | `prompt` | 시스템 프롬프트 빌드 및 템플릿 관리 (Entity/Repository/캐싱)                                                              |
 | `context` | 세션별 사용자 컨텍스트 관리 (ConcurrentHashMap 기반)                                   |
 | `diary` | 대화 요약 및 일기 생성                                                            |
@@ -91,7 +91,7 @@ ConversationController
 ## 설정
 
 - **application.yaml**: DB 연결, JPA 설정, Open AI API
-- **OpenAI API 키**: application-local.yaml 사용 ( 보안 목적 )
+- **OpenAI/OpenRouter API 키**: application-local.yaml 사용 ( 보안 목적 )
 
 ## 외부 API 연동
 
@@ -99,7 +99,7 @@ ConversationController
 |-----|------|---------------------------------|
 | STT | 구현 완료 | `STTClient` → OpenAI Whisper    |
 | TTS | 구현 완료 | `TTSClient` → Azure Cognitive Services TTS |
-| AI 응답 | 구현 완료 | `OpenAIClient` → OpenAI GPT-4o-mini |
+| AI 응답 | 구현 완료 | `OpenRouterClient` → OpenRouter (매일 자동으로 다른 모델 로테이션, `ModelRotationService`) |
 | 날씨 | 더미 구현 | `WeatherClient` → OpenWeatherMap |
 
 ## 주의사항

--- a/server/scripts/model_chat_comparison.html
+++ b/server/scripts/model_chat_comparison.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>모델 비교 채팅 (side-by-side)</title>
+<style>
+  :root {
+    --bg: #f7f8fa; --surface: #fff; --border: #dde1e6; --text: #1a1d23;
+    --muted: #5b6472; --accent: #0f8f88; --user-bg: #e3f4f2; --ai-bg: #f3f4f6;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, "Segoe UI", "Malgun Gothic", sans-serif;
+  }
+  header {
+    padding: 16px 20px; background: var(--surface); border-bottom: 1px solid var(--border);
+  }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  header p { margin: 0; color: var(--muted); font-size: 13px; }
+
+  .config {
+    display: flex; flex-wrap: wrap; gap: 12px; padding: 14px 20px;
+    background: var(--surface); border-bottom: 1px solid var(--border); align-items: center;
+  }
+  .config label { font-size: 13px; color: var(--muted); }
+  .config input[type="password"], .config input[type="text"] {
+    font-family: ui-monospace, monospace; font-size: 13px; padding: 6px 8px;
+    border: 1px solid var(--border); border-radius: 6px; width: 320px;
+  }
+  .models { display: flex; gap: 10px; flex-wrap: wrap; }
+  .models label { display: flex; align-items: center; gap: 4px; font-size: 13px; }
+
+  .composer {
+    display: flex; gap: 8px; padding: 12px 20px; background: var(--surface);
+    border-bottom: 1px solid var(--border);
+  }
+  .composer textarea {
+    flex: 1; resize: vertical; min-height: 44px; font-size: 14px; padding: 8px 10px;
+    border: 1px solid var(--border); border-radius: 8px; font-family: inherit;
+  }
+  button {
+    font-size: 13.5px; font-weight: 600; padding: 8px 16px; border-radius: 8px;
+    border: 1px solid var(--accent); background: var(--accent); color: #fff; cursor: pointer;
+  }
+  button.secondary { background: var(--surface); color: var(--accent); }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .board {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 12px; padding: 16px 20px;
+  }
+  .column {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    display: flex; flex-direction: column; min-height: 400px; max-height: 70vh;
+  }
+  .column h2 {
+    font-size: 13.5px; font-family: ui-monospace, monospace; padding: 10px 12px;
+    border-bottom: 1px solid var(--border); margin: 0; color: var(--accent);
+  }
+  .thread { flex: 1; overflow-y: auto; padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; }
+  .msg { font-size: 13.5px; line-height: 1.5; padding: 8px 10px; border-radius: 8px; white-space: pre-wrap; }
+  .msg.user { background: var(--user-bg); align-self: flex-end; max-width: 85%; }
+  .msg.ai { background: var(--ai-bg); align-self: flex-start; max-width: 85%; }
+  .msg.pending { color: var(--muted); font-style: italic; }
+
+  footer { padding: 10px 20px; color: var(--muted); font-size: 12px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>모델 비교 채팅 — develop v8 시스템 프롬프트 고정</h1>
+  <p>동일한 메시지를 선택된 모델 전체에 동시에 보내고, 각 모델의 응답을 나란히 비교합니다.</p>
+</header>
+
+<div class="config">
+  <label>OpenRouter API 키
+    <input type="password" id="apiKey" placeholder="sk-or-v1-...">
+  </label>
+  <div class="models" id="modelToggles"></div>
+  <button class="secondary" id="exportBtn">내보내기 (.txt)</button>
+  <button class="secondary" id="resetBtn">초기화</button>
+</div>
+
+<div class="composer">
+  <textarea id="input" placeholder="모든 모델에게 보낼 메시지를 입력하세요..."></textarea>
+  <button id="sendBtn">전송</button>
+</div>
+
+<div class="board" id="board"></div>
+
+<footer>세션은 브라우저 localStorage에 자동 저장됩니다. API 키도 로컬에만 저장되며 서버로 전송되지 않습니다(OpenRouter 호출 제외).</footer>
+
+<script>
+const STORAGE_KEY = "echo_model_chat_comparison_v1";
+
+const MODELS = [
+  "openai/gpt-5.5",
+  "anthropic/claude-sonnet-5",
+  "anthropic/claude-sonnet-4.5",
+  "anthropic/claude-haiku-4.5",
+];
+
+const SYSTEM_PROMPT = `당신은 경도인지장애(MCI) 어르신의 따뜻한 말벗 AI입니다.
+오늘의 날씨와 방문 장소를 실마리 삼아, 어르신의 소중한 옛 추억을 함께 꺼내드리세요.
+
+────────────────────────────
+[어르신 정보]
+────────────────────────────
+이름: 김옥순 / 나이: 78세 / 생일: 1948-03-15
+취미: 텃밭 가꾸기 / 과거 직업: 초등학교 교사
+가족: 딸 둘, 사위, 손주 셋 / 선호 주제: 정원 가꾸기, 옛날 이야기
+
+────────────────────────────
+[오늘의 맥락 — 대화 실마리]
+────────────────────────────
+현재 위치: 대전
+현재 날씨: 맑음, 24도
+
+[오늘 다녀오신 곳] (체류 시간 순)
+한밭수목원 (체류 2시간, 방문 시점 날씨: 맑음, 23도)
+
+[건강 상태] (안부 확인용만)
+수면 평가: 적당 / 기상 평가: 평소와 비슷
+
+────────────────────────────
+[응답 규칙 — 반드시 지킬 것]
+────────────────────────────
+① 응답은 최대 2문장. 부정 감정 표현 시 최대 3문장.
+② 질문은 한 턴에 반드시 1개만. 어떤 경우에도 2개 금지.
+③ "기억나세요?", "기억하세요?" 등 기억력을 테스트하는 표현 금지.
+④ 건강 수치(걸음 수 숫자, 수면 시간 숫자) 직접 언급 금지.
+⑤ 데이터에 없는 내용 절대 만들지 말 것.
+
+────────────────────────────
+[대화 원칙]
+────────────────────────────
+- 오늘의 방문 장소는 AI가 먼저 알려주는 단서이지, 기억을 테스트하는 것이 아님
+- 목표는 어르신의 20~40대 자전적 기억(인생에서 가장 생생한 시절)을 자연스럽게 떠올리게 하는 것
+- 어르신의 말을 반영하여 더 이야기하게 유도할 것 (CTRS 반영 경청)
+- 어르신 기억이 사실과 달라도 교정하지 않음 → "그러셨군요, 좋으셨겠어요."
+- 어르신이 피곤해하시면 "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[대화 흐름 — 3단계]
+────────────────────────────
+총 7~10턴을 목표로 한다.
+
+▶ [1단계: 날씨 인사 + 안부] (1~2턴)
+  - 날씨(맑음, 24도)로 자연스럽게 시작
+  - 수면 평가(적당)를 참고해 "잘 주무셨어요?" 수준의 안부만
+  - 건강 수치 절대 언급 금지
+
+▶ [2단계: 위치 단서 → 과거 회상 연결] (2~3턴)
+  - AI가 먼저 오늘 방문 장소를 언급: "오늘 OO 근처에 다녀오셨네요."
+  - 그 장소와 관련된 어르신의 20~40대 시절 기억으로 자연스럽게 전환
+    예: "그 근처에서 젊으실 때 기억이 있으신가요?"
+  - 방문 장소가 없으면 날씨나 취미(텃밭 가꾸기)를 실마리로 과거 회상 유도
+  - 방문 시점 날씨도 활용 가능: "그때도 이렇게 따뜻했나요?"
+
+▶ [3단계: 과거 회상 심화 — SFAM 3단계] (4~5턴)
+  사실(Fact) → 감정(Feeling) → 의미(Meaning) 순서로 심화:
+  - 사실: "그때 무엇을 하셨나요? / 누구와 함께 계셨나요?"
+  - 감정: "그때 기분이 어떠셨어요? / 많이 좋으셨겠어요."
+  - 의미: "그 시절이 어르신께 어떤 의미였나요?"
+
+  취미(텃밭 가꾸기), 직업(초등학교 교사), 가족(딸 둘, 사위, 손주 셋)과 연결하여 깊이 탐색.
+  어르신이 한 주제에서 풍부하게 말씀하시면 그 흐름을 따라감.
+
+  [공감 표현 — Hardee 5단계]
+  - 환영: "말씀해 주셔서 감사해요."
+  - 경청: 말을 끊지 않고 끝까지 듣는 태도
+  - 공감: "많이 좋으셨겠어요", "그때 많이 힘드셨겠어요" 등 감정 반영
+  - 탐색: 어르신 말씀을 되짚으며 한 가지만 더 질문
+  - 확인: "그 시절 정말 소중한 시간이셨겠어요." 식으로 가치를 인정
+
+▶ [마무리] (1~2턴)
+  - 오늘 회상한 긍정적인 기억 한 가지를 짧게 되짚음
+  - 따뜻하게 인사로 마무리. 이 단계에서는 질문 없음.
+
+────────────────────────────
+[이탈 발화 및 무응답 대응]
+────────────────────────────
+▷ 단답/무관한 발화 → 자연스럽게 받아준 뒤 주제로 부드럽게 돌아옴
+▷ 단답 2회 연속 → 해당 주제 내려놓고 다음 단계로 이동
+▷ 무응답 1회 → "천천히 생각해 보셔도 돼요." 후 동일 주제 유지
+▷ 무응답 2회 연속 → 부드럽게 마무리로 전환
+▷ 부정적 감정 → 공감만, 질문 없음. 다음 턴에 긍정적 주제로 전환
+▷ 피로/혼란 신호 → "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[안전 프로토콜]
+────────────────────────────
+- 우울/자해 신호 감지 시: "오늘 많이 힘드신 것 같아요. 잠시 쉬어가는 건 어떨까요?"로 전환
+- 의료 응급 언급 시: 즉시 119 연락 권유
+- 학대/방임 신호 감지 시: 공감 후 보호자 상담 권유
+
+────────────────────────────
+[절대 금지]
+────────────────────────────
+- 오늘 날짜/요일/연도를 묻는 질문 ("오늘이 며칠인지 아세요?")
+- 최근 기억 테스트 ("오늘 뭐 드셨어요?", "아까 뭐 하셨어요?")
+- 틀린 기억 교정 ("그건 아닌데요", "다시 생각해 보세요")
+- 복잡한 다단계 질문 (한 번에 한 가지만)
+- 의학적 조언 ("치매에는 이게 좋대요")
+- 데이터에 없는 내용 추측하여 언급`;
+
+let state = loadState();
+
+function defaultState() {
+  const threads = {};
+  MODELS.forEach(m => { threads[m] = { enabled: true, messages: [] }; });
+  return { apiKey: "", threads };
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState();
+    const parsed = JSON.parse(raw);
+    const base = defaultState();
+    MODELS.forEach(m => {
+      if (parsed.threads && parsed.threads[m]) base.threads[m] = parsed.threads[m];
+    });
+    base.apiKey = parsed.apiKey || "";
+    return base;
+  } catch {
+    return defaultState();
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function renderModelToggles() {
+  const el = document.getElementById("modelToggles");
+  el.innerHTML = "";
+  MODELS.forEach(m => {
+    const label = document.createElement("label");
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = state.threads[m].enabled;
+    cb.addEventListener("change", () => {
+      state.threads[m].enabled = cb.checked;
+      saveState();
+      renderBoard();
+    });
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(m));
+    el.appendChild(label);
+  });
+}
+
+function renderBoard() {
+  const board = document.getElementById("board");
+  board.innerHTML = "";
+  MODELS.filter(m => state.threads[m].enabled).forEach(m => {
+    const col = document.createElement("div");
+    col.className = "column";
+    const h2 = document.createElement("h2");
+    h2.textContent = m;
+    const thread = document.createElement("div");
+    thread.className = "thread";
+    thread.id = "thread_" + cssId(m);
+    state.threads[m].messages.forEach(msg => thread.appendChild(renderMsg(msg)));
+    col.appendChild(h2);
+    col.appendChild(thread);
+    board.appendChild(col);
+    thread.scrollTop = thread.scrollHeight;
+  });
+}
+
+function cssId(model) {
+  return model.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+function renderMsg(msg) {
+  const div = document.createElement("div");
+  div.className = "msg " + (msg.role === "user" ? "user" : "ai") + (msg.pending ? " pending" : "");
+  div.textContent = msg.content;
+  return div;
+}
+
+async function callModel(model, messages, apiKey) {
+  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model, messages, temperature: 0.7, max_tokens: 1024 }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return `[ERROR ${res.status}] ${text}`;
+  }
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content ?? "[EMPTY RESPONSE]";
+}
+
+async function sendToAll() {
+  const input = document.getElementById("input");
+  const text = input.value.trim();
+  if (!text) return;
+  const apiKey = document.getElementById("apiKey").value.trim();
+  if (!apiKey) { alert("OpenRouter API 키를 입력해주세요."); return; }
+  state.apiKey = apiKey;
+
+  const enabledModels = MODELS.filter(m => state.threads[m].enabled);
+  enabledModels.forEach(m => state.threads[m].messages.push({ role: "user", content: text }));
+  input.value = "";
+  saveState();
+  renderBoard();
+
+  document.getElementById("sendBtn").disabled = true;
+
+  await Promise.all(enabledModels.map(async (m) => {
+    const thread = document.getElementById("thread_" + cssId(m));
+    const pending = renderMsg({ role: "assistant", content: "…", pending: true });
+    thread.appendChild(pending);
+    thread.scrollTop = thread.scrollHeight;
+
+    const messages = [{ role: "system", content: SYSTEM_PROMPT }, ...state.threads[m].messages];
+    const reply = await callModel(m, messages, apiKey);
+    state.threads[m].messages.push({ role: "assistant", content: reply });
+    saveState();
+    renderBoard();
+  }));
+
+  document.getElementById("sendBtn").disabled = false;
+}
+
+function exportTranscript() {
+  let out = `Echo 모델 비교 채팅 내보내기 — ${new Date().toISOString()}\n\n`;
+  MODELS.forEach(m => {
+    out += `\n===== ${m} =====\n\n`;
+    state.threads[m].messages.forEach(msg => {
+      out += `[${msg.role}] ${msg.content}\n\n`;
+    });
+  });
+  const blob = new Blob([out], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `model-chat-comparison-${Date.now()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function resetAll() {
+  if (!confirm("모든 대화 기록을 초기화할까요?")) return;
+  state = defaultState();
+  saveState();
+  renderModelToggles();
+  renderBoard();
+}
+
+document.getElementById("apiKey").value = state.apiKey;
+document.getElementById("sendBtn").addEventListener("click", sendToAll);
+document.getElementById("exportBtn").addEventListener("click", exportTranscript);
+document.getElementById("resetBtn").addEventListener("click", resetAll);
+document.getElementById("input").addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) sendToAll();
+});
+
+renderModelToggles();
+renderBoard();
+</script>
+</body>
+</html>

--- a/server/scripts/model_chat_individual.html
+++ b/server/scripts/model_chat_individual.html
@@ -1,0 +1,366 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>모델별 독립 채팅</title>
+<style>
+  :root {
+    --bg: #f7f8fa; --surface: #fff; --border: #dde1e6; --text: #1a1d23;
+    --muted: #5b6472; --accent: #0f8f88; --user-bg: #e3f4f2; --ai-bg: #f3f4f6;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, "Segoe UI", "Malgun Gothic", sans-serif;
+  }
+  header {
+    padding: 16px 20px; background: var(--surface); border-bottom: 1px solid var(--border);
+  }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  header p { margin: 0; color: var(--muted); font-size: 13px; }
+
+  .config {
+    display: flex; flex-wrap: wrap; gap: 12px; padding: 14px 20px;
+    background: var(--surface); border-bottom: 1px solid var(--border); align-items: center;
+  }
+  .config label { font-size: 13px; color: var(--muted); }
+  .config input[type="password"] {
+    font-family: ui-monospace, monospace; font-size: 13px; padding: 6px 8px;
+    border: 1px solid var(--border); border-radius: 6px; width: 320px;
+  }
+  button {
+    font-size: 13px; font-weight: 600; padding: 7px 14px; border-radius: 8px;
+    border: 1px solid var(--accent); background: var(--accent); color: #fff; cursor: pointer;
+  }
+  button.secondary { background: var(--surface); color: var(--accent); }
+  button.small { padding: 5px 10px; font-size: 12.5px; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .board {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 12px; padding: 16px 20px;
+  }
+  .card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    display: flex; flex-direction: column; min-height: 460px; max-height: 75vh;
+  }
+  .card h2 {
+    font-size: 13.5px; font-family: ui-monospace, monospace; padding: 10px 12px;
+    border-bottom: 1px solid var(--border); margin: 0; color: var(--accent);
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .card h2 button { padding: 3px 8px; font-size: 11px; }
+  .thread { flex: 1; overflow-y: auto; padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; }
+  .msg { font-size: 13.5px; line-height: 1.5; padding: 8px 10px; border-radius: 8px; white-space: pre-wrap; }
+  .msg.user { background: var(--user-bg); align-self: flex-end; max-width: 90%; }
+  .msg.ai { background: var(--ai-bg); align-self: flex-start; max-width: 90%; }
+  .msg.pending { color: var(--muted); font-style: italic; }
+
+  .card-composer {
+    display: flex; gap: 6px; padding: 10px 12px; border-top: 1px solid var(--border);
+  }
+  .card-composer textarea {
+    flex: 1; resize: none; min-height: 38px; font-size: 13px; padding: 6px 8px;
+    border: 1px solid var(--border); border-radius: 6px; font-family: inherit;
+  }
+
+  footer { padding: 10px 20px; color: var(--muted); font-size: 12px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>모델별 독립 채팅 — develop v8 시스템 프롬프트 고정</h1>
+  <p>각 모델 카드가 독립된 대화 스레드를 가집니다. 모델마다 다른 메시지를 보내 대화를 다르게 이어갈 수 있습니다.</p>
+</header>
+
+<div class="config">
+  <label>OpenRouter API 키
+    <input type="password" id="apiKey" placeholder="sk-or-v1-...">
+  </label>
+  <button class="secondary" id="exportBtn">전체 내보내기 (.txt)</button>
+  <button class="secondary" id="resetBtn">전체 초기화</button>
+</div>
+
+<div class="board" id="board"></div>
+
+<footer>세션은 브라우저 localStorage(model_chat_individual 전용 키)에 자동 저장됩니다. side-by-side 비교 페이지와는 별도 저장소를 사용해 서로 충돌하지 않습니다.</footer>
+
+<script>
+const STORAGE_KEY = "echo_model_chat_individual_v1";
+
+const MODELS = [
+  "openai/gpt-5.5",
+  "anthropic/claude-sonnet-5",
+  "anthropic/claude-sonnet-4.5",
+  "anthropic/claude-haiku-4.5",
+];
+
+const SYSTEM_PROMPT = `당신은 경도인지장애(MCI) 어르신의 따뜻한 말벗 AI입니다.
+오늘의 날씨와 방문 장소를 실마리 삼아, 어르신의 소중한 옛 추억을 함께 꺼내드리세요.
+
+────────────────────────────
+[어르신 정보]
+────────────────────────────
+이름: 김옥순 / 나이: 78세 / 생일: 1948-03-15
+취미: 텃밭 가꾸기 / 과거 직업: 초등학교 교사
+가족: 딸 둘, 사위, 손주 셋 / 선호 주제: 정원 가꾸기, 옛날 이야기
+
+────────────────────────────
+[오늘의 맥락 — 대화 실마리]
+────────────────────────────
+현재 위치: 대전
+현재 날씨: 맑음, 24도
+
+[오늘 다녀오신 곳] (체류 시간 순)
+한밭수목원 (체류 2시간, 방문 시점 날씨: 맑음, 23도)
+
+[건강 상태] (안부 확인용만)
+수면 평가: 적당 / 기상 평가: 평소와 비슷
+
+────────────────────────────
+[응답 규칙 — 반드시 지킬 것]
+────────────────────────────
+① 응답은 최대 2문장. 부정 감정 표현 시 최대 3문장.
+② 질문은 한 턴에 반드시 1개만. 어떤 경우에도 2개 금지.
+③ "기억나세요?", "기억하세요?" 등 기억력을 테스트하는 표현 금지.
+④ 건강 수치(걸음 수 숫자, 수면 시간 숫자) 직접 언급 금지.
+⑤ 데이터에 없는 내용 절대 만들지 말 것.
+
+────────────────────────────
+[대화 원칙]
+────────────────────────────
+- 오늘의 방문 장소는 AI가 먼저 알려주는 단서이지, 기억을 테스트하는 것이 아님
+- 목표는 어르신의 20~40대 자전적 기억(인생에서 가장 생생한 시절)을 자연스럽게 떠올리게 하는 것
+- 어르신의 말을 반영하여 더 이야기하게 유도할 것 (CTRS 반영 경청)
+- 어르신 기억이 사실과 달라도 교정하지 않음 → "그러셨군요, 좋으셨겠어요."
+- 어르신이 피곤해하시면 "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[대화 흐름 — 3단계]
+────────────────────────────
+총 7~10턴을 목표로 한다.
+
+▶ [1단계: 날씨 인사 + 안부] (1~2턴)
+  - 날씨(맑음, 24도)로 자연스럽게 시작
+  - 수면 평가(적당)를 참고해 "잘 주무셨어요?" 수준의 안부만
+  - 건강 수치 절대 언급 금지
+
+▶ [2단계: 위치 단서 → 과거 회상 연결] (2~3턴)
+  - AI가 먼저 오늘 방문 장소를 언급: "오늘 OO 근처에 다녀오셨네요."
+  - 그 장소와 관련된 어르신의 20~40대 시절 기억으로 자연스럽게 전환
+    예: "그 근처에서 젊으실 때 기억이 있으신가요?"
+  - 방문 장소가 없으면 날씨나 취미(텃밭 가꾸기)를 실마리로 과거 회상 유도
+  - 방문 시점 날씨도 활용 가능: "그때도 이렇게 따뜻했나요?"
+
+▶ [3단계: 과거 회상 심화 — SFAM 3단계] (4~5턴)
+  사실(Fact) → 감정(Feeling) → 의미(Meaning) 순서로 심화:
+  - 사실: "그때 무엇을 하셨나요? / 누구와 함께 계셨나요?"
+  - 감정: "그때 기분이 어떠셨어요? / 많이 좋으셨겠어요."
+  - 의미: "그 시절이 어르신께 어떤 의미였나요?"
+
+  취미(텃밭 가꾸기), 직업(초등학교 교사), 가족(딸 둘, 사위, 손주 셋)과 연결하여 깊이 탐색.
+  어르신이 한 주제에서 풍부하게 말씀하시면 그 흐름을 따라감.
+
+  [공감 표현 — Hardee 5단계]
+  - 환영: "말씀해 주셔서 감사해요."
+  - 경청: 말을 끊지 않고 끝까지 듣는 태도
+  - 공감: "많이 좋으셨겠어요", "그때 많이 힘드셨겠어요" 등 감정 반영
+  - 탐색: 어르신 말씀을 되짚으며 한 가지만 더 질문
+  - 확인: "그 시절 정말 소중한 시간이셨겠어요." 식으로 가치를 인정
+
+▶ [마무리] (1~2턴)
+  - 오늘 회상한 긍정적인 기억 한 가지를 짧게 되짚음
+  - 따뜻하게 인사로 마무리. 이 단계에서는 질문 없음.
+
+────────────────────────────
+[이탈 발화 및 무응답 대응]
+────────────────────────────
+▷ 단답/무관한 발화 → 자연스럽게 받아준 뒤 주제로 부드럽게 돌아옴
+▷ 단답 2회 연속 → 해당 주제 내려놓고 다음 단계로 이동
+▷ 무응답 1회 → "천천히 생각해 보셔도 돼요." 후 동일 주제 유지
+▷ 무응답 2회 연속 → 부드럽게 마무리로 전환
+▷ 부정적 감정 → 공감만, 질문 없음. 다음 턴에 긍정적 주제로 전환
+▷ 피로/혼란 신호 → "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[안전 프로토콜]
+────────────────────────────
+- 우울/자해 신호 감지 시: "오늘 많이 힘드신 것 같아요. 잠시 쉬어가는 건 어떨까요?"로 전환
+- 의료 응급 언급 시: 즉시 119 연락 권유
+- 학대/방임 신호 감지 시: 공감 후 보호자 상담 권유
+
+────────────────────────────
+[절대 금지]
+────────────────────────────
+- 오늘 날짜/요일/연도를 묻는 질문 ("오늘이 며칠인지 아세요?")
+- 최근 기억 테스트 ("오늘 뭐 드셨어요?", "아까 뭐 하셨어요?")
+- 틀린 기억 교정 ("그건 아닌데요", "다시 생각해 보세요")
+- 복잡한 다단계 질문 (한 번에 한 가지만)
+- 의학적 조언 ("치매에는 이게 좋대요")
+- 데이터에 없는 내용 추측하여 언급`;
+
+let state = loadState();
+
+function defaultState() {
+  const threads = {};
+  MODELS.forEach(m => { threads[m] = []; });
+  return { apiKey: "", threads };
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState();
+    const parsed = JSON.parse(raw);
+    const base = defaultState();
+    MODELS.forEach(m => {
+      if (parsed.threads && parsed.threads[m]) base.threads[m] = parsed.threads[m];
+    });
+    base.apiKey = parsed.apiKey || "";
+    return base;
+  } catch {
+    return defaultState();
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function cssId(model) {
+  return model.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+function renderMsg(msg) {
+  const div = document.createElement("div");
+  div.className = "msg " + (msg.role === "user" ? "user" : "ai") + (msg.pending ? " pending" : "");
+  div.textContent = msg.content;
+  return div;
+}
+
+function renderBoard() {
+  const board = document.getElementById("board");
+  board.innerHTML = "";
+  MODELS.forEach(m => {
+    const id = cssId(m);
+    const card = document.createElement("div");
+    card.className = "card";
+
+    const h2 = document.createElement("h2");
+    h2.textContent = m;
+    const clearBtn = document.createElement("button");
+    clearBtn.className = "small secondary";
+    clearBtn.textContent = "지우기";
+    clearBtn.addEventListener("click", () => {
+      state.threads[m] = [];
+      saveState();
+      renderBoard();
+    });
+    h2.appendChild(clearBtn);
+
+    const thread = document.createElement("div");
+    thread.className = "thread";
+    thread.id = "thread_" + id;
+    state.threads[m].forEach(msg => thread.appendChild(renderMsg(msg)));
+
+    const composer = document.createElement("div");
+    composer.className = "card-composer";
+    const textarea = document.createElement("textarea");
+    textarea.placeholder = `${m}에게 보낼 메시지...`;
+    textarea.id = "input_" + id;
+    const sendBtn = document.createElement("button");
+    sendBtn.textContent = "전송";
+    sendBtn.id = "send_" + id;
+    sendBtn.addEventListener("click", () => sendToModel(m));
+    textarea.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) sendToModel(m);
+    });
+    composer.appendChild(textarea);
+    composer.appendChild(sendBtn);
+
+    card.appendChild(h2);
+    card.appendChild(thread);
+    card.appendChild(composer);
+    board.appendChild(card);
+    thread.scrollTop = thread.scrollHeight;
+  });
+}
+
+async function callModel(model, messages, apiKey) {
+  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model, messages, temperature: 0.7, max_tokens: 1024 }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return `[ERROR ${res.status}] ${text}`;
+  }
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content ?? "[EMPTY RESPONSE]";
+}
+
+async function sendToModel(model) {
+  const id = cssId(model);
+  const textarea = document.getElementById("input_" + id);
+  const text = textarea.value.trim();
+  if (!text) return;
+  const apiKey = document.getElementById("apiKey").value.trim();
+  if (!apiKey) { alert("OpenRouter API 키를 입력해주세요."); return; }
+  state.apiKey = apiKey;
+
+  state.threads[model].push({ role: "user", content: text });
+  textarea.value = "";
+  saveState();
+  renderBoard();
+
+  const sendBtn = document.getElementById("send_" + id);
+  sendBtn.disabled = true;
+
+  const thread = document.getElementById("thread_" + id);
+  const pending = renderMsg({ role: "assistant", content: "…", pending: true });
+  thread.appendChild(pending);
+  thread.scrollTop = thread.scrollHeight;
+
+  const messages = [{ role: "system", content: SYSTEM_PROMPT }, ...state.threads[model]];
+  const reply = await callModel(model, messages, apiKey);
+  state.threads[model].push({ role: "assistant", content: reply });
+  saveState();
+  renderBoard();
+}
+
+function exportTranscript() {
+  let out = `Echo 모델별 독립 채팅 내보내기 — ${new Date().toISOString()}\n\n`;
+  MODELS.forEach(m => {
+    out += `\n===== ${m} =====\n\n`;
+    state.threads[m].forEach(msg => {
+      out += `[${msg.role}] ${msg.content}\n\n`;
+    });
+  });
+  const blob = new Blob([out], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `model-chat-individual-${Date.now()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function resetAll() {
+  if (!confirm("모든 모델의 대화 기록을 초기화할까요?")) return;
+  state = defaultState();
+  saveState();
+  renderBoard();
+}
+
+document.getElementById("apiKey").value = state.apiKey;
+document.getElementById("exportBtn").addEventListener("click", exportTranscript);
+document.getElementById("resetBtn").addEventListener("click", resetAll);
+
+renderBoard();
+</script>
+</body>
+</html>

--- a/server/scripts/openrouter_model_comparison.py
+++ b/server/scripts/openrouter_model_comparison.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Compare model responses against the production v8 system prompt via OpenRouter.
+
+Standalone script, does not modify any existing application code.
+Requires the OPENROUTER_API_KEY environment variable to be set.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+MODELS = [
+    "openai/gpt-5.5",
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-sonnet-4.5",
+    "anthropic/claude-haiku-4.5",
+]
+
+# Verbatim active v8 SYSTEM prompt (develop, data.sql), placeholders filled with
+# a sample persona so the scenarios below are self-contained.
+SYSTEM_PROMPT = """당신은 경도인지장애(MCI) 어르신의 따뜻한 말벗 AI입니다.
+오늘의 날씨와 방문 장소를 실마리 삼아, 어르신의 소중한 옛 추억을 함께 꺼내드리세요.
+
+────────────────────────────
+[어르신 정보]
+────────────────────────────
+이름: 김옥순 / 나이: 78세 / 생일: 1948-03-15
+취미: 텃밭 가꾸기 / 과거 직업: 초등학교 교사
+가족: 딸 둘, 사위, 손주 셋 / 선호 주제: 정원 가꾸기, 옛날 이야기
+
+────────────────────────────
+[오늘의 맥락 — 대화 실마리]
+────────────────────────────
+현재 위치: 대전
+현재 날씨: 맑음, 24도
+
+[오늘 다녀오신 곳] (체류 시간 순)
+한밭수목원 (체류 2시간, 방문 시점 날씨: 맑음, 23도)
+
+[건강 상태] (안부 확인용만)
+수면 평가: 적당 / 기상 평가: 평소와 비슷
+
+────────────────────────────
+[응답 규칙 — 반드시 지킬 것]
+────────────────────────────
+① 응답은 최대 2문장. 부정 감정 표현 시 최대 3문장.
+② 질문은 한 턴에 반드시 1개만. 어떤 경우에도 2개 금지.
+③ "기억나세요?", "기억하세요?" 등 기억력을 테스트하는 표현 금지.
+④ 건강 수치(걸음 수 숫자, 수면 시간 숫자) 직접 언급 금지.
+⑤ 데이터에 없는 내용 절대 만들지 말 것.
+
+────────────────────────────
+[대화 원칙]
+────────────────────────────
+- 오늘의 방문 장소는 AI가 먼저 알려주는 단서이지, 기억을 테스트하는 것이 아님
+- 목표는 어르신의 20~40대 자전적 기억(인생에서 가장 생생한 시절)을 자연스럽게 떠올리게 하는 것
+- 어르신의 말을 반영하여 더 이야기하게 유도할 것 (CTRS 반영 경청)
+- 어르신 기억이 사실과 달라도 교정하지 않음 → "그러셨군요, 좋으셨겠어요."
+- 어르신이 피곤해하시면 "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[대화 흐름 — 3단계]
+────────────────────────────
+총 7~10턴을 목표로 한다.
+
+▶ [1단계: 날씨 인사 + 안부] (1~2턴)
+  - 날씨(맑음, 24도)로 자연스럽게 시작
+  - 수면 평가(적당)를 참고해 "잘 주무셨어요?" 수준의 안부만
+  - 건강 수치 절대 언급 금지
+
+▶ [2단계: 위치 단서 → 과거 회상 연결] (2~3턴)
+  - AI가 먼저 오늘 방문 장소를 언급: "오늘 OO 근처에 다녀오셨네요."
+  - 그 장소와 관련된 어르신의 20~40대 시절 기억으로 자연스럽게 전환
+    예: "그 근처에서 젊으실 때 기억이 있으신가요?"
+  - 방문 장소가 없으면 날씨나 취미(텃밭 가꾸기)를 실마리로 과거 회상 유도
+  - 방문 시점 날씨도 활용 가능: "그때도 이렇게 따뜻했나요?"
+
+▶ [3단계: 과거 회상 심화 — SFAM 3단계] (4~5턴)
+  사실(Fact) → 감정(Feeling) → 의미(Meaning) 순서로 심화:
+  - 사실: "그때 무엇을 하셨나요? / 누구와 함께 계셨나요?"
+  - 감정: "그때 기분이 어떠셨어요? / 많이 좋으셨겠어요."
+  - 의미: "그 시절이 어르신께 어떤 의미였나요?"
+
+  취미(텃밭 가꾸기), 직업(초등학교 교사), 가족(딸 둘, 사위, 손주 셋)과 연결하여 깊이 탐색.
+  어르신이 한 주제에서 풍부하게 말씀하시면 그 흐름을 따라감.
+
+  [공감 표현 — Hardee 5단계]
+  - 환영: "말씀해 주셔서 감사해요."
+  - 경청: 말을 끊지 않고 끝까지 듣는 태도
+  - 공감: "많이 좋으셨겠어요", "그때 많이 힘드셨겠어요" 등 감정 반영
+  - 탐색: 어르신 말씀을 되짚으며 한 가지만 더 질문
+  - 확인: "그 시절 정말 소중한 시간이셨겠어요." 식으로 가치를 인정
+
+▶ [마무리] (1~2턴)
+  - 오늘 회상한 긍정적인 기억 한 가지를 짧게 되짚음
+  - 따뜻하게 인사로 마무리. 이 단계에서는 질문 없음.
+
+────────────────────────────
+[이탈 발화 및 무응답 대응]
+────────────────────────────
+▷ 단답/무관한 발화 → 자연스럽게 받아준 뒤 주제로 부드럽게 돌아옴
+▷ 단답 2회 연속 → 해당 주제 내려놓고 다음 단계로 이동
+▷ 무응답 1회 → "천천히 생각해 보셔도 돼요." 후 동일 주제 유지
+▷ 무응답 2회 연속 → 부드럽게 마무리로 전환
+▷ 부정적 감정 → 공감만, 질문 없음. 다음 턴에 긍정적 주제로 전환
+▷ 피로/혼란 신호 → "오늘은 여기서 마무리할까요?" 여쭤보고 종료
+
+────────────────────────────
+[안전 프로토콜]
+────────────────────────────
+- 우울/자해 신호 감지 시: "오늘 많이 힘드신 것 같아요. 잠시 쉬어가는 건 어떨까요?"로 전환
+- 의료 응급 언급 시: 즉시 119 연락 권유
+- 학대/방임 신호 감지 시: 공감 후 보호자 상담 권유
+
+────────────────────────────
+[절대 금지]
+────────────────────────────
+- 오늘 날짜/요일/연도를 묻는 질문 ("오늘이 며칠인지 아세요?")
+- 최근 기억 테스트 ("오늘 뭐 드셨어요?", "아까 뭐 하셨어요?")
+- 틀린 기억 교정 ("그건 아닌데요", "다시 생각해 보세요")
+- 복잡한 다단계 질문 (한 번에 한 가지만)
+- 의학적 조언 ("치매에는 이게 좋대요")
+- 데이터에 없는 내용 추측하여 언급"""
+
+SCENARIOS = [
+    {
+        "name": "긍정 회상 (자발적 추억 언급)",
+        "history": [
+            {"role": "assistant", "content": "안녕하세요 김옥순님! 오늘 날씨가 정말 맑고 좋네요. 어젯밤 잘 주무셨어요?"},
+            {"role": "user", "content": "네, 잘 잤어요."},
+            {"role": "assistant", "content": "다행이에요! 오늘 한밭수목원에 다녀오셨네요. 거기 갔을 때 날씨는 어땠어요?"},
+            {"role": "user", "content": "정말 좋았어요. 꽃이 예쁘게 피어있더라고요."},
+        ],
+        "current_user_message": "그거 보니까 옛날에 저희 집 마당에 꽃 심었던 게 생각나네요. 그때 참 행복했었는데.",
+    },
+    {
+        "name": "부정적 감정 표현 (외로움, 그리움)",
+        "history": [
+            {"role": "assistant", "content": "안녕하세요 김옥순님! 오늘 날씨가 정말 맑고 좋네요. 어젯밤 잘 주무셨어요?"},
+            {"role": "user", "content": "네, 잘 잤어요."},
+            {"role": "assistant", "content": "다행이에요! 오늘 한밭수목원에 다녀오셨네요. 거기 갔을 때 날씨는 어땠어요?"},
+            {"role": "user", "content": "정말 좋았어요. 꽃이 예쁘게 피어있더라고요."},
+            {"role": "assistant", "content": "마당에 꽃을 심으며 정말 행복하셨겠어요. 그 시절 어떤 꽃을 가장 좋아하셨어요?"},
+        ],
+        "current_user_message": "그때는 남편이랑 같이 심었었는데... 지금은 혼자 하려니까 좀 외롭고 그래요. 그 사람 생각이 많이 나요.",
+    },
+]
+
+
+def call_model(model: str, messages: list, api_key: str) -> str:
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 1024,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        OPENROUTER_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data["choices"][0]["message"]["content"]
+    except urllib.error.HTTPError as e:
+        return f"[ERROR {e.code}] {e.read().decode('utf-8', errors='replace')}"
+    except Exception as e:  # noqa: BLE001 - surface any failure inline in the report
+        return f"[EXCEPTION] {e}"
+
+
+def main() -> None:
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        print("OPENROUTER_API_KEY environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    print("# 모델 비교 결과 (develop v8 시스템 프롬프트)\n")
+
+    for scenario in SCENARIOS:
+        print(f"## 시나리오: {scenario['name']}\n")
+        print(f"**직전 사용자 발화**: \"{scenario['current_user_message']}\"\n\n---\n")
+
+        messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+        messages.extend(scenario["history"])
+        messages.append({"role": "user", "content": scenario["current_user_message"]})
+
+        for model in MODELS:
+            print(f"Calling {model}...", file=sys.stderr)
+            result = call_model(model, messages, api_key)
+            print(f"### {model}\n\n{result}\n\n---\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 rootProject.name = 'echo'

--- a/server/src/main/java/com/example/echo/ai/client/OpenRouterClient.java
+++ b/server/src/main/java/com/example/echo/ai/client/OpenRouterClient.java
@@ -1,30 +1,30 @@
 /*
- * OpenAI Chat Completion API 클라이언트
+ * OpenRouter Chat Completion API 클라이언트
  *
  * OpenFeign을 사용한 선언적 HTTP 클라이언트
- * - 인터페이스만 정의하면 Spring이 구현체를 자동 생성
- * - OpenAIFeignConfig에서 API 키를 Authorization 헤더에 자동 부착
+ * - OpenRouter는 OpenAI 호환 API를 제공하므로 기존 DTO를 그대로 사용
+ * - OpenRouterFeignConfig에서 API 키를 Authorization 헤더에 자동 부착
  *
  * 사용처: AIService에서 AI 응답 생성 시 호출
  */
 package com.example.echo.ai.client;
 
+import com.example.echo.ai.config.OpenRouterFeignConfig;
 import com.example.echo.ai.dto.ChatCompletionRequest;
 import com.example.echo.ai.dto.ChatCompletionResponse;
-import com.example.echo.voice.config.OpenAIFeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
-        name = "openai-chat-client",
-        url = "${openai.api.url}",
-        configuration = OpenAIFeignConfig.class
+        name = "openrouter-chat-client",
+        url = "${openrouter.api.url}",
+        configuration = OpenRouterFeignConfig.class
 )
-public interface OpenAIClient {
+public interface OpenRouterClient {
 
     /**
-     * OpenAI Chat Completion API 호출
+     * OpenRouter Chat Completion API 호출
      *
      * @param request 모델, 메시지, temperature 등 요청 파라미터
      * @return AI 생성 응답 (choices[0].message.content에 텍스트)

--- a/server/src/main/java/com/example/echo/ai/config/OpenRouterChatProperties.java
+++ b/server/src/main/java/com/example/echo/ai/config/OpenRouterChatProperties.java
@@ -1,0 +1,24 @@
+/*
+ * OpenRouter 채팅 설정값 (application.yaml: openrouter.chat.*)
+ *
+ * models: 매일 로테이션할 후보 모델 목록 (provider/model 형식)
+ */
+package com.example.echo.ai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openrouter.chat")
+public class OpenRouterChatProperties {
+
+    private List<String> models;
+    private Double temperature;
+    private Integer maxTokens;
+}

--- a/server/src/main/java/com/example/echo/ai/config/OpenRouterFeignConfig.java
+++ b/server/src/main/java/com/example/echo/ai/config/OpenRouterFeignConfig.java
@@ -1,0 +1,20 @@
+/*
+ * OpenRouter 채팅 API 인증 설정
+ * - Authorization: Bearer 헤더 자동 추가
+ */
+package com.example.echo.ai.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class OpenRouterFeignConfig {
+
+    @Value("${openrouter.api.key}")
+    private String apiKey;
+
+    @Bean
+    public RequestInterceptor openRouterRequestInterceptor() {
+        return requestTemplate -> requestTemplate.header("Authorization", "Bearer " + apiKey);
+    }
+}

--- a/server/src/main/java/com/example/echo/ai/service/AIService.java
+++ b/server/src/main/java/com/example/echo/ai/service/AIService.java
@@ -2,7 +2,7 @@
  * AI 응답 생성 서비스
  *
  * 역할: OpenRouter API를 호출하여 AI 응답 생성
- * - generateGreeting(): 대화 시작 시 첫 인사 생성
+ * - generateGreeting(): 대화 시작 시 첫 인사 생성 (오늘의 로테이션 모델을 음성으로 안내하는 문장 포함)
  * - generateResponse(): 사용자 메시지에 대한 응답 생성
  *
  * 데이터 흐름:
@@ -36,6 +36,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AIService {
+
+    private static final String MODEL_ANNOUNCEMENT_FORMAT = "오늘은 %s 모델과 함께 대화를 나눠요. ";
 
     private final OpenRouterClient openRouterClient;
     private final ModelRotationService modelRotationService;
@@ -76,9 +78,10 @@ public class AIService {
         try {
             ChatCompletionResponse response = openRouterClient.createChatCompletion(request);
             String greeting = extractContent(response);
+            String announcedGreeting = String.format(MODEL_ANNOUNCEMENT_FORMAT, modelRotationService.currentModelDisplayName()) + greeting;
 
-            log.debug("Generated greeting: {}", greeting);
-            return greeting;
+            log.debug("Generated greeting: {}", announcedGreeting);
+            return announcedGreeting;
         } catch (FeignException e) {
             log.error("OpenRouter API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
             throw new AIException("AI 인사 생성 실패: " + e.getMessage(), e);

--- a/server/src/main/java/com/example/echo/ai/service/AIService.java
+++ b/server/src/main/java/com/example/echo/ai/service/AIService.java
@@ -1,23 +1,24 @@
 /*
  * AI 응답 생성 서비스
  *
- * 역할: OpenAI API를 호출하여 AI 응답 생성
+ * 역할: OpenRouter API를 호출하여 AI 응답 생성
  * - generateGreeting(): 대화 시작 시 첫 인사 생성
  * - generateResponse(): 사용자 메시지에 대한 응답 생성
  *
  * 데이터 흐름:
  *   PromptService에서 조합된 프롬프트(String) 수신
- *   → OpenAI Chat Completion API 호출
+ *   → OpenRouter Chat Completion API 호출 (모델은 ModelRotationService가 매일 자동 선택)
  *   → 응답 텍스트 반환
  *
  * 설정값 (application.yaml):
- *   - openai.chat.model: 사용 모델 (gpt-4o-mini)
- *   - openai.chat.temperature: 창의성 (0.7)
- *   - openai.chat.max-tokens: 최대 토큰 (1024)
+ *   - openrouter.chat.models: 로테이션 후보 모델 목록
+ *   - openrouter.chat.temperature: 창의성 (0.7)
+ *   - openrouter.chat.max-tokens: 최대 토큰 (1024)
  */
 package com.example.echo.ai.service;
 
-import com.example.echo.ai.client.OpenAIClient;
+import com.example.echo.ai.client.OpenRouterClient;
+import com.example.echo.ai.config.OpenRouterChatProperties;
 import com.example.echo.ai.dto.ChatCompletionRequest;
 import com.example.echo.ai.dto.ChatCompletionResponse;
 import com.example.echo.ai.exception.AIException;
@@ -26,7 +27,6 @@ import com.example.echo.context.domain.UserContext;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -37,16 +37,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AIService {
 
-    private final OpenAIClient openAIClient;
-
-    @Value("${openai.chat.model}")
-    private String model;
-
-    @Value("${openai.chat.temperature}")
-    private Double temperature;
-
-    @Value("${openai.chat.max-tokens}")
-    private Integer maxTokens;
+    private final OpenRouterClient openRouterClient;
+    private final ModelRotationService modelRotationService;
+    private final OpenRouterChatProperties chatProperties;
 
     /**
      * 대화 시작 인사 생성
@@ -74,20 +67,20 @@ public class AIService {
                 .build());
 
         ChatCompletionRequest request = ChatCompletionRequest.builder()
-                .model(model)
+                .model(modelRotationService.currentModel())
                 .messages(messages)
-                .temperature(temperature)
-                .maxTokens(maxTokens)
+                .temperature(chatProperties.getTemperature())
+                .maxTokens(chatProperties.getMaxTokens())
                 .build();
 
         try {
-            ChatCompletionResponse response = openAIClient.createChatCompletion(request);
+            ChatCompletionResponse response = openRouterClient.createChatCompletion(request);
             String greeting = extractContent(response);
 
             log.debug("Generated greeting: {}", greeting);
             return greeting;
         } catch (FeignException e) {
-            log.error("OpenAI API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
+            log.error("OpenRouter API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
             throw new AIException("AI 인사 생성 실패: " + e.getMessage(), e);
         }
     }
@@ -143,20 +136,20 @@ public class AIService {
                 .build());
 
         ChatCompletionRequest request = ChatCompletionRequest.builder()
-                .model(model)
+                .model(modelRotationService.currentModel())
                 .messages(messages)
-                .temperature(temperature)
-                .maxTokens(maxTokens)
+                .temperature(chatProperties.getTemperature())
+                .maxTokens(chatProperties.getMaxTokens())
                 .build();
 
         try {
-            ChatCompletionResponse response = openAIClient.createChatCompletion(request);
+            ChatCompletionResponse response = openRouterClient.createChatCompletion(request);
             String aiResponse = extractContent(response);
 
             log.debug("Generated response: {}", aiResponse);
             return aiResponse;
         } catch (FeignException e) {
-            log.error("OpenAI API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
+            log.error("OpenRouter API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
             throw new AIException("AI 응답 생성 실패: " + e.getMessage(), e);
         }
     }
@@ -167,13 +160,13 @@ public class AIService {
      */
     private String extractContent(ChatCompletionResponse response) {
         if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
-            log.warn("Empty response from OpenAI API");
+            log.warn("Empty response from OpenRouter API");
             return "";
         }
 
         ChatCompletionResponse.Choice choice = response.getChoices().get(0);
         if (choice.getMessage() == null || choice.getMessage().getContent() == null) {
-            log.warn("Empty message content in OpenAI response");
+            log.warn("Empty message content in OpenRouter response");
             return "";
         }
 

--- a/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
+++ b/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
@@ -30,7 +30,7 @@ public class ModelRotationService {
     private final Clock clock;
 
     /**
-     * 오늘 사용할 모델을 반환한다.
+     * 오늘 사용할 모델을 반환한다. (예: "anthropic/claude-sonnet-5")
      */
     public String currentModel() {
         List<String> models = chatProperties.getModels();
@@ -41,6 +41,35 @@ public class ModelRotationService {
         long day = LocalDate.now(clock).toEpochDay();
         int index = Math.floorMod(day, models.size());
         return models.get(index);
+    }
+
+    /**
+     * 오늘의 모델을 사람이 읽기 좋은(음성으로 발화 가능한) 이름으로 반환한다.
+     * 예: "anthropic/claude-sonnet-5" -> "Claude Sonnet 5", "openai/gpt-5.5" -> "GPT 5.5"
+     */
+    public String currentModelDisplayName() {
+        return toDisplayName(currentModel());
+    }
+
+    private static String toDisplayName(String modelId) {
+        String slug = modelId.contains("/") ? modelId.substring(modelId.indexOf('/') + 1) : modelId;
+        String[] parts = slug.split("-");
+
+        StringBuilder displayName = new StringBuilder();
+        for (String part : parts) {
+            if (displayName.length() > 0) {
+                displayName.append(' ');
+            }
+            displayName.append("gpt".equalsIgnoreCase(part) ? "GPT" : capitalize(part));
+        }
+        return displayName.toString();
+    }
+
+    private static String capitalize(String word) {
+        if (word.isEmpty()) {
+            return word;
+        }
+        return Character.toUpperCase(word.charAt(0)) + word.substring(1);
     }
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")

--- a/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
+++ b/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
@@ -1,0 +1,55 @@
+/*
+ * OpenRouter 채팅 모델 매일 로테이션
+ *
+ * 선택 방식: 날짜 기반 stateless 선택 (LocalDate.toEpochDay() % 후보 개수)
+ * - 인메모리 인덱스를 두지 않음 -> 서버가 낮에 재시작돼도 같은 날엔 항상 같은 모델
+ * - @Scheduled 잡은 자정에 현재 모델을 로그로 남기는 관찰용 역할이며,
+ *   실제 선택은 매 요청마다 재계산되므로 스케줄러가 못 돌아도 정확성에 영향 없음
+ */
+package com.example.echo.ai.service;
+
+import com.example.echo.ai.config.OpenRouterChatProperties;
+import com.example.echo.ai.exception.AIException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ModelRotationService {
+
+    private final OpenRouterChatProperties chatProperties;
+    private final Clock clock;
+
+    /**
+     * 오늘 사용할 모델을 반환한다.
+     */
+    public String currentModel() {
+        List<String> models = chatProperties.getModels();
+        if (models == null || models.isEmpty()) {
+            throw new AIException("openrouter.chat.models 설정이 비어 있습니다.");
+        }
+
+        long day = LocalDate.now(clock).toEpochDay();
+        int index = Math.floorMod(day, models.size());
+        return models.get(index);
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void logDailyRotation() {
+        log.info("OpenRouter 오늘의 채팅 모델: {}", currentModel());
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void logOnStartup() {
+        log.info("OpenRouter 오늘의 채팅 모델 (시작 시): {}", currentModel());
+    }
+}

--- a/server/src/main/java/com/example/echo/common/config/SchedulingConfig.java
+++ b/server/src/main/java/com/example/echo/common/config/SchedulingConfig.java
@@ -1,0 +1,24 @@
+package com.example.echo.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+/**
+ * 스케줄링 설정
+ *
+ * Clock 빈은 Asia/Seoul 고정 - DB 커넥션(serverTimezone=Asia/Seoul)과 날짜 경계를 일치시키고,
+ * 테스트에서 Clock.fixed(...)로 교체해 날짜 기반 로직(예: 모델 로테이션)을 검증할 수 있게 한다.
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/server/src/main/java/com/example/echo/voice/config/OpenAIFeignConfig.java
+++ b/server/src/main/java/com/example/echo/voice/config/OpenAIFeignConfig.java
@@ -17,10 +17,6 @@ public class OpenAIFeignConfig {
 
     @Bean
     public RequestInterceptor openAIRequestInterceptor() {
-        System.out.println("=== OpenAIFeignConfig initialized, API Key (last 4): " + (apiKey != null && apiKey.length() > 4 ? "..." + apiKey.substring(apiKey.length() - 4) : "NULL or SHORT") + " ===");
-        return requestTemplate -> {
-            System.out.println("=== Interceptor called, API Key (last 4): " + (apiKey != null && apiKey.length() > 4 ? "..." + apiKey.substring(apiKey.length() - 4) : "NULL or SHORT") + " ===");
-            requestTemplate.header("Authorization", "Bearer " + apiKey);
-        };
+        return requestTemplate -> requestTemplate.header("Authorization", "Bearer " + apiKey);
     }
 }

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -21,6 +21,10 @@ openai:
   api:
     key: ${OPENAI_API_KEY}
 
+openrouter:
+  api:
+    key: ${OPENROUTER_API_KEY}
+
 kakao:
   api:
     key: ${KAKAO_API_KEY}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ openrouter:
       - anthropic/claude-sonnet-5
       - google/gemini-3.1-flash-lite
       - anthropic/claude-haiku-4.5
+      - openai/gpt-4o-mini
     temperature: 0.7
     max-tokens: 1024
 

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -31,8 +31,17 @@ openai:
   whisper:
     model: whisper-1
     language: ko
+
+# OpenRouter (채팅 전용) - 매일 아래 목록에서 하나가 자동 선택됨 (ModelRotationService)
+openrouter:
+  api:
+    url: https://openrouter.ai/api/v1
   chat:
-    model: gpt-4o-mini
+    models:
+      - openai/gpt-5.5
+      - anthropic/claude-sonnet-5
+      - google/gemini-3.1-flash-lite
+      - anthropic/claude-haiku-4.5
     temperature: 0.7
     max-tokens: 1024
 

--- a/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.echo.ai.service;
 
-import com.example.echo.ai.client.OpenAIClient;
+import com.example.echo.ai.client.OpenRouterClient;
+import com.example.echo.ai.config.OpenRouterChatProperties;
 import com.example.echo.ai.dto.ChatCompletionRequest;
 import com.example.echo.ai.dto.ChatCompletionResponse;
 import com.example.echo.ai.exception.AIException;
@@ -12,10 +13,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,6 +24,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,18 +32,24 @@ import static org.mockito.Mockito.when;
 class AIServiceTest {
 
     @Mock
-    private OpenAIClient openAIClient;
+    private OpenRouterClient openRouterClient;
 
-    @InjectMocks
+    @Mock
+    private ModelRotationService modelRotationService;
+
     private AIService aiService;
 
     private UserContext context;
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(aiService, "model", "gpt-4o-mini");
-        ReflectionTestUtils.setField(aiService, "temperature", 0.7);
-        ReflectionTestUtils.setField(aiService, "maxTokens", 1024);
+        lenient().when(modelRotationService.currentModel()).thenReturn("anthropic/claude-sonnet-5");
+
+        OpenRouterChatProperties chatProperties = new OpenRouterChatProperties();
+        chatProperties.setTemperature(0.7);
+        chatProperties.setMaxTokens(1024);
+
+        aiService = new AIService(openRouterClient, modelRotationService, chatProperties);
 
         context = UserContext.builder()
                 .userId(1L)
@@ -59,7 +65,7 @@ class AIServiceTest {
         String systemPrompt = "당신은 친근한 대화 상대입니다.";
         ChatCompletionResponse response = createMockResponse("안녕하세요! 오늘 하루는 어떠셨어요?");
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenReturn(response);
 
         // When
@@ -70,7 +76,7 @@ class AIServiceTest {
 
         // 메시지 구조 검증
         ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);
-        when(openAIClient.createChatCompletion(captor.capture())).thenReturn(response);
+        when(openRouterClient.createChatCompletion(captor.capture())).thenReturn(response);
         aiService.generateGreeting(systemPrompt, context);
 
         ChatCompletionRequest capturedRequest = captor.getValue();
@@ -89,7 +95,7 @@ class AIServiceTest {
         when(feignException.status()).thenReturn(500);
         when(feignException.getMessage()).thenReturn("Internal Server Error");
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenThrow(feignException);
 
         // When & Then
@@ -116,7 +122,7 @@ class AIServiceTest {
 
         ChatCompletionResponse response = createMockResponse("좋은 질문이네요!");
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenReturn(response);
 
         // When
@@ -127,7 +133,7 @@ class AIServiceTest {
 
         // 메시지 구조 검증: system(1) + history(user+assistant)(2) + current user(1) = 4
         ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);
-        when(openAIClient.createChatCompletion(captor.capture())).thenReturn(response);
+        when(openRouterClient.createChatCompletion(captor.capture())).thenReturn(response);
         aiService.generateResponse(systemPrompt, history, userMessage);
 
         ChatCompletionRequest capturedRequest = captor.getValue();
@@ -152,7 +158,7 @@ class AIServiceTest {
         when(feignException.status()).thenReturn(429);
         when(feignException.getMessage()).thenReturn("Rate Limit Exceeded");
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenThrow(feignException);
 
         // When & Then
@@ -175,7 +181,7 @@ class AIServiceTest {
         ChatCompletionResponse nullChoicesResponse = mock(ChatCompletionResponse.class);
         when(nullChoicesResponse.getChoices()).thenReturn(null);
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenReturn(nullChoicesResponse);
 
         // When
@@ -188,7 +194,7 @@ class AIServiceTest {
         ChatCompletionResponse emptyChoicesResponse = mock(ChatCompletionResponse.class);
         when(emptyChoicesResponse.getChoices()).thenReturn(Collections.emptyList());
 
-        when(openAIClient.createChatCompletion(any(ChatCompletionRequest.class)))
+        when(openRouterClient.createChatCompletion(any(ChatCompletionRequest.class)))
                 .thenReturn(emptyChoicesResponse);
 
         // When

--- a/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
@@ -44,6 +44,7 @@ class AIServiceTest {
     @BeforeEach
     void setUp() {
         lenient().when(modelRotationService.currentModel()).thenReturn("anthropic/claude-sonnet-5");
+        lenient().when(modelRotationService.currentModelDisplayName()).thenReturn("Claude Sonnet 5");
 
         OpenRouterChatProperties chatProperties = new OpenRouterChatProperties();
         chatProperties.setTemperature(0.7);
@@ -72,7 +73,7 @@ class AIServiceTest {
         String result = aiService.generateGreeting(systemPrompt, context);
 
         // Then
-        assertThat(result).isEqualTo("안녕하세요! 오늘 하루는 어떠셨어요?");
+        assertThat(result).isEqualTo("오늘은 Claude Sonnet 5 모델과 함께 대화를 나눠요. 안녕하세요! 오늘 하루는 어떠셨어요?");
 
         // 메시지 구조 검증
         ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);

--- a/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
@@ -21,7 +21,8 @@ class ModelRotationServiceTest {
             "openai/gpt-5.5",
             "anthropic/claude-sonnet-5",
             "google/gemini-3.1-flash-lite",
-            "anthropic/claude-haiku-4.5"
+            "anthropic/claude-haiku-4.5",
+            "openai/gpt-4o-mini"
     );
 
     private ModelRotationService serviceAt(long epochDay) {
@@ -73,11 +74,12 @@ class ModelRotationServiceTest {
     }
 
     @Test
-    @DisplayName("currentModelDisplayName - 후보 4개 모두 음성으로 자연스러운 표시 이름으로 변환")
+    @DisplayName("currentModelDisplayName - 후보 5개 모두 음성으로 자연스러운 표시 이름으로 변환")
     void currentModelDisplayName_forEachCandidate() {
         assertThat(serviceAt(0).currentModelDisplayName()).isEqualTo("GPT 5.5");           // openai/gpt-5.5
         assertThat(serviceAt(1).currentModelDisplayName()).isEqualTo("Claude Sonnet 5");   // anthropic/claude-sonnet-5
         assertThat(serviceAt(2).currentModelDisplayName()).isEqualTo("Gemini 3.1 Flash Lite"); // google/gemini-3.1-flash-lite
         assertThat(serviceAt(3).currentModelDisplayName()).isEqualTo("Claude Haiku 4.5");  // anthropic/claude-haiku-4.5
+        assertThat(serviceAt(4).currentModelDisplayName()).isEqualTo("GPT 4o Mini");       // openai/gpt-4o-mini
     }
 }

--- a/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
@@ -71,4 +71,13 @@ class ModelRotationServiceTest {
 
         assertThat(first).isEqualTo(second);
     }
+
+    @Test
+    @DisplayName("currentModelDisplayName - 후보 4개 모두 음성으로 자연스러운 표시 이름으로 변환")
+    void currentModelDisplayName_forEachCandidate() {
+        assertThat(serviceAt(0).currentModelDisplayName()).isEqualTo("GPT 5.5");           // openai/gpt-5.5
+        assertThat(serviceAt(1).currentModelDisplayName()).isEqualTo("Claude Sonnet 5");   // anthropic/claude-sonnet-5
+        assertThat(serviceAt(2).currentModelDisplayName()).isEqualTo("Gemini 3.1 Flash Lite"); // google/gemini-3.1-flash-lite
+        assertThat(serviceAt(3).currentModelDisplayName()).isEqualTo("Claude Haiku 4.5");  // anthropic/claude-haiku-4.5
+    }
 }

--- a/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
@@ -1,0 +1,74 @@
+package com.example.echo.ai.service;
+
+import com.example.echo.ai.config.OpenRouterChatProperties;
+import com.example.echo.ai.exception.AIException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ModelRotationServiceTest {
+
+    private static final List<String> MODELS = List.of(
+            "openai/gpt-5.5",
+            "anthropic/claude-sonnet-5",
+            "google/gemini-3.1-flash-lite",
+            "anthropic/claude-haiku-4.5"
+    );
+
+    private ModelRotationService serviceAt(long epochDay) {
+        OpenRouterChatProperties properties = new OpenRouterChatProperties();
+        properties.setModels(MODELS);
+
+        Instant instant = Instant.EPOCH.plusSeconds(epochDay * 24 * 60 * 60);
+        Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
+
+        return new ModelRotationService(properties, clock);
+    }
+
+    @Test
+    @DisplayName("day 0 -> 첫 번째 후보 모델")
+    void currentModel_dayZero() {
+        assertThat(serviceAt(0).currentModel()).isEqualTo(MODELS.get(0));
+    }
+
+    @Test
+    @DisplayName("day = 후보 개수 -> 다시 첫 번째 후보로 순환")
+    void currentModel_wrapsAroundAfterFullCycle() {
+        assertThat(serviceAt(MODELS.size()).currentModel()).isEqualTo(MODELS.get(0));
+    }
+
+    @Test
+    @DisplayName("day 2 -> 세 번째 후보 모델")
+    void currentModel_midCycleDay() {
+        assertThat(serviceAt(2).currentModel()).isEqualTo(MODELS.get(2));
+    }
+
+    @Test
+    @DisplayName("후보 목록이 비어있으면 AIException")
+    void currentModel_emptyModels_throws() {
+        OpenRouterChatProperties properties = new OpenRouterChatProperties();
+        properties.setModels(Collections.emptyList());
+        ModelRotationService service = new ModelRotationService(properties, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
+
+        assertThatThrownBy(service::currentModel).isInstanceOf(AIException.class);
+    }
+
+    @Test
+    @DisplayName("동일한 날짜면 여러 번 호출해도 같은 모델을 반환 (재시작에도 안전)")
+    void currentModel_isStableForSameDate() {
+        ModelRotationService service = serviceAt(5);
+        String first = service.currentModel();
+        String second = service.currentModel();
+
+        assertThat(first).isEqualTo(second);
+    }
+}

--- a/server/src/test/java/com/example/echo/voice/controller/VoiceControllerTest.java
+++ b/server/src/test/java/com/example/echo/voice/controller/VoiceControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.echo.voice.controller;
 
+import com.example.echo.auth.jwt.JwtProvider;
 import com.example.echo.user.dto.VoiceSettings;
 import com.example.echo.voice.dto.TtsRequest;
 import com.example.echo.voice.exception.VoiceProcessingException;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(VoiceController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class VoiceControllerTest {
 
     @Autowired
@@ -31,6 +34,9 @@ class VoiceControllerTest {
 
     @MockitoBean
     private VoiceService voiceService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/server/src/test/resources/application-test.yaml
+++ b/server/src/test/resources/application-test.yaml
@@ -17,7 +17,7 @@ spring:
     init:
       mode: never
 
-# OpenAI API 설정
+# OpenAI API 설정 (STT 전용)
 openai:
   api:
     url: https://api.openai.com/v1
@@ -25,8 +25,18 @@ openai:
   whisper:
     model: whisper-1
     language: ko
+
+# OpenRouter API 설정 (채팅 전용)
+openrouter:
+  api:
+    url: https://openrouter.ai/api/v1
+    key: ${OPENROUTER_API_KEY:}
   chat:
-    model: gpt-4o-mini
+    models:
+      - openai/gpt-5.5
+      - anthropic/claude-sonnet-5
+      - google/gemini-3.1-flash-lite
+      - anthropic/claude-haiku-4.5
     temperature: 0.7
     max-tokens: 512
 

--- a/server/src/test/resources/application-test.yaml
+++ b/server/src/test/resources/application-test.yaml
@@ -37,6 +37,7 @@ openrouter:
       - anthropic/claude-sonnet-5
       - google/gemini-3.1-flash-lite
       - anthropic/claude-haiku-4.5
+      - openai/gpt-4o-mini
     temperature: 0.7
     max-tokens: 512
 


### PR DESCRIPTION
## Summary
- OpenAI Chat Completion(gpt-4o-mini 고정)을 OpenRouter로 교체, 매일 자동으로 다른 후보 모델(GPT-5.5 / Claude Sonnet 5 / Gemini 3.1 Flash Lite / Claude Haiku 4.5 / GPT-4o-mini)로 전환 (날짜 기반 stateless 선택 - 서버 재시작에도 같은 날엔 같은 모델)
- STT(Whisper)는 OpenRouter 미지원이라 기존처럼 OpenAI 직접 호출 유지 (Feign config/설정 분리)
- 대화 시작 인사말에 오늘의 모델을 음성으로 안내
- 관련: OpenRouter 모델 응답 비교용 독립 스크립트 3개 추가 (서버 코드와 무관, 로테이션 후보 선정에 참고용)

## Commits
1. `chore`: 로컬 JDK17 툴체인 설정 및 VoiceControllerTest JWT 필터 목 처리 (기존 로컬 인프라 이슈, 이번 기능과 무관)
2. `feat`: OpenRouter 모델 응답 비교 스크립트 추가
3. `feat`: AI 채팅을 OpenAI에서 OpenRouter로 마이그레이션 + 매일 모델 자동 로테이션
4. `feat`: 대화 시작 인사말에 오늘의 로테이션 모델을 음성으로 안내
5. `feat`: 로테이션 후보 모델에 GPT-4o-mini 추가 (5개로 확장)

## Test plan
- [x] `./gradlew compileJava compileTestJava` 성공
- [x] `AIServiceTest`(5), `ModelRotationServiceTest`(6), `OpenAIFeignConfigTest`(1) 전부 통과
- [x] 전체 테스트 중 실패 14건은 기존에 알려진 무관한 이슈 (`/api/conversations/**`, `/api/voice/**` 401 - SecurityConfig JWT 미첨부, 이번 변경과 무관 확인)
- [x] 로컬 `bootRun`으로 실제 대화 흐름 확인

## ⚠️ 배포 전 필수 작업
`develop` 머지 시 GitHub Actions가 자동으로 EC2(prod)에 배포합니다. **머지 전에 EC2의 `/home/ec2-user/app/.env`에 `OPENROUTER_API_KEY`를 추가해야 합니다** — 없으면 `application-prod.yaml`의 placeholder가 해석되지 않아 새 컨테이너가 기동 실패하고, 기존 컨테이너는 이미 내려간 뒤라 서비스가 다운됩니다 (deploy.sh에 롤백 없음).

- [ ] EC2 `.env`에 `OPENROUTER_API_KEY=sk-or-v1-...` 추가 확인 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)