### PR TITLE
fix: 온보딩 완료 직후 크래시(AEADBadTagException) 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/local/DatabasePassphrase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/DatabasePassphrase.kt
@@ -27,23 +27,45 @@ object DatabasePassphrase {
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
 
-    /** 저장된 비밀번호를 바이트로 반환. 없으면 새로 생성해 저장 후 반환. */
+    /**
+     * 저장된 비밀번호를 바이트로 반환. 없으면 새로 생성해 저장 후 반환.
+     *
+     * 백업/복원 등으로 암호화된 값만 남고 Keystore 키가 유실되면 복호화 시
+     * AEADBadTagException이 발생한다 (Keystore 키는 백업에 포함되지 않아 발생 가능).
+     * 이 경우 손상된 저장소를 초기화하고 새 비밀번호를 발급한다.
+     * (기존 SQLCipher DB는 새 비밀번호로 열 수 없지만, isDbEncrypted()도 함께
+     *  초기화되어 false를 반환하므로 AppDatabase.buildDatabase()가 자동으로 삭제 후 재생성한다.)
+     */
     fun getOrCreate(context: Context): ByteArray {
-        val p = prefs(context)
-        val existing = p.getString(KEY_PASSPHRASE, null)
+        val existing = try {
+            prefs(context).getString(KEY_PASSPHRASE, null)
+        } catch (e: Exception) {
+            deleteCorruptedPrefs(context)
+            null
+        }
         if (existing != null) return existing.toByteArray(Charsets.UTF_8)
 
         val random = ByteArray(32)
         SecureRandom().nextBytes(random)
         val passphrase = Base64.encodeToString(random, Base64.NO_WRAP)
-        p.edit().putString(KEY_PASSPHRASE, passphrase).apply()
+        prefs(context).edit().putString(KEY_PASSPHRASE, passphrase).apply()
         return passphrase.toByteArray(Charsets.UTF_8)
     }
 
-    fun isDbEncrypted(context: Context): Boolean =
+    fun isDbEncrypted(context: Context): Boolean = try {
         prefs(context).getBoolean(KEY_DB_ENCRYPTED, false)
+    } catch (e: Exception) {
+        deleteCorruptedPrefs(context)
+        false
+    }
 
     fun markDbEncrypted(context: Context) {
         prefs(context).edit().putBoolean(KEY_DB_ENCRYPTED, true).apply()
+    }
+
+    private fun deleteCorruptedPrefs(context: Context) {
+        try {
+            java.io.File(context.filesDir.parent + "/shared_prefs/$PREF_NAME.xml").delete()
+        } catch (e: Exception) { /* ignore */ }
     }
 }

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,8 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Keystore로 암호화된 파일은 백업/복원 후 키 불일치로 크래시를 유발하므로 제외 (Android 30 이하) -->
+    <exclude domain="sharedpref" path="secure_auth_prefs.xml"/>
+    <exclude domain="sharedpref" path="secure_db_prefs.xml"/>
+    <exclude domain="database" path="echo_database"/>
 </full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -4,16 +4,17 @@
    for details.
 -->
 <data-extraction-rules>
+    <!-- Keystore로 암호화된 파일은 백업해도 복호화 키(하드웨어 바인딩)가 함께 복원되지 않아,
+         복원 후 예전 암호문 + 새 키 불일치로 AEADBadTagException이 발생해 앱이 크래시한다.
+         암호화 저장소와 그 저장소로 잠기는 DB는 백업/기기 이전 대상에서 제외. -->
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="secure_auth_prefs.xml"/>
+        <exclude domain="sharedpref" path="secure_db_prefs.xml"/>
+        <exclude domain="database" path="echo_database"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="secure_auth_prefs.xml"/>
+        <exclude domain="sharedpref" path="secure_db_prefs.xml"/>
+        <exclude domain="database" path="echo_database"/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## 문제
삼성 Android 16 실기기에서 초기 설정(온보딩) 완료 직후 앱이 종료됨.

## 원인
`DatabasePassphrase.getOrCreate()`가 Android Keystore 복호화 실패를 처리하지 않아
`AEADBadTagException`이 그대로 앱을 크래시시킴.

`android:allowBackup=true` + 빈 백업 규칙으로 인해: 암호화된 SharedPreferences
파일(`secure_db_prefs.xml` 등)은 자동 백업되지만, 그 파일을 복호화하는
Android Keystore 키는 하드웨어 바인딩이라 백업되지 않음. 앱 삭제 후 재설치 시
"예전 암호문 + 새로 생성된 키" 조합이 되어 복호화가 실패함.

## 수정
- `DatabasePassphrase`: 이미 같은 패턴을 쓰던 `TokenStorage`처럼, 복호화 실패 시
  손상된 저장소 파일을 삭제하고 새 비밀번호를 발급 (크래시 대신 자동 복구).
  `isDbEncrypted()`도 함께 초기화되어 `AppDatabase.buildDatabase()`가 기존
  SQLCipher DB를 자동으로 삭제 후 재생성함.
- `data_extraction_rules.xml` / `backup_rules.xml`: 암호화 저장소와 SQLCipher DB를
  백업/기기 이전 대상에서 제외해 근본 원인(키-암호문 불일치) 자체를 차단.

## 실기기 재현/확인
- 삼성 Android 16 기기에서 실제 크래시 스택트레이스 확보 (`AEADBadTagException` →
  `AndroidKeystoreAesGcm.decrypt` → `KeysetHandle.decrypt`) 후 원인 확정.
- `assembleProdDebug` 컴파일 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)