### PR TITLE
fix: 대화 알람 활성화 플래그(alarm_enabled) 제거

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmReceiver.kt
@@ -43,13 +43,10 @@ class ConversationAlarmReceiver : BroadcastReceiver() {
         showNotification(context, hasLocationPermission)
 
         // 다음날 알람 재스케줄링
-        val storage = ConversationAlarmStorage(context)
-        if (storage.isAlarmEnabled()) {
-            val time = storage.getConversationTime()
-            if (time != null) {
-                ConversationAlarmScheduler.scheduleAlarm(context, time)
-                Log.d(TAG, "다음날 대화 알람 재스케줄링 완료: $time")
-            }
+        val time = ConversationAlarmStorage(context).getConversationTime()
+        if (time != null) {
+            ConversationAlarmScheduler.scheduleAlarm(context, time)
+            Log.d(TAG, "다음날 대화 알람 재스케줄링 완료: $time")
         }
     }
 

--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmScheduler.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmScheduler.kt
@@ -129,14 +129,7 @@ object ConversationAlarmScheduler {
      * 같은 requestCode의 PendingIntent를 덮어쓰므로 중복 호출해도 알람은 하나만 유지됨
      */
     fun rescheduleFromStorage(context: Context) {
-        val storage = ConversationAlarmStorage(context)
-
-        if (!storage.isAlarmEnabled()) {
-            Log.d(TAG, "알람 비활성화 상태 - 재스케줄링 건너뜀")
-            return
-        }
-
-        val time = storage.getConversationTime()
+        val time = ConversationAlarmStorage(context).getConversationTime()
         if (time == null) {
             Log.d(TAG, "저장된 대화 시간 없음 - 재스케줄링 건너뜀")
             return

--- a/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/alarm/ConversationAlarmStorage.kt
@@ -7,7 +7,6 @@ import android.content.SharedPreferences
  * 대화 알람 설정을 SharedPreferences에 저장
  *
  * - 대화 시간 (HH:mm 형식)
- * - 알람 활성화 상태
  */
 class ConversationAlarmStorage(context: Context) {
 
@@ -35,19 +34,6 @@ class ConversationAlarmStorage(context: Context) {
     fun getConversationTime(): String? = prefs.getString(KEY_CONVERSATION_TIME, null)
 
     /**
-     * 알람 활성화 상태 저장
-     */
-    fun setAlarmEnabled(enabled: Boolean) {
-        prefs.edit().putBoolean(KEY_ALARM_ENABLED, enabled).apply()
-    }
-
-    /**
-     * 알람 활성화 상태 조회
-     * @return 기본값 false
-     */
-    fun isAlarmEnabled(): Boolean = prefs.getBoolean(KEY_ALARM_ENABLED, false)
-
-    /**
      * 모든 설정 초기화
      */
     fun clear() {
@@ -57,6 +43,5 @@ class ConversationAlarmStorage(context: Context) {
     companion object {
         private const val PREF_NAME = "conversation_alarm_prefs"
         private const val KEY_CONVERSATION_TIME = "conversation_time"
-        private const val KEY_ALARM_ENABLED = "alarm_enabled"
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingScreen.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -158,7 +156,6 @@ fun OnboardingScreen(
                 onVoiceSpeedChange = viewModel::updateVoiceSpeed,
                 onVoiceToneChange = viewModel::updateVoiceTone,
                 onConversationTimeChange = viewModel::updateConversationTime,
-                onAlarmEnabledChange = viewModel::updateAlarmEnabled,
                 onSleepHoursChange = viewModel::updatePreferredSleepHours
             )
 
@@ -267,7 +264,6 @@ private fun StepContent(
     onVoiceSpeedChange: (Double) -> Unit,
     onVoiceToneChange: (String) -> Unit,
     onConversationTimeChange: (String) -> Unit,
-    onAlarmEnabledChange: (Boolean) -> Unit,
     onSleepHoursChange: (String) -> Unit
 ) {
     when (step) {
@@ -280,9 +276,7 @@ private fun StepContent(
         )
         2 -> TimePickerStep(
             selected = uiState.conversationTime,
-            onTimeSelected = onConversationTimeChange,
-            alarmEnabled = uiState.alarmEnabled,
-            onAlarmEnabledChange = onAlarmEnabledChange
+            onTimeSelected = onConversationTimeChange
         )
         3 -> EchoOutlinedTextField(
             value = uiState.guardianEmail,
@@ -335,54 +329,15 @@ private fun DatePickerStep(selected: String, onDateSelected: (String) -> Unit) {
 @Composable
 private fun TimePickerStep(
     selected: String,
-    onTimeSelected: (String) -> Unit,
-    alarmEnabled: Boolean,
-    onAlarmEnabledChange: (Boolean) -> Unit
+    onTimeSelected: (String) -> Unit
 ) {
-    val colors = LocalEchoColors.current
     val initial = if (selected.isNotEmpty()) selected else "21:00"
     LaunchedEffect(Unit) {
         if (selected.isEmpty()) onTimeSelected("21:00")
     }
 
     Column {
-        // 시간 설정 (핵심)
         EchoTimePickerContent(value = initial, onValueChange = onTimeSelected)
-
-        Spacer(Modifier.height(32.dp))
-
-        // 알람 토글 (부가)
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Column {
-                Text(
-                    text = "매일 알림 받기",
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Medium,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.textPrimary
-                )
-                Text(
-                    text = if (alarmEnabled) "설정한 시간에 알림을 보내드려요" else "알림을 받지 않습니다",
-                    fontSize = 14.sp,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.textSecondary
-                )
-            }
-            Switch(
-                checked = alarmEnabled,
-                onCheckedChange = onAlarmEnabledChange,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = Color.White,
-                    checkedTrackColor = colors.accentGreen,
-                    uncheckedThumbColor = Color.White,
-                    uncheckedTrackColor = colors.bgMuted
-                )
-            )
-        }
     }
 }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/onboarding/OnboardingViewModel.kt
@@ -35,7 +35,6 @@ data class OnboardingUiState(
     val voiceSpeed: Double = 1.0,
     val voiceTone: String = "warm",
     val conversationTime: String = "",
-    val alarmEnabled: Boolean = true,
     val preferredSleepHours: String = "",
     val fieldError: String? = null,
     val isLoading: Boolean = false,
@@ -63,7 +62,6 @@ class OnboardingViewModel(
     fun updateVoiceSpeed(value: Double) = _uiState.update { it.copy(voiceSpeed = value) }
     fun updateVoiceTone(value: String) = _uiState.update { it.copy(voiceTone = value) }
     fun updateConversationTime(value: String) = _uiState.update { it.copy(conversationTime = value, fieldError = null) }
-    fun updateAlarmEnabled(value: Boolean) = _uiState.update { it.copy(alarmEnabled = value) }
     fun updatePreferredSleepHours(value: String) = _uiState.update { it.copy(preferredSleepHours = value, fieldError = null) }
 
     fun next() {
@@ -131,9 +129,8 @@ class OnboardingViewModel(
                     // 알람 설정 로컬 저장 및 스케줄링
                     val time = state.conversationTime.ifBlank { null }
                     alarmStorage.saveConversationTime(time)
-                    alarmStorage.setAlarmEnabled(state.alarmEnabled)
 
-                    if (state.alarmEnabled && time != null) {
+                    if (time != null) {
                         ConversationAlarmScheduler.scheduleAlarm(getApplication(), time)
                     }
 
@@ -145,8 +142,7 @@ class OnboardingViewModel(
                         is ApiResult.Success -> if (statusResult.data.completed) {
                             val time = state.conversationTime.ifBlank { null }
                             alarmStorage.saveConversationTime(time)
-                            alarmStorage.setAlarmEnabled(state.alarmEnabled)
-                            if (state.alarmEnabled && time != null) {
+                            if (time != null) {
                                 ConversationAlarmScheduler.scheduleAlarm(getApplication(), time)
                             }
                             _uiState.update { it.copy(isLoading = false, isCompleted = true) }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -52,8 +52,6 @@ data class SettingsUiState(
     val voiceTone: String = "warm",
     val conversationTime: String? = null,
     val preferredSleepHours: Int? = null,
-    // 알림 설정
-    val alarmEnabled: Boolean = false,
     // 위치 수집 설정
     val locationCollectionStartTime: String = "06:00",
     val isLocationCollectionRunning: Boolean = false,
@@ -246,9 +244,6 @@ class SettingsViewModel(
     private fun loadSettings() {
         val context = getApplication<Application>()
 
-        // 로컬 알람 설정 로드
-        val alarmEnabled = alarmStorage.isAlarmEnabled()
-
         // 위치 수집 시간 로드
         val locationStartTime = locationStorage.getStartTime()
 
@@ -261,7 +256,6 @@ class SettingsViewModel(
 
         _uiState.update {
             it.copy(
-                alarmEnabled = alarmEnabled,
                 locationCollectionStartTime = locationStartTime,
                 isLocationCollectionRunning = LocationCollectionService.isRunning,
                 hasLocationPermission = hasLocation,
@@ -299,7 +293,7 @@ class SettingsViewModel(
      */
     private fun syncAlarmWithServerTime(serverTime: String?) {
         alarmStorage.saveConversationTime(serverTime)
-        updateAlarmSchedule(serverTime)  // 비활성화 상태거나 time=null이면 내부에서 cancelAlarm
+        updateAlarmSchedule(serverTime)  // time=null이면 내부에서 cancelAlarm
     }
 
     /**
@@ -471,46 +465,6 @@ class SettingsViewModel(
         }
     }
 
-    fun setAlarmEnabled(enabled: Boolean) {
-        val time = _uiState.value.conversationTime
-
-        // 시간이 설정되지 않은 상태에서 켜는 경우: 기본 시간(21:00)을 서버에 먼저 저장
-        // 서버 저장이 실패하면 아무것도 켜지 않고 안내 (서버-로컬-UI 불일치로 인한 유령 알람 방지)
-        if (enabled && time.isNullOrBlank()) {
-            viewModelScope.launch {
-                when (userRepository.updateConversationTime(DEFAULT_CONVERSATION_TIME)) {
-                    is ApiResult.Success -> {
-                        alarmStorage.setAlarmEnabled(true)
-                        alarmStorage.saveConversationTime(DEFAULT_CONVERSATION_TIME)
-                        _uiState.update {
-                            it.copy(
-                                alarmEnabled = true,
-                                conversationTime = DEFAULT_CONVERSATION_TIME,
-                                savedMessage = "알림이 설정되었습니다"
-                            )
-                        }
-                        updateAlarmSchedule(DEFAULT_CONVERSATION_TIME)
-                    }
-                    is ApiResult.Error -> _uiState.update {
-                        it.copy(
-                            alarmEnabled = false,
-                            errorMessage = "알림을 설정하지 못했습니다. 잠시 후 다시 시도해주세요."
-                        )
-                    }
-                }
-            }
-            return
-        }
-
-        // 시간이 이미 있는 켜기/끄기: 서버 변경 불필요, 로컬만 갱신
-        alarmStorage.setAlarmEnabled(enabled)
-        _uiState.update { it.copy(alarmEnabled = enabled) }
-        updateAlarmSchedule(time)
-
-        val message = if (enabled) "알림이 설정되었습니다" else "알림이 해제되었습니다"
-        _uiState.update { it.copy(savedMessage = message) }
-    }
-
     /**
      * 위치 수집 상태 확인 및 자동 조정
      * - 현재 시간이 수집 범위(시작 시간 ~ 대화 시간) 밖이면 서비스 자동 중지
@@ -593,8 +547,6 @@ class SettingsViewModel(
     }
 
     companion object {
-        private const val DEFAULT_CONVERSATION_TIME = "21:00"
-
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
@@ -606,9 +558,8 @@ class SettingsViewModel(
 
     private fun updateAlarmSchedule(time: String?) {
         val context = getApplication<Application>()
-        val enabled = _uiState.value.alarmEnabled
 
-        if (enabled && !time.isNullOrBlank()) {
+        if (!time.isNullOrBlank()) {
             ConversationAlarmScheduler.scheduleAlarm(context, time)
         } else {
             ConversationAlarmScheduler.cancelAlarm(context)

--- a/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmSchedulerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/alarm/ConversationAlarmSchedulerTest.kt
@@ -4,7 +4,6 @@ import android.app.AlarmManager
 import android.app.Application
 import android.content.Context
 import android.os.Build
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -35,7 +34,6 @@ class ConversationAlarmSchedulerTest {
         // Given: 알람 설정 저장 + 알람 예약 (로그인 상태 재현)
         val storage = ConversationAlarmStorage(context)
         storage.saveConversationTime("21:00")
-        storage.setAlarmEnabled(true)
         ConversationAlarmScheduler.scheduleAlarm(context, "21:00")
         assertTrue("알람이 예약되어야 함", shadowAlarmManager.scheduledAlarms.isNotEmpty())
 
@@ -45,6 +43,5 @@ class ConversationAlarmSchedulerTest {
         // Then: 알람 취소 + 저장소 클리어 (로그아웃한 사용자에게 알람이 울리지 않아야 함)
         assertTrue("알람이 취소되어야 함", shadowAlarmManager.scheduledAlarms.isEmpty())
         assertNull("대화 시간이 삭제되어야 함", ConversationAlarmStorage(context).getConversationTime())
-        assertFalse("알람 활성화 플래그가 초기화되어야 함", ConversationAlarmStorage(context).isAlarmEnabled())
     }
 }

--- a/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
@@ -9,7 +9,6 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowPowerManager
 import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
-import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationCollectionStorage
@@ -172,7 +171,6 @@ class SettingsViewModelTest {
         // Given: 로컬에는 20:00으로 저장 + 알람 활성화, 서버는 21:30 반환 (다른 기기에서 변경한 상황)
         val alarmStorage = ConversationAlarmStorage(context)
         alarmStorage.saveConversationTime("20:00")
-        alarmStorage.setAlarmEnabled(true)
         coEvery { mockUserRepository.getPreferences() } returns
             ApiResult.Success(UserPreferences(conversationTime = "21:30"))
 
@@ -190,7 +188,6 @@ class SettingsViewModelTest {
         // Given: 로컬과 서버 모두 21:30 (강제 종료 등으로 AlarmManager 등록만 사라진 상황 가정)
         val alarmStorage = ConversationAlarmStorage(context)
         alarmStorage.saveConversationTime("21:30")
-        alarmStorage.setAlarmEnabled(true)
         coEvery { mockUserRepository.getPreferences() } returns
             ApiResult.Success(UserPreferences(conversationTime = "21:30"))
 
@@ -200,48 +197,6 @@ class SettingsViewModelTest {
 
         // Then: 시간이 같아도 설정 화면 진입만으로 끊긴 알람이 복구되어야 함
         verify { ConversationAlarmScheduler.scheduleAlarm(any(), "21:30") }
-    }
-
-    // ===== 알람 켜기 기본시간 서버 저장 =====
-
-    @Test
-    fun `알람켜기_기본시간_서버저장_실패시_롤백하고_오류를_표시한다`() = runTest {
-        // Given: 대화 시간 미설정 + 서버 저장 실패 (오프라인 등)
-        coEvery { mockUserRepository.updateConversationTime(any()) } returns
-            ApiResult.Error(ApiException.NetworkError())
-
-        val viewModel = SettingsViewModel(context, mockUserRepository)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // When: 알람 토글 ON
-        viewModel.setAlarmEnabled(true)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Then: 아무것도 켜지지 않고 오류 안내 (서버-로컬-UI 불일치로 인한 유령 알람 방지)
-        assertFalse(viewModel.uiState.value.alarmEnabled)
-        assertFalse(ConversationAlarmStorage(context).isAlarmEnabled())
-        assertTrue(viewModel.uiState.value.errorMessage != null)
-        verify(exactly = 0) { ConversationAlarmScheduler.scheduleAlarm(any(), any()) }
-    }
-
-    @Test
-    fun `알람켜기_기본시간_서버저장_성공시_로컬저장_및_알람예약한다`() = runTest {
-        // Given: 대화 시간 미설정 + 서버 저장 성공
-        coEvery { mockUserRepository.updateConversationTime(any()) } returns
-            ApiResult.Success(UserPreferences(conversationTime = "21:00"))
-
-        val viewModel = SettingsViewModel(context, mockUserRepository)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // When: 알람 토글 ON
-        viewModel.setAlarmEnabled(true)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        // Then: 기본 시간(21:00)으로 로컬 저장 + 알람 예약
-        assertTrue(viewModel.uiState.value.alarmEnabled)
-        assertEquals("21:00", ConversationAlarmStorage(context).getConversationTime())
-        assertTrue(ConversationAlarmStorage(context).isAlarmEnabled())
-        verify { ConversationAlarmScheduler.scheduleAlarm(any(), "21:00") }
     }
 
     // ===== checkAndUpdateLocationCollectionStatus 자동 시작 (1개) =====


### PR DESCRIPTION
## 요약
- 로그아웃 후 재로그인 시 `alarm_enabled` SharedPreferences 값이 복구되지 않아, 대화 시간은 저장돼 있는데 알람은 영구적으로 꺼진 채 유지되는 버그를 발견 (실기기 `dumpsys alarm` + SharedPreferences 직접 확인으로 재현/확인).
- `alarm_enabled`는 설정 화면 UI에 연결되지 않은 죽은 코드였고, 온보딩에서도 시간을 안 바꾸면 항상 기본값 21:00이 채워지므로 별도로 켜고/끌 필요가 없는 값이었음.
- `conversation_time` 존재 여부만으로 알람 스케줄링 여부를 판단하도록 단순화하고, `alarm_enabled` 관련 코드(저장/조회/UI 토글)를 전부 제거.

## 변경 사항
- `ConversationAlarmStorage`: `alarm_enabled` 키/`setAlarmEnabled`/`isAlarmEnabled` 제거
- `ConversationAlarmScheduler.rescheduleFromStorage`, `ConversationAlarmReceiver.onReceive`(다음날 재예약): enabled 체크 제거, 시간 존재 여부만 확인
- `SettingsViewModel`: `alarmEnabled` UI 상태 제거, UI에 연결 안 돼있던 `setAlarmEnabled()` 및 관련 상수 삭제
- `OnboardingViewModel`/`OnboardingScreen`: `alarmEnabled` 상태와 "매일 알림 받기" 스위치 UI 제거

## 테스트
- [x] 로컬 빌드(`installLocalDebug`) 및 실기기(Galaxy, USB) 설치 확인
- [x] 온보딩에서 대화 시간 설정 후 `dumpsys alarm`으로 알람이 정상 스케줄링됨을 확인
- [x] SharedPreferences에 `conversation_time`만 저장되고 알람이 정상 동작함을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)