### PR TITLE
feat: 대화 중 화면 자동 꺼짐 방지

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -85,6 +86,14 @@ fun ConversationScreen(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // 대화 중(Idle이 아닐 때)에는 화면이 자동으로 꺼지지 않도록 유지
+    val view = LocalView.current
+    val isConversationActive = uiState.conversationState !is ConversationState.Idle
+    DisposableEffect(isConversationActive) {
+        view.keepScreenOn = isConversationActive
+        onDispose { view.keepScreenOn = false }
     }
 
     LaunchedEffect(uiState.errorMessage) {


### PR DESCRIPTION
## 요약
- 대화 진행 중(녹음/듣기/재생/전송 등, `ConversationState.Idle`이 아닌 상태)에 화면이 자동으로 꺼지지 않도록 `FLAG_KEEP_SCREEN_ON`을 적용.
- 대화가 끝나 `Idle`로 돌아가거나 화면을 벗어나면 원복되어, 다른 화면/평소 사용 시 배터리 절약 동작에는 영향 없음.

## 변경 사항
- `ConversationScreen.kt`: `LocalView.current.keepScreenOn`을 `uiState.conversationState`에 따라 토글하는 `DisposableEffect` 추가

## 테스트
- [x] 실기기(Galaxy, USB)에서 대화 시작 후 `dumpsys window`로 `FLAG_KEEP_SCREEN_ON`(0x80) 비트가 실제로 설정됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)