### PR TITLE
test: SettingsViewModelTest의 AndroidKeyStore 실패 수정

### DIFF
--- a/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/settings/SettingsViewModelTest.kt
@@ -11,6 +11,7 @@ import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.location.LocationCollectionService
 import com.example.graduation_project.data.location.LocationCollectionStorage
 import com.example.graduation_project.data.location.LocationScheduler
@@ -65,6 +66,11 @@ class SettingsViewModelTest {
         // UserRepository mock 설정
         mockUserRepository = mockk()
         coEvery { mockUserRepository.getPreferences() } returns ApiResult.Success(UserPreferences())
+
+        // Robolectric JVM에는 AndroidKeyStore가 없어 실제 AppDatabase(SQLCipher 비밀번호 생성)를
+        // 만들 수 없음 → 싱글톤을 목으로 대체해 Keystore 접근 차단
+        mockkObject(AppDatabase.Companion)
+        every { AppDatabase.getInstance(any()) } returns mockk(relaxed = true)
 
         // 기본 mock 설정
         mockkObject(PermissionChecker)


### PR DESCRIPTION
## 개요
`./gradlew build` 실행 시 `SettingsViewModelTest` 10건이 전부 실패하던 문제를 수정합니다.

## 원인
- `SettingsViewModel` 생성자가 `LocationStorageManager`를 만들며 `AppDatabase.getInstance()`를 호출
- `AppDatabase.buildDatabase()`는 SQLCipher 비밀번호 준비를 위해 `DatabasePassphrase.getOrCreate()`를 호출하고, 여기서 `AndroidKeyStore` 기반 `MasterKey`를 생성
- **Robolectric JVM에는 `AndroidKeyStore` 프로바이더가 없어** `KeyStoreException: AndroidKeyStore not found`로 ViewModel 생성 자체가 실패 → 클래스의 테스트 10건 전부 실패
- Room DB에 SQLCipher 암호화가 적용된 시점(#345 무렵)부터 develop에서 재현되던 기존 문제입니다

## 수정 내용
`setUp()`에서 `AppDatabase` 싱글톤을 mockkObject로 목 처리해 실제 DB 생성(Keystore 접근)을 차단합니다. 테스트 코드만 변경했으며 프로덕션 코드 변경은 없습니다.

```kotlin
mockkObject(AppDatabase.Companion)
every { AppDatabase.getInstance(any()) } returns mockk(relaxed = true)
```

목 해제는 기존 `tearDown()`의 `unmockkAll()`이 처리합니다.

## 테스트
- `SettingsViewModelTest` 10건 전부 통과 (수정 전: 10건 전부 실패)
- 전체 유닛 테스트 181건 통과, 실패 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)