### PR TITLE
chore: 변경된 계획에 맞지 않는 낡은 TODO/주석 정리

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/health/HealthConnectManager.kt
@@ -187,10 +187,6 @@ class HealthConnectManager(private val context: Context) {
         else -> "운동"
     }
 
-    // TODO: ExerciseRoute GPS 데이터 활용 기능 추후 재도입 예정
-    // 참고: feature/US5.5-healthconnect-route-tracking 브랜치, commit 1feb261
-    // 삭제된 메서드: readTodayExerciseRoutes(), readExerciseSessionLocations()
-
     /**
      * NotInstalled 상태일 때 Play Store로 연결.
      * Play Store 앱이 없으면 브라우저 웹 링크로 폴백.

--- a/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
@@ -47,5 +47,5 @@ data class HealthData(
     val steps: Int? = null,
     val exerciseDistanceKm: Double? = null,  // renamed: exerciseDistance → exerciseDistanceKm
     val exerciseActivity: String? = null,
-    val activityList: String? = null         // 활동 목록 (추후 구현)
+    val activityList: String? = null         // 오늘 운동 활동 목록 (쉼표 구분)
 )

--- a/android/app/src/main/java/com/example/graduation_project/presentation/model/ConversationError.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/model/ConversationError.kt
@@ -35,8 +35,7 @@ sealed class ConversationError {
 
     /**
      * 오디오 재생 실패 (안전망)
-     * - 현재: 텍스트 폴백으로 단순 처리
-     * - 추후: 팀 설계 3단계 재시도 로직 추가 예정
+     * - 로컬 재생 재시도 → 서버 TTS 재요청(1회) → 텍스트 폴백 순으로 처리
      */
     data object TtsError : ConversationError()
 }


### PR DESCRIPTION
## 개요
계획이 바뀌었거나 이미 구현이 끝났는데 남아 있던 낡은 TODO/주석을 정리합니다. 코드 동작 변경 없음(주석만 수정).

## 변경 사항
- **`HealthConnectManager.kt`**: "ExerciseRoute GPS 데이터 활용 기능 추후 재도입 예정" TODO 블록 삭제 — US 5.5는 자체 위치 수집(`LocationScheduler` + `StayPointDetector`) 방식으로 확정되어 폐기된 계획입니다
- **`ConversationModels.kt`**: `activityList`의 "(추후 구현)" 표기 제거 — `readTodayActivityList()`로 이미 구현되어 대화 시작 시 서버로 전송 중입니다
- **`ConversationError.kt`**: `TtsError`의 "3단계 재시도 로직 추가 예정" 주석을 실제 구현된 동작(로컬 재생 재시도 → 서버 TTS 재요청 1회 → 텍스트 폴백) 설명으로 교체

참고: `ConversationViewModel`의 userName TODO는 #368에서 별도로 제거됩니다.

## 테스트
- 주석만 변경되어 컴파일 통과 확인 (`:app:compileLocalDebugKotlin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)