### PR TITLE
fix: 다른 기기 로그인 시 대화 알람이 예약되지 않는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
+import com.example.graduation_project.data.alarm.ConversationAlarmStorage
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.location.LocationManager
@@ -39,6 +41,8 @@ class HomeViewModel(
     )
 ) : AndroidViewModel(application) {
 
+    private val alarmStorage = ConversationAlarmStorage(application)
+
     private val _uiState = MutableStateFlow(HomeUiState(date = formatToday()))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
@@ -59,8 +63,24 @@ class HomeViewModel(
                     userName = result.data.name ?: "",
                     conversationTime = result.data.conversationTime
                 )
+                syncAlarmWithServerTime(result.data.conversationTime)
             }
             is ApiResult.Error -> Unit
+        }
+    }
+
+    /**
+     * 다른 기기에서 로그인한 경우 로컬 알람 저장소가 비어 있어 대화 알람이 예약되지 않는
+     * 문제 방지: 홈 진입 시마다 서버 대화 시간 기준으로 로컬 알람을 동기화한다.
+     * (같은 PendingIntent를 덮어쓰므로 반복 호출해도 중복 예약되지 않음)
+     */
+    private fun syncAlarmWithServerTime(serverTime: String?) {
+        alarmStorage.saveConversationTime(serverTime)
+        val context = getApplication<Application>()
+        if (!serverTime.isNullOrBlank()) {
+            ConversationAlarmScheduler.scheduleAlarm(context, serverTime)
+        } else {
+            ConversationAlarmScheduler.cancelAlarm(context)
         }
     }
 

--- a/android/app/src/test/java/com/example/graduation_project/presentation/home/HomeViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/home/HomeViewModelTest.kt
@@ -1,0 +1,119 @@
+package com.example.graduation_project.presentation.home
+
+import android.app.Application
+import android.os.Build
+import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
+import com.example.graduation_project.data.alarm.ConversationAlarmStorage
+import com.example.graduation_project.data.api.ApiResult
+import com.example.graduation_project.data.local.AppDatabase
+import com.example.graduation_project.data.location.LocationManager
+import com.example.graduation_project.data.location.LocationStorageManager
+import com.example.graduation_project.data.model.UserPreferences
+import com.example.graduation_project.data.repository.UserRepository
+import com.example.graduation_project.data.repository.WeatherRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * 다른 기기에서 로그인했을 때(로컬 알람 저장소가 비어있는 상태) 홈 화면 진입만으로도
+ * 대화 알람이 서버 시간 기준으로 동기화되는지 검증.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.S])
+class HomeViewModelTest {
+
+    private lateinit var context: Application
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var mockUserRepository: UserRepository
+    private lateinit var mockWeatherRepository: WeatherRepository
+    private lateinit var mockLocationManager: LocationManager
+    private lateinit var mockLocationStorageManager: LocationStorageManager
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        Dispatchers.setMain(testDispatcher)
+
+        mockUserRepository = mockk()
+        mockWeatherRepository = mockk()
+        mockLocationManager = mockk()
+        mockLocationStorageManager = mockk()
+
+        coEvery { mockLocationStorageManager.getTodayLocations() } returns emptyList()
+        coEvery { mockLocationManager.getCurrentLocation() } returns null
+
+        // Robolectric JVM에는 AndroidKeyStore가 없어 실제 AppDatabase(SQLCipher 비밀번호 생성)를
+        // 만들 수 없음 → 싱글톤을 목으로 대체해 Keystore 접근 차단 (SettingsViewModelTest와 동일 패턴)
+        mockkObject(AppDatabase.Companion)
+        every { AppDatabase.getInstance(any()) } returns mockk(relaxed = true)
+
+        mockkObject(ConversationAlarmScheduler)
+        every { ConversationAlarmScheduler.scheduleAlarm(any(), any()) } just Runs
+        every { ConversationAlarmScheduler.cancelAlarm(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    private fun createViewModel(): HomeViewModel = HomeViewModel(
+        application = context,
+        userRepository = mockUserRepository,
+        weatherRepository = mockWeatherRepository,
+        locationManager = mockLocationManager,
+        locationStorageManager = mockLocationStorageManager
+    )
+
+    @Test
+    fun `홈_진입시_서버_대화시간으로_로컬_알람을_동기화한다`() = runTest {
+        // Given: 다른 기기에서 로그인한 상황 가정 - 로컬 알람 저장소는 비어있고 서버에만 대화 시간이 있음
+        coEvery { mockUserRepository.getPreferences() } returns
+            ApiResult.Success(UserPreferences(conversationTime = "21:30"))
+
+        // When: 홈 화면 진입 (ViewModel 생성)
+        createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 로컬 저장소에도 반영되고 알람이 예약되어야 함 (설정 화면을 열지 않아도)
+        assertEquals("21:30", ConversationAlarmStorage(context).getConversationTime())
+        verify { ConversationAlarmScheduler.scheduleAlarm(any(), "21:30") }
+    }
+
+    @Test
+    fun `서버_대화시간이_없으면_로컬_알람을_취소한다`() = runTest {
+        // Given: 서버에 대화 시간이 설정되어 있지 않음
+        coEvery { mockUserRepository.getPreferences() } returns
+            ApiResult.Success(UserPreferences(conversationTime = null))
+
+        // When: 홈 화면 진입
+        createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then: 로컬에 남아있을 수 있는 알람을 취소해 서버 상태와 어긋나지 않게 함
+        verify { ConversationAlarmScheduler.cancelAlarm(any()) }
+    }
+}


### PR DESCRIPTION
## 요약
- 온보딩을 이미 완료한 계정으로 새 기기에 로그인하면 `CHECKING` 라우트가 바로 `Home`으로 분기해 설정 화면을 거치지 않음.
- 서버 대화 시간을 로컬 `AlarmManager`에 동기화하는 코드는 `SettingsViewModel`에만 있었기 때문에, 사용자가 설정 화면을 스스로 열기 전까지 그 기기에는 대화 알람이 전혀 예약되지 않는 공백이 있었음.
- 경도인지장애 어르신 대상 앱 특성상 설정 화면을 스스로 열어 확인하는 걸 기대하기 어려워 실사용에서 걸릴 수 있는 갭으로 판단.

## 변경 사항
- `HomeViewModel.loadUserPreferences()`에도 서버 대화 시간 → 로컬 알람 동기화 로직 추가 (홈 화면 진입만으로 알람이 예약/취소되도록 함)
- `SettingsViewModel` 쪽 동기화(강제종료 등으로 `AlarmManager` 등록만 사라진 경우 복구용, PR #363)는 그대로 유지 — 같은 `PendingIntent`를 덮어쓰는 멱등 동작이라 두 곳에서 호출돼도 안전
- `HomeViewModelTest` 신규 추가: 서버 대화 시간이 있으면 로컬에 동기화 + 알람 예약, 없으면 알람 취소되는지 검증 (`AppDatabase` 싱글톤을 목 처리해 Robolectric의 AndroidKeyStore 제약 회피)

## 테스트
- [x] `compileProdDebugUnitTestKotlin` 성공
- [x] `testProdDebugUnitTest` — `HomeViewModelTest`(2), `SettingsViewModelTest`(8), `ConversationAlarmSchedulerTest`(1) 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)