### PR TITLE
fix: 컨텍스트 TTL 정리 스케줄러 추가

### DIFF
--- a/server/src/main/java/com/example/echo/context/service/ContextService.java
+++ b/server/src/main/java/com/example/echo/context/service/ContextService.java
@@ -14,8 +14,11 @@ import com.example.echo.user.dto.UserPreferences;
 import com.example.echo.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,12 +29,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @RequiredArgsConstructor
 public class ContextService {
 
+    /**
+     * 컨텍스트 TTL - 앱 크래시/강제 종료로 endConversation()이 호출되지 못한 경우에도
+     * 마지막 접근 후 이 기간이 지나면 스케줄러가 컨텍스트를 정리한다.
+     */
+    private static final Duration CONTEXT_TTL = Duration.ofDays(1);
+
     private final ConcurrentHashMap<Long, UserContext> contextStore = new ConcurrentHashMap<>();
 
     private final UserService userService;
     private final HealthDataService healthDataService;
     private final WeatherClient weatherClient;
     private final LocationService locationService;
+    private final Clock clock;
 
     /**
      * 컨텍스트 초기화 (위치 데이터 포함)
@@ -87,7 +97,7 @@ public class ContextService {
                 .preferences(preferences)
                 .todayWeather(weather)
                 .locationData(locationData)
-                .lastAccessTime(LocalDateTime.now())
+                .lastAccessTime(LocalDateTime.now(clock))
                 .isActive(true)
                 .build();
 
@@ -127,7 +137,7 @@ public class ContextService {
         if (context == null) {
             throw new IllegalStateException("Context not found for userId: " + userId);
         }
-        context.setLastAccessTime(LocalDateTime.now());
+        context.setLastAccessTime(LocalDateTime.now(clock));
         return context;
     }
 
@@ -153,5 +163,21 @@ public class ContextService {
         } else {
             log.warn("컨텍스트 정리 실패 - 이미 제거됨 또는 존재하지 않음 - userId: {}", userId);
         }
+    }
+
+    /**
+     * 앱 크래시/강제 종료로 endConversation()이 호출되지 못해 남아있는 컨텍스트를 TTL 기준으로 정리한다.
+     */
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void cleanupExpiredContexts() {
+        LocalDateTime threshold = LocalDateTime.now(clock).minus(CONTEXT_TTL);
+        contextStore.entrySet().removeIf(entry -> {
+            boolean expired = entry.getValue().getLastAccessTime().isBefore(threshold);
+            if (expired) {
+                log.info("[컨텍스트] TTL 만료로 정리 - userId: {}, lastAccessTime: {}",
+                        entry.getKey(), entry.getValue().getLastAccessTime());
+            }
+            return expired;
+        });
     }
 }

--- a/server/src/test/java/com/example/echo/context/service/ContextServiceTest.java
+++ b/server/src/test/java/com/example/echo/context/service/ContextServiceTest.java
@@ -15,11 +15,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -35,7 +38,6 @@ import static org.mockito.ArgumentMatchers.eq;
 @DisplayName("ContextService 테스트")
 class ContextServiceTest {
 
-    @InjectMocks
     private ContextService contextService;
 
     @Mock
@@ -50,6 +52,8 @@ class ContextServiceTest {
     @Mock
     private LocationService locationService;
 
+    private Clock clock;
+
     private Long userId;
     private UserPreferences mockPreferences;
     private HealthData mockHealthData;
@@ -58,6 +62,9 @@ class ContextServiceTest {
 
     @BeforeEach
     void setUp() {
+        clock = Clock.fixed(Instant.parse("2026-07-18T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+        contextService = new ContextService(userService, healthDataService, weatherClient, locationService, clock);
+
         userId = 1L;
 
         mockPreferences = UserPreferences.builder()
@@ -308,6 +315,52 @@ class ContextServiceTest {
 
             // when & then (예외 발생하지 않아야 함)
             assertThatCode(() -> contextService.finalizeContext(nonExistentUserId))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupExpiredContexts 메서드")
+    class CleanupExpiredContexts {
+
+        @Test
+        @DisplayName("성공: TTL(1일)이 지난 Context는 정리된다")
+        void success_removesExpiredContext() {
+            // given
+            given(userService.getPreferences(userId)).willReturn(mockPreferences);
+            given(healthDataService.buildEnrichedHealthData(eq(mockHealthData), eq(userId), any()))
+                    .willReturn(mockEnrichedHealthData);
+            given(weatherClient.getCurrentWeather(null, null)).willReturn(mockWeatherData);
+
+            UserContext context = contextService.initializeContext(userId, mockHealthData);
+            context.setLastAccessTime(LocalDateTime.now(clock).minusDays(1).minusMinutes(1));
+
+            // when
+            contextService.cleanupExpiredContexts();
+
+            // then
+            assertThatThrownBy(() -> contextService.getContext(userId))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Context not found");
+        }
+
+        @Test
+        @DisplayName("성공: TTL 이내의 Context는 유지된다")
+        void success_keepsContextWithinTtl() {
+            // given
+            given(userService.getPreferences(userId)).willReturn(mockPreferences);
+            given(healthDataService.buildEnrichedHealthData(eq(mockHealthData), eq(userId), any()))
+                    .willReturn(mockEnrichedHealthData);
+            given(weatherClient.getCurrentWeather(null, null)).willReturn(mockWeatherData);
+
+            UserContext context = contextService.initializeContext(userId, mockHealthData);
+            context.setLastAccessTime(LocalDateTime.now(clock).minusHours(1));
+
+            // when
+            contextService.cleanupExpiredContexts();
+
+            // then
+            assertThatCode(() -> contextService.getContext(userId))
                     .doesNotThrowAnyException();
         }
     }


### PR DESCRIPTION
## Summary
- 앱 크래시/강제 종료로 `endConversation()`이 호출되지 못하면 `UserContext`가 서버 메모리에 무기한 상주하던 문제를 해결
- `ContextService`에 매시 정각 실행되는 `@Scheduled` 정리 잡(`cleanupExpiredContexts`)을 추가해, `lastAccessTime` 기준 1일이 지난 컨텍스트를 자동 제거
- TTL 판정 기준과 `lastAccessTime` 갱신 모두 기존 `SchedulingConfig`의 `Clock` 빈(Asia/Seoul 고정, `ModelRotationService`와 동일 패턴)을 사용하도록 통일

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test --tests "com.example.echo.context.service.ContextServiceTest"` 통과 (TTL 만료/유지 케이스 신규 테스트 포함)
- [x] `./gradlew build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)