### PR TITLE
fix: 위치 정보 관련 민감 로그를 DEBUG로 하향하고 prod DEBUG 격상 제거

### DIFF
--- a/server/src/main/java/com/example/echo/context/service/ContextService.java
+++ b/server/src/main/java/com/example/echo/context/service/ContextService.java
@@ -92,7 +92,7 @@ public class ContextService {
                 .build();
 
         contextStore.put(userId, context);
-        log.info("[컨텍스트] 저장 완료 - userId: {}, currentCity: {}, 방문장소 수: {}",
+        log.debug("[컨텍스트] 저장 완료 - userId: {}, currentCity: {}, 방문장소 수: {}",
                 userId,
                 locationData != null ? locationData.getCurrentCity() : "null",
                 locationData != null && locationData.getVisitedPlaces() != null

--- a/server/src/main/java/com/example/echo/conversation/controller/ConversationController.java
+++ b/server/src/main/java/com/example/echo/conversation/controller/ConversationController.java
@@ -56,7 +56,7 @@ public class ConversationController {
         log.info("=== 대화 시작 요청 - userId: {} ===", userId);
         if (request != null && request.getLocationData() != null) {
             var loc = request.getLocationData();
-            log.info("[입력] 현재좌표: ({}, {}), 총이동거리: {}km",
+            log.debug("[입력] 현재좌표: ({}, {}), 총이동거리: {}km",
                     loc.getCurrentLatitude(), loc.getCurrentLongitude(), loc.getTotalDistanceKm());
             if (loc.getVisitedPlaces() != null) {
                 log.info("[입력] 방문장소 수: {}", loc.getVisitedPlaces().size());

--- a/server/src/main/java/com/example/echo/location/service/GeocodingService.java
+++ b/server/src/main/java/com/example/echo/location/service/GeocodingService.java
@@ -25,7 +25,7 @@ public class GeocodingService {
             KakaoGeocodingResponse response = geocodingClient.reverseGeocode(lon, lat, "WGS84");
             return extractAddress(response);
         } catch (Exception e) {
-            log.warn("현재 위치 역지오코딩 실패 - lat:{}, lon:{}, 이유:{}", lat, lon, e.getMessage());
+            log.warn("현재 위치 역지오코딩 실패 - 이유:{}", e.getMessage());
             return null;
         }
     }
@@ -38,7 +38,7 @@ public class GeocodingService {
                     .address(extractAddress(response))
                     .build();
         } catch (Exception e) {
-            log.warn("방문 장소 역지오코딩 실패 - lat:{}, lon:{}, 이유:{}", lat, lon, e.getMessage());
+            log.warn("방문 장소 역지오코딩 실패 - 이유:{}", e.getMessage());
             return GeocodingResult.builder().build();
         }
     }

--- a/server/src/main/java/com/example/echo/location/service/LocationService.java
+++ b/server/src/main/java/com/example/echo/location/service/LocationService.java
@@ -59,7 +59,7 @@ public class LocationService {
             }
         }
 
-        log.info("위치 데이터 보강 완료 - currentCity: {}, 방문장소 수: {}, 총 이동거리: {}km",
+        log.debug("위치 데이터 보강 완료 - currentCity: {}, 방문장소 수: {}, 총 이동거리: {}km",
                 currentCity, enrichedPlaces.size(), raw.getTotalDistanceKm());
 
         return LocationData.builder()

--- a/server/src/main/java/com/example/echo/prompt/service/PromptService.java
+++ b/server/src/main/java/com/example/echo/prompt/service/PromptService.java
@@ -126,7 +126,7 @@ public class PromptService {
             variables.put("visitedPlacesText", visitedPlacesText);
 
             // 프롬프트에 들어가는 위치 정보 로그
-            log.info("[프롬프트] currentCity: {}", variables.get("currentCity"));
+            log.debug("[프롬프트] currentCity: {}", variables.get("currentCity"));
             log.debug("[프롬프트] visitedPlacesText:\n{}", visitedPlacesText);
         } else {
             variables.put("currentCity", "");

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -47,7 +47,3 @@ supertone:
 
 server:
   forward-headers-strategy: native
-
-logging:
-  level:
-    com.example.echo.location: DEBUG


### PR DESCRIPTION
## Summary
- `application-prod.yaml`이 `com.example.echo.location` 패키지를 DEBUG로 격상시켜, 사용자의 실제 방문 주소·장소명이 운영 환경 stdout 로그에 그대로 찍히던 문제를 해결
- 원본 좌표/`currentCity`를 찍던 INFO 레벨 로그(`ConversationController`, `ContextService`, `LocationService`, `PromptService`)를 DEBUG로 하향해, 별도 설정 없이는 어디서도 노출되지 않도록 정리
- 역지오코딩 실패 시 WARN 로그(`GeocodingService`)에서도 원본 좌표를 제거하고 실패 사유만 남기도록 정리 (실패 원인은 `e.getMessage()`로 충분히 진단 가능)
- 로컬/dev 디버깅용 상세 로그(주소·좌표 포함, DEBUG 레벨)는 그대로 유지 — 필요 시 개발자가 명시적으로 켜서 확인 가능

## Test plan
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew build` 통과 (기존에 알려진 14개 통합/E2E 테스트 401 실패는 `SecurityConfig` 인증 미적용 이슈로, 이번 변경과 무관)
- [x] `application-prod.yaml`에서 `logging.level.com.example.echo.location: DEBUG` 오버라이드 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)