### PR TITLE
fix: WeatherClient 로그에서 원본 GPS 좌표 제거

### DIFF
--- a/server/src/main/java/com/example/echo/common/client/WeatherClient.java
+++ b/server/src/main/java/com/example/echo/common/client/WeatherClient.java
@@ -141,7 +141,7 @@ public class WeatherClient {
      */
     private WeatherData callCurrentWeatherApi(Double latitude, Double longitude) {
         try {
-            log.debug("현재 날씨 조회 요청 - 위도: {}, 경도: {}", latitude, longitude);
+            log.debug("현재 날씨 조회 요청");
 
             WeatherApiResponse response = weatherApiClient.getWeather(
                     latitude,
@@ -157,7 +157,7 @@ public class WeatherClient {
             return weatherData;
 
         } catch (Exception e) {
-            log.error("현재 날씨 조회 실패 - 위도: {}, 경도: {}, 오류: {}", latitude, longitude, e.getMessage());
+            log.error("현재 날씨 조회 실패 - 오류: {}", e.getMessage());
             return null;
         }
     }
@@ -172,7 +172,7 @@ public class WeatherClient {
      */
     private VisitWeather callTimemachineApi(Double latitude, Double longitude, long timestamp) {
         try {
-            log.debug("방문 날씨 조회 요청 - 위도: {}, 경도: {}, timestamp: {}", latitude, longitude, timestamp);
+            log.debug("방문 날씨 조회 요청 - timestamp: {}", timestamp);
 
             TimemachineApiResponse response = weatherApiClient.getTimemachineWeather(
                     latitude,
@@ -194,11 +194,10 @@ public class WeatherClient {
 
         } catch (FeignException.TooManyRequests e) {
             log.error("⚠️ OpenWeatherMap API 한도 초과! 관리자 확인 필요. " +
-                    "일일 무료 한도: 1000회. 위도: {}, 경도: {}", latitude, longitude);
+                    "일일 무료 한도: 1000회.");
             return null;
         } catch (FeignException.Unauthorized e) {
-            log.error("⚠️ OpenWeatherMap API 인증 실패! API 키를 확인하세요. " +
-                    "위도: {}, 경도: {}", latitude, longitude);
+            log.error("⚠️ OpenWeatherMap API 인증 실패! API 키를 확인하세요.");
             return null;
         } catch (FeignException.Forbidden e) {
             log.error("⚠️ One Call API 3.0 구독이 필요합니다! " +
@@ -206,12 +205,12 @@ public class WeatherClient {
                     "https://home.openweathermap.org/subscriptions");
             return null;
         } catch (FeignException e) {
-            log.error("방문 날씨 조회 실패 - 위도: {}, 경도: {}, timestamp: {}, HTTP 상태: {}, 오류: {}",
-                    latitude, longitude, timestamp, e.status(), e.getMessage());
+            log.error("방문 날씨 조회 실패 - timestamp: {}, HTTP 상태: {}, 오류: {}",
+                    timestamp, e.status(), e.getMessage());
             return null;
         } catch (Exception e) {
-            log.error("방문 날씨 조회 실패 - 위도: {}, 경도: {}, timestamp: {}, 오류: {}",
-                    latitude, longitude, timestamp, e.getMessage());
+            log.error("방문 날씨 조회 실패 - timestamp: {}, 오류: {}",
+                    timestamp, e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- 위치 로깅 하드닝(#373) 이후 전체 코드베이스를 재점검하던 중 `WeatherClient.java`가 빠져있던 것을 발견
- `callCurrentWeatherApi`/`callTimemachineApi`의 DEBUG 로그뿐 아니라 **ERROR 레벨 로그 5곳**에서도 원본 위경도가 그대로 찍히고 있었음 — ERROR는 별도 설정 없이 모든 환경에서 항상 출력되므로, 이전에 고친 DEBUG/INFO 케이스보다 오히려 노출 범위가 넓었음
- 좌표를 모두 제거하고 timestamp/HTTP 상태/오류 메시지 등 진단에 필요한 정보만 남김 (반올림된 캐시 키(`%.1f,%.1f`, 약 10km)는 원본 좌표가 아니라 그대로 유지)

## Test plan
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew test --tests "com.example.echo.common.client.WeatherClientTest"` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)