### PR TITLE
fix(server): 일기 생성 스킵과 실패를 DiaryOutcome 타입으로 구분

### DIFF
--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -10,6 +10,7 @@ import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.conversation.dto.TtsRetryResponse;
 import com.example.echo.conversation.exception.ConversationNotFoundException;
 import com.example.echo.diary.entity.Diary;
+import com.example.echo.diary.service.DiaryOutcome;
 import com.example.echo.diary.service.DiaryService;
 import com.example.echo.health.dto.HealthData;
 import com.example.echo.location.dto.RawLocationData;
@@ -150,13 +151,14 @@ public class ConversationService {
             log.info("컨텍스트 조회 완료 - 대화 턴 수: {}", context.getConversationHistory().size());
 
             // 2. 일기 생성 (동기) - 실패해도 대화 종료는 계속되며, 결과를 응답에 명시
-            Diary diary = diaryService.generateAndSaveDiary(context);
-            if (diary == null) {
-                diaryStatus = "SKIPPED";
-            } else {
+            DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
+            if (outcome instanceof DiaryOutcome.Processed processed) {
+                Diary diary = processed.diary();
                 diaryStatus = diary.getStatus().name();
                 diaryId = diary.getId();
                 diaryError = diary.getFailureReason();
+            } else {
+                diaryStatus = "SKIPPED";
             }
         } catch (Exception e) {
             log.error("일기 생성 실패 - userId: {}", userId, e);

--- a/server/src/main/java/com/example/echo/diary/service/DiaryOutcome.java
+++ b/server/src/main/java/com/example/echo/diary/service/DiaryOutcome.java
@@ -1,0 +1,19 @@
+package com.example.echo.diary.service;
+
+import com.example.echo.diary.entity.Diary;
+
+/**
+ * DiaryService.generateAndSaveDiary()의 결과
+ *
+ * - Skipped: 사용자 발화가 없어 일기 생성을 의도적으로 건너뜀 (일기 없음)
+ * - Processed: 일기 생성을 시도함. diary.getStatus()가 SUCCESS 또는 FAILED이며,
+ *   실패 기록 저장 자체가 실패한 경우 diary.getId()는 null일 수 있음
+ *
+ * "스킵"과 "실패"가 둘 다 null로 뭉뚱그려지던 것을 타입으로 구분하기 위해 도입.
+ */
+public sealed interface DiaryOutcome {
+
+    record Skipped() implements DiaryOutcome {}
+
+    record Processed(Diary diary) implements DiaryOutcome {}
+}

--- a/server/src/main/java/com/example/echo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/example/echo/diary/service/DiaryService.java
@@ -45,10 +45,11 @@ public class DiaryService {
      * 대화 종료 시 오늘의 일기 생성/갱신
      *
      * @param context 대화 종료 시점의 UserContext
-     * @return 저장된 Diary (SUCCESS 또는 FAILED), 사용자 발화가 없어 스킵한 경우 null
+     * @return Skipped(사용자 발화 없어 의도적으로 건너뜀) 또는
+     *         Processed(생성 시도함 - diary.status가 SUCCESS/FAILED, 실패 기록 저장까지 실패하면 diary.id는 null)
      */
     @Transactional
-    public Diary generateAndSaveDiary(UserContext context) {
+    public DiaryOutcome generateAndSaveDiary(UserContext context) {
         Long userId = context.getUserId();
         LocalDate today = LocalDate.now(KST);
 
@@ -58,7 +59,7 @@ public class DiaryService {
         // 인사만 듣고 종료한 세션은 일기를 만들 내용이 없음 - 기존 일기를 건드리지 않고 스킵
         if (!hasUserMessage(context.getConversationHistory())) {
             log.info("일기 생성 스킵 - 사용자 발화 없음 - userId: {}", userId);
-            return null;
+            return new DiaryOutcome.Skipped();
         }
 
         Diary existing = diaryRepository.findByUserIdAndDiaryDate(userId, today).orElse(null);
@@ -71,10 +72,10 @@ public class DiaryService {
 
             Diary saved = upsertSuccess(userId, today, existing, content, weather);
             log.info("일기 생성 완료 - userId: {}, diaryId: {}, 길이: {}", userId, saved.getId(), content.length());
-            return saved;
+            return new DiaryOutcome.Processed(saved);
         } catch (Exception e) {
             log.error("일기 생성 실패 - userId: {}, date: {}", userId, today, e);
-            return saveFailure(userId, today, existing, e);
+            return new DiaryOutcome.Processed(saveFailure(userId, today, existing, e));
         }
     }
 
@@ -131,17 +132,22 @@ public class DiaryService {
 
     private Diary saveFailure(Long userId, LocalDate date, Diary existing, Exception cause) {
         String reason = truncate(cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName());
+        Diary failed;
+        if (existing != null) {
+            // 같은 날 이미 성공한 일기가 있으면 content는 보존하고 상태만 FAILED로 표시
+            existing.markFailed(reason);
+            failed = existing;
+        } else {
+            failed = buildNewDiary(userId, date, null, null, DiaryStatus.FAILED, reason);
+        }
         try {
-            if (existing != null) {
-                // 같은 날 이미 성공한 일기가 있으면 content는 보존하고 상태만 FAILED로 표시
-                existing.markFailed(reason);
-                return diaryRepository.save(existing);
-            }
-            return diaryRepository.save(buildNewDiary(userId, date, null, null, DiaryStatus.FAILED, reason));
+            return diaryRepository.save(failed);
         } catch (Exception saveError) {
-            // 실패 기록 저장마저 실패해도 대화 종료 흐름은 막지 않음
+            // 실패 기록 저장마저 실패해도 대화 종료 흐름은 막지 않음.
+            // DiaryOutcome.Processed로 감싸 반환해야 하므로, 저장은 못 했더라도(id=null)
+            // status=FAILED인 객체는 그대로 반환한다
             log.error("일기 실패 기록 저장 실패 - userId: {}, date: {}", userId, date, saveError);
-            return null;
+            return failed;
         }
     }
 

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -9,6 +9,7 @@ import com.example.echo.conversation.dto.ConversationResponse;
 import com.example.echo.conversation.dto.ConversationStartResponse;
 import com.example.echo.diary.entity.Diary;
 import com.example.echo.diary.entity.DiaryStatus;
+import com.example.echo.diary.service.DiaryOutcome;
 import com.example.echo.diary.service.DiaryService;
 import com.example.echo.health.service.HealthDataService;
 import com.example.echo.prompt.service.PromptService;
@@ -283,7 +284,7 @@ class ConversationServiceTest2 {
                     .status(DiaryStatus.SUCCESS)
                     .build();
             given(contextService.getContext(userId)).willReturn(mockContext);
-            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(diary);
+            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(new DiaryOutcome.Processed(diary));
             willDoNothing().given(contextService).finalizeContext(userId);
 
             // when
@@ -306,7 +307,7 @@ class ConversationServiceTest2 {
                     .failureReason("AI 일기 생성 실패: 401")
                     .build();
             given(contextService.getContext(userId)).willReturn(mockContext);
-            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(failedDiary);
+            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(new DiaryOutcome.Processed(failedDiary));
             willDoNothing().given(contextService).finalizeContext(userId);
 
             // when
@@ -323,7 +324,7 @@ class ConversationServiceTest2 {
         void diarySkipped_responseContainsSkipped() {
             // given
             given(contextService.getContext(userId)).willReturn(mockContext);
-            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(null);
+            given(diaryService.generateAndSaveDiary(mockContext)).willReturn(new DiaryOutcome.Skipped());
             willDoNothing().given(contextService).finalizeContext(userId);
 
             // when

--- a/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
@@ -80,10 +80,10 @@ class DiaryServiceTest {
         when(diaryRepository.save(any(Diary.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // when
-        Diary result = diaryService.generateAndSaveDiary(context);
+        DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
 
         // then
-        assertThat(result).isNotNull();
+        Diary result = processedDiary(outcome);
         assertThat(result.getStatus()).isEqualTo(DiaryStatus.SUCCESS);
         assertThat(result.getContent()).isEqualTo("오늘은 산책을 다녀왔다.");
         assertThat(result.getDiaryDate()).isEqualTo(TODAY);
@@ -108,10 +108,11 @@ class DiaryServiceTest {
         when(diaryRepository.save(any(Diary.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // when
-        Diary result = diaryService.generateAndSaveDiary(context);
+        DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
 
         // then
         verify(promptService).buildDiaryPrompt(eq(context), eq("아침에 쓴 기존 일기"));
+        Diary result = processedDiary(outcome);
         assertThat(result.getStatus()).isEqualTo(DiaryStatus.SUCCESS);
         assertThat(result.getContent()).isEqualTo("아침 산책과 오후 이야기를 담은 통합 일기");
         assertThat(result.getFailureReason()).isNull();
@@ -134,13 +135,34 @@ class DiaryServiceTest {
         when(diaryRepository.save(any(Diary.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // when
-        Diary result = diaryService.generateAndSaveDiary(context);
+        DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
 
         // then
-        assertThat(result).isNotNull();
+        Diary result = processedDiary(outcome);
         assertThat(result.getStatus()).isEqualTo(DiaryStatus.FAILED);
         assertThat(result.getFailureReason()).contains("AI 일기 생성 실패");
         assertThat(result.getContent()).isEqualTo("아침에 성공한 일기"); // 성공본 보존
+    }
+
+    @Test
+    @DisplayName("AI 생성과 실패 기록 저장이 모두 실패해도 Skipped와 구분되는 Processed(FAILED)를 반환한다")
+    void generateAndSaveDiary_returnsProcessedFailedEvenWhenFailureRecordSaveFails() {
+        // given
+        UserContext context = contextWithUserMessage();
+        when(diaryRepository.findByUserIdAndDiaryDate(TEST_USER_ID, TODAY)).thenReturn(Optional.empty());
+        when(promptService.buildDiaryPrompt(eq(context), isNull())).thenReturn("일기 프롬프트");
+        when(aiService.generateDiary("일기 프롬프트")).thenThrow(new AIException("AI 일기 생성 실패: 500"));
+        when(diaryRepository.save(any(Diary.class))).thenThrow(new RuntimeException("DB 연결 끊김"));
+
+        // when
+        DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
+
+        // then: Skipped가 아니라 Processed(FAILED)여야 "발화 없어 스킵"과 구분됨
+        assertThat(outcome).isInstanceOf(DiaryOutcome.Processed.class);
+        Diary result = processedDiary(outcome);
+        assertThat(result.getStatus()).isEqualTo(DiaryStatus.FAILED);
+        assertThat(result.getFailureReason()).contains("AI 일기 생성 실패");
+        assertThat(result.getId()).isNull(); // 저장 자체는 실패했으므로 id는 없음
     }
 
     @Test
@@ -157,11 +179,16 @@ class DiaryServiceTest {
                 .build());
 
         // when
-        Diary result = diaryService.generateAndSaveDiary(context);
+        DiaryOutcome outcome = diaryService.generateAndSaveDiary(context);
 
         // then
-        assertThat(result).isNull();
+        assertThat(outcome).isInstanceOf(DiaryOutcome.Skipped.class);
         verifyNoInteractions(aiService);
         verify(diaryRepository, never()).save(any());
+    }
+
+    private static Diary processedDiary(DiaryOutcome outcome) {
+        assertThat(outcome).isInstanceOf(DiaryOutcome.Processed.class);
+        return ((DiaryOutcome.Processed) outcome).diary();
     }
 }


### PR DESCRIPTION
## Summary
- Sonnet 5 서브에이전트 코드 리뷰(일기 탭 기능)에서 발견된 버그 수정
- `DiaryService.generateAndSaveDiary()`가 "사용자 발화 없어 스킵"과 "생성+실패기록 저장 이중 실패"를 둘 다 `null`로 반환해, `ConversationService.endConversation`이 실제 이중 실패도 `diaryStatus=SKIPPED`로 잘못 응답하던 문제
- `DiaryOutcome`(`Skipped`/`Processed(Diary)`) sealed interface를 도입해 두 케이스를 타입으로 명확히 구분
- `saveFailure`는 실패 기록 저장 자체가 실패해도 `status=FAILED`인 `Diary`를 반환 (id는 null일 수 있음) — 더 이상 `null`을 반환하지 않음

## Test plan
- [x] `DiaryServiceTest` — 이중 실패 시 `Skipped`가 아닌 `Processed(FAILED)` 반환 회귀 테스트 추가
- [x] `ConversationServiceTest2` — SUCCESS/FAILED/SKIPPED 매핑 테스트 통과 확인
- [x] `./gradlew test --tests "com.example.echo.diary.*" --tests "com.example.echo.conversation.*"` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaArTGhszEAWffypfXFdWx