### PR TITLE
fix(diary-tab): 일기 탭 날짜 버킷을 서버 diaryDate 기준으로 통일

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -131,10 +131,19 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
+    // Room 마이그레이션 테스트에서 ApplicationProvider(Context) 제공
+    testImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+// 버전별 Room 스키마 JSON을 내보낸다 (기존에는 exportSchema=false라 과거 버전 스키마가 없었음)
+// - 마이그레이션 작성 시 실제 컬럼/타입을 대조하는 참고 자료로 사용
+// - 새 마이그레이션 테스트 작성 시 정확한 CREATE TABLE 문의 출처로 사용 (AppDatabaseMigrationTest 참고)
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }

--- a/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/3.json
+++ b/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/3.json
@@ -1,0 +1,157 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "2ff6154bfabb825ae7198bef3c326f2b",
+    "entities": [
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "location_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `date` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "diaries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `title` TEXT, `content` TEXT, `status` TEXT NOT NULL, `failureReason` TEXT, `weather` TEXT, `mood` TEXT, `updatedAt` TEXT, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureReason",
+            "columnName": "failureReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "weather",
+            "columnName": "weather",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mood",
+            "columnName": "mood",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2ff6154bfabb825ae7198bef3c326f2b')"
+    ]
+  }
+}

--- a/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/4.json
+++ b/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/4.json
@@ -1,0 +1,181 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "90d4ef72b0507e18bdbdb6ab9b23c4d9",
+    "entities": [
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "location_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `date` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "diaries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `title` TEXT, `content` TEXT, `status` TEXT NOT NULL, `failureReason` TEXT, `weather` TEXT, `mood` TEXT, `updatedAt` TEXT, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureReason",
+            "columnName": "failureReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "weather",
+            "columnName": "weather",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mood",
+            "columnName": "mood",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "conversation_diary_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationId` TEXT NOT NULL, `diaryDate` TEXT NOT NULL, PRIMARY KEY(`conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diaryDate",
+            "columnName": "diaryDate",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '90d4ef72b0507e18bdbdb6ab9b23c4d9')"
+    ]
+  }
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/local/AppDatabase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/AppDatabase.kt
@@ -6,9 +6,11 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.example.graduation_project.data.local.dao.ConversationDiaryLinkDao
 import com.example.graduation_project.data.local.dao.DiaryDao
 import com.example.graduation_project.data.local.dao.LocationPointDao
 import com.example.graduation_project.data.local.dao.MessageDao
+import com.example.graduation_project.data.local.entity.ConversationDiaryLinkEntity
 import com.example.graduation_project.data.local.entity.DiaryEntity
 import com.example.graduation_project.data.local.entity.LocationPointEntity
 import com.example.graduation_project.data.local.entity.MessageEntity
@@ -26,9 +28,9 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
  * - 마이그레이션 전략 필요 (현재는 fallbackToDestructiveMigration 사용)
  */
 @Database(
-    entities = [MessageEntity::class, LocationPointEntity::class, DiaryEntity::class],
-    version = 3,
-    exportSchema = false
+    entities = [MessageEntity::class, LocationPointEntity::class, DiaryEntity::class, ConversationDiaryLinkEntity::class],
+    version = 4,
+    exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
 
@@ -37,6 +39,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun locationPointDao(): LocationPointDao
 
     abstract fun diaryDao(): DiaryDao
+
+    abstract fun conversationDiaryLinkDao(): ConversationDiaryLinkDao
 
     companion object {
         private const val DATABASE_NAME = "echo_database"
@@ -87,6 +91,24 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         /**
+         * Migration 3 → 4: conversation_diary_link 테이블 추가
+         * (로컬 대화 세션 conversationId → 서버가 확정한 diaryDate 매핑)
+         * 기존 messages/location_points/diaries 테이블은 그대로 유지
+         * 주의: 컬럼 타입/NOT NULL이 ConversationDiaryLinkEntity와 정확히 일치해야 함
+         *       (불일치 시 destructive fallback이 발동해 기존 메시지가 삭제됨)
+         */
+        internal val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS conversation_diary_link (
+                        conversationId TEXT NOT NULL PRIMARY KEY,
+                        diaryDate TEXT NOT NULL
+                    )
+                """.trimIndent())
+            }
+        }
+
+        /**
          * 데이터베이스 인스턴스 가져오기
          * - 스레드 안전한 싱글톤
          */
@@ -119,7 +141,7 @@ abstract class AppDatabase : RoomDatabase() {
                 DATABASE_NAME
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 // Migration 실패 시에만 fallback (안전망)
                 .fallbackToDestructiveMigration(dropAllTables = true)
                 .build()

--- a/android/app/src/main/java/com/example/graduation_project/data/local/dao/ConversationDiaryLinkDao.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/dao/ConversationDiaryLinkDao.kt
@@ -1,0 +1,35 @@
+package com.example.graduation_project.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.graduation_project.data.local.entity.ConversationDiaryLinkEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * conversationId → 서버가 확정한 diaryDate 매핑 DAO
+ * - 일기 탭에서 로컬 세션의 날짜 버킷을 서버와 정확히 맞추는 데 사용
+ */
+@Dao
+interface ConversationDiaryLinkDao {
+
+    /**
+     * /end 응답으로 diaryDate를 받았을 때 매핑 저장
+     * - 같은 conversationId면 덮어쓰기 (재종료·재시도 대비)
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(link: ConversationDiaryLinkEntity)
+
+    /**
+     * 전체 매핑 조회 (Flow) - 일기 탭 목록 병합에 사용
+     */
+    @Query("SELECT * FROM conversation_diary_link")
+    fun observeAll(): Flow<List<ConversationDiaryLinkEntity>>
+
+    /**
+     * 단건 조회 - 일기 상세 화면에서 사용
+     */
+    @Query("SELECT diaryDate FROM conversation_diary_link WHERE conversationId = :conversationId")
+    suspend fun getDiaryDate(conversationId: String): String?
+}

--- a/android/app/src/main/java/com/example/graduation_project/data/local/entity/ConversationDiaryLinkEntity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/entity/ConversationDiaryLinkEntity.kt
@@ -1,0 +1,22 @@
+package com.example.graduation_project.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * 로컬 대화 세션(conversationId)이 서버에서 실제로 어느 날짜의 일기로 기록됐는지 매핑
+ *
+ * 서버는 /end 호출 시점(대화 종료 시각) 기준 KST 날짜로 일기를 기록하므로,
+ * 클라이언트가 세션 메시지 타임스탬프로 날짜를 추정(sessionDateKey)하는 대신
+ * 이 매핑을 우선 신뢰해 일기 탭의 날짜 버킷을 서버와 정확히 맞춘다.
+ * (diaryStatus=SKIPPED이거나 /end 응답을 아직 못 받은 세션은 매핑이 없어
+ *  sessionDateKey 휴리스틱으로 폴백한다)
+ *
+ * @param diaryDate "yyyy-MM-dd" (Asia/Seoul), 서버 ConversationEndResponse.diaryDate 그대로
+ */
+@Entity(tableName = "conversation_diary_link")
+data class ConversationDiaryLinkEntity(
+    @PrimaryKey
+    val conversationId: String,
+    val diaryDate: String
+)

--- a/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/ConversationModels.kt
@@ -25,7 +25,8 @@ data class ConversationEndResponse(
     val endedAt: String? = null,
     val diaryStatus: String? = null,   // SUCCESS | FAILED | SKIPPED (구서버는 null)
     val diaryId: Long? = null,
-    val diaryError: String? = null
+    val diaryError: String? = null,
+    val diaryDate: String? = null      // "yyyy-MM-dd" (Asia/Seoul), SKIPPED/구서버는 null
 )
 
 // /api/conversations/tts-retry 응답 Model(DTO)

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -17,6 +17,7 @@ import com.example.graduation_project.domain.health.IHealthRepository
 import com.example.graduation_project.data.health.StayPointDetectorImpl
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.dao.MessageDao
+import com.example.graduation_project.data.local.entity.ConversationDiaryLinkEntity
 import com.example.graduation_project.data.local.entity.MessageEntity
 import com.example.graduation_project.data.repository.ConversationRepository
 import com.example.graduation_project.data.repository.DiaryRepository
@@ -561,6 +562,7 @@ class ConversationViewModel(
             audioPlayerManager.stop()
             audioRecordManager.stop()
 
+            val endedConversationId = conversationId  // nulling되기 전에 캡처 (아래에서 링크 저장에 사용)
             val result = repository.endConversation()
 
             when (result) {
@@ -581,6 +583,18 @@ class ConversationViewModel(
                         ).show()
                     } else {
                         Log.i(TAG, "일기 생성 결과: $diaryStatus (diaryId: ${result.data.diaryId})")
+                    }
+
+                    // 서버가 확정한 diaryDate를 이 세션(conversationId)에 매핑해 저장
+                    // - 일기 탭에서 로컬 타임스탬프 추정 대신 이 값을 신뢰해 날짜 버킷을 서버와 맞춤
+                    val diaryDate = result.data.diaryDate
+                    if (diaryDate != null && endedConversationId != null) {
+                        launch {
+                            runCatching {
+                                AppDatabase.getInstance(getApplication()).conversationDiaryLinkDao()
+                                    .upsert(ConversationDiaryLinkEntity(endedConversationId, diaryDate))
+                            }.onFailure { Log.w(TAG, "대화-일기 날짜 매핑 저장 실패", it) }
+                        }
                     }
 
                     // 일기 로컬 캐시 갱신 (실패해도 무시 - 일기 탭 진입 시 재시도됨)

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
@@ -45,6 +45,7 @@ import com.example.graduation_project.ui.theme.OutfitFontFamily
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 // ViewModel
@@ -69,6 +70,7 @@ class DiaryDetailViewModel(
     private val database = AppDatabase.getInstance(application)
     private val messageDao = database.messageDao()
     private val diaryDao = database.diaryDao()
+    private val conversationDiaryLinkDao = database.conversationDiaryLinkDao()
 
     private val _uiState = MutableStateFlow(DiaryDetailUiState())
     val uiState: StateFlow<DiaryDetailUiState> = _uiState.asStateFlow()
@@ -79,16 +81,22 @@ class DiaryDetailViewModel(
 
     private fun load() {
         viewModelScope.launch {
-            messageDao.getSessionRanges().collect { ranges ->
-                val sessions = ranges
-                    .filter { sessionDateKey(it.firstTimestamp) == date }
-                    .mapNotNull { buildSessionSummary(messageDao, it) }
-                _uiState.value = DiaryDetailUiState(
-                    diary = diaryDao.getByDate(date),
-                    sessions = sessions,
-                    isLoading = false
-                )
-            }
+            combine(
+                messageDao.getSessionRanges(),
+                conversationDiaryLinkDao.observeAll()
+            ) { ranges, links -> ranges to links.associate { it.conversationId to it.diaryDate } }
+                .collect { (ranges, linkedDates) ->
+                    // DiaryViewModel의 버킷 기준과 동일하게: 서버 diaryDate가 있으면 우선 신뢰,
+                    // 없으면 lastTimestamp 휴리스틱으로 폴백
+                    val sessions = ranges
+                        .filter { resolveDateKey(it, linkedDates[it.conversationId]) == date }
+                        .mapNotNull { buildSessionSummary(messageDao, it, date) }
+                    _uiState.value = DiaryDetailUiState(
+                        diary = diaryDao.getByDate(date),
+                        sessions = sessions,
+                        isLoading = false
+                    )
+                }
         }
     }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
@@ -19,6 +19,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
+private data class DiaryTabSources(
+    val diaries: List<DiaryEntity>,
+    val ranges: List<SessionRange>,
+    val diaryDateByConversationId: Map<String, String>,
+    val syncError: String?
+)
+
 /**
  * 일기 탭 목록 항목
  *
@@ -48,6 +55,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     private val database = AppDatabase.getInstance(application)
     private val messageDao = database.messageDao()
     private val diaryDao = database.diaryDao()
+    private val conversationDiaryLinkDao = database.conversationDiaryLinkDao()
     private val diaryRepository = DiaryRepository(diaryDao)
 
     private val syncError = MutableStateFlow<String?>(null)
@@ -77,14 +85,15 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
             combine(
                 diaryDao.observeAll(),
                 messageDao.getSessionRanges(),
+                conversationDiaryLinkDao.observeAll(),
                 syncError
-            ) { diaries, ranges, error ->
-                Triple(diaries, ranges, error)
-            }.collect { (diaries, ranges, error) ->
+            ) { diaries, ranges, links, error ->
+                DiaryTabSources(diaries, ranges, links.associate { it.conversationId to it.diaryDate }, error)
+            }.collect { sources ->
                 _uiState.value = DiaryListUiState(
-                    items = buildItems(diaries, ranges),
+                    items = buildItems(sources),
                     isLoading = false,
-                    syncError = error
+                    syncError = sources.syncError
                 )
             }
         }
@@ -94,12 +103,11 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
      * 병합 규칙: 날짜 내림차순으로,
      * 일기가 있는 날 = 일기 카드 1개 / 없는 날 = 그날의 세션 카드 나열
      */
-    private suspend fun buildItems(
-        diaries: List<DiaryEntity>,
-        ranges: List<SessionRange>
-    ): List<DiaryDayItem> {
-        val diariesByDate = diaries.associateBy { it.date }
-        val sessionsByDate = ranges.groupBy { sessionDateKey(it.firstTimestamp) }
+    private suspend fun buildItems(sources: DiaryTabSources): List<DiaryDayItem> {
+        val diariesByDate = sources.diaries.associateBy { it.date }
+        val sessionsByDate = sources.ranges.groupBy {
+            resolveDateKey(it, sources.diaryDateByConversationId[it.conversationId])
+        }
         val allDates = (diariesByDate.keys + sessionsByDate.keys).sortedDescending()
 
         val items = mutableListOf<DiaryDayItem>()
@@ -112,7 +120,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 )
             } else {
                 sessionsByDate[date]?.forEach { range ->
-                    buildSessionSummary(messageDao, range)?.let {
+                    buildSessionSummary(messageDao, range, date)?.let {
                         items += DiaryDayItem.SessionCard(it)
                     }
                 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/SessionSummaries.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/SessionSummaries.kt
@@ -22,6 +22,17 @@ internal val KST: TimeZone = TimeZone.getTimeZone("Asia/Seoul")
 internal fun sessionDateKey(timestamp: Long): String =
     SimpleDateFormat("yyyy-MM-dd", Locale.KOREAN).apply { timeZone = KST }.format(Date(timestamp))
 
+/**
+ * 세션의 날짜 버킷 계산
+ *
+ * 서버가 /end 응답으로 확정해 준 diaryDate(ConversationDiaryLinkEntity)가 있으면
+ * 그 값을 우선 신뢰한다 (서버는 /end 호출 시점 기준 KST 날짜로 일기를 기록하므로 정확함).
+ * 매핑이 없는 세션(SKIPPED, 오프라인, 이 기능 이전의 과거 기록 등)은
+ * lastTimestamp(세션 종료 시각) 기반 휴리스틱으로 폴백한다.
+ */
+internal fun resolveDateKey(range: SessionRange, linkedDiaryDate: String?): String =
+    linkedDiaryDate ?: sessionDateKey(range.lastTimestamp)
+
 /** "yyyy-MM-dd" → "yyyy년 M월 d일 (E)" */
 internal fun formatKoreanDate(dateKey: String): String {
     val parser = SimpleDateFormat("yyyy-MM-dd", Locale.KOREAN).apply { timeZone = KST }
@@ -36,8 +47,15 @@ internal fun formatKoreanTime(timestamp: Long): String =
 /**
  * 세션의 메시지를 조회해 목록 카드용 요약 생성
  * (기존 대화기록 탭의 buildSummary 로직 이식)
+ *
+ * @param dateKey resolveDateKey()로 계산한 이 세션의 날짜 버킷 ("yyyy-MM-dd").
+ *   호출부에서 그룹핑에 쓴 것과 동일한 값을 넘겨야 카드에 표시되는 날짜와 버킷이 어긋나지 않는다.
  */
-internal suspend fun buildSessionSummary(messageDao: MessageDao, range: SessionRange): ConversationSummary? {
+internal suspend fun buildSessionSummary(
+    messageDao: MessageDao,
+    range: SessionRange,
+    dateKey: String
+): ConversationSummary? {
     val messages = messageDao.getMessagesByConversationIdOnce(range.conversationId)
     if (messages.isEmpty()) return null
 
@@ -50,7 +68,7 @@ internal suspend fun buildSessionSummary(messageDao: MessageDao, range: SessionR
 
     return ConversationSummary(
         conversationId = range.conversationId,
-        date = formatKoreanDate(sessionDateKey(first.timestamp)),
+        date = formatKoreanDate(dateKey),
         timeRange = "${formatKoreanTime(first.timestamp)} ~ ${formatKoreanTime(last.timestamp)}",
         durationMin = durationMin,
         previewText = preview

--- a/android/app/src/test/java/com/example/graduation_project/data/local/AppDatabaseMigrationTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/local/AppDatabaseMigrationTest.kt
@@ -1,0 +1,114 @@
+package com.example.graduation_project.data.local
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * AppDatabase Room 마이그레이션 회귀 테스트
+ *
+ * Room의 androidx.room:room-testing MigrationTestHelper는 이 프로젝트의 Room 2.8.4 +
+ * Robolectric 조합에서 "This driver is configured to open a database named..." 예외를
+ * 던지는 신규 SQLiteDriver 경로 관련 비호환 문제가 있어 사용할 수 없었다.
+ * 대신 순수 SupportSQLiteOpenHelper로 v3 스키마(app/schemas/.../3.json에 내보낸 실제
+ * CREATE TABLE 문 그대로)를 직접 구성하고, 프로덕션 MIGRATION_3_4를 그대로 실행해 검증한다.
+ *
+ * MIGRATION_3_4(conversation_diary_link 테이블 추가)가
+ * - 기존 messages/diaries 데이터를 보존하는지
+ * - 신규 테이블 컬럼이 ConversationDiaryLinkEntity(컬럼명/타입/NOT NULL)와 정확히 일치하는지
+ * 확인한다. 컬럼 타입/NOT NULL이 어긋나면 실기기에서 destructive fallback이 발동해
+ * 기존 메시지가 통째로 삭제될 수 있으므로, 이 테스트가 그 회귀를 막는다.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // targetSdk(36)이 로컬 Robolectric(4.14.1, 최대 API 35 지원)보다 앞서있어 명시 고정
+class AppDatabaseMigrationTest {
+
+    /** app/schemas/.../3.json에 내보낸 실제 v3 CREATE TABLE 문 (messages/location_points/diaries) */
+    private fun openV3Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(ApplicationProvider.getApplicationContext())
+            .name(null) // in-memory
+            .callback(object : SupportSQLiteOpenHelper.Callback(3) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `messages` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, " +
+                            "`role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))"
+                    )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `location_points` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                            "`latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `date` TEXT NOT NULL)"
+                    )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `diaries` (`date` TEXT NOT NULL, `serverId` INTEGER NOT NULL, " +
+                            "`title` TEXT, `content` TEXT, `status` TEXT NOT NULL, `failureReason` TEXT, `weather` TEXT, " +
+                            "`mood` TEXT, `updatedAt` TEXT, PRIMARY KEY(`date`))"
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+            })
+            .build()
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    @Test
+    fun `MIGRATION_3_4는 기존 messages diaries 데이터를 보존하고 conversation_diary_link 테이블을 정확히 만든다`() {
+        // given: v3 상태의 DB를 만들고 기존 데이터를 채운다
+        val db = openV3Database()
+        db.execSQL(
+            "INSERT INTO messages (id, conversationId, role, content, timestamp) " +
+                "VALUES ('m1', 'conv-1', 'user', '안녕하세요', 1000)"
+        )
+        db.execSQL(
+            "INSERT INTO diaries (date, serverId, title, content, status, failureReason, weather, mood, updatedAt) " +
+                "VALUES ('2026-01-15', 1, '1월 15일의 일기', '오늘 하루', 'SUCCESS', NULL, '맑음', NULL, '2026-01-15T20:00:00')"
+        )
+
+        // when: 프로덕션 코드의 MIGRATION_3_4를 그대로 실행
+        AppDatabase.MIGRATION_3_4.migrate(db)
+
+        // then: 기존 messages 데이터 보존
+        db.query("SELECT id, conversationId FROM messages").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("m1", cursor.getString(cursor.getColumnIndexOrThrow("id")))
+            assertEquals("conv-1", cursor.getString(cursor.getColumnIndexOrThrow("conversationId")))
+        }
+
+        // then: 기존 diaries 데이터 보존
+        db.query("SELECT date, status FROM diaries").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("2026-01-15", cursor.getString(cursor.getColumnIndexOrThrow("date")))
+            assertEquals("SUCCESS", cursor.getString(cursor.getColumnIndexOrThrow("status")))
+        }
+
+        // then: 신규 테이블 컬럼 구조가 ConversationDiaryLinkEntity와 정확히 일치하는지
+        // (PRAGMA table_info로 컬럼명/타입/NOT NULL을 직접 대조 - 이게 어긋나면 destructive fallback 위험)
+        val columns = mutableMapOf<String, Pair<String, Boolean>>() // name -> (type, notNull)
+        db.query("PRAGMA table_info(conversation_diary_link)").use { cursor ->
+            val nameIdx = cursor.getColumnIndexOrThrow("name")
+            val typeIdx = cursor.getColumnIndexOrThrow("type")
+            val notNullIdx = cursor.getColumnIndexOrThrow("notnull")
+            while (cursor.moveToNext()) {
+                columns[cursor.getString(nameIdx)] = cursor.getString(typeIdx) to (cursor.getInt(notNullIdx) == 1)
+            }
+        }
+        assertEquals(setOf("conversationId", "diaryDate"), columns.keys)
+        assertEquals("TEXT" to true, columns["conversationId"])
+        assertEquals("TEXT" to true, columns["diaryDate"])
+
+        // then: 실제 insert/query도 정상 동작
+        db.execSQL("INSERT INTO conversation_diary_link (conversationId, diaryDate) VALUES ('conv-1', '2026-01-15')")
+        db.query("SELECT diaryDate FROM conversation_diary_link WHERE conversationId = 'conv-1'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("2026-01-15", cursor.getString(0))
+        }
+
+        db.close()
+    }
+}

--- a/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
@@ -88,7 +88,9 @@ class ConversationViewModelTest {
         // android.util.Log은 JVM 단위 테스트에서 사용 불가 → static mock으로 대체
         mockkStatic(Log::class)
         every { Log.d(any(), any<String>()) } returns 0
+        every { Log.i(any(), any<String>()) } returns 0
         every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
         every { Log.e(any(), any<String>()) } returns 0
         every { Log.e(any(), any<String>(), any()) } returns 0
 

--- a/android/app/src/test/java/com/example/graduation_project/presentation/diary/SessionSummariesTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/diary/SessionSummariesTest.kt
@@ -1,0 +1,71 @@
+package com.example.graduation_project.presentation.diary
+
+import com.example.graduation_project.data.local.dao.MessageDao
+import com.example.graduation_project.data.local.dao.SessionRange
+import com.example.graduation_project.data.local.entity.MessageEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * resolveDateKey() / buildSessionSummary()의 날짜 계산 회귀 테스트
+ *
+ * 서버는 /end 호출 시점(대화 종료 시각) 기준 KST 날짜로 일기를 기록하므로,
+ * - 서버가 확정한 diaryDate(ConversationDiaryLinkEntity)가 있으면 그 값을 그대로 신뢰하고
+ * - 없으면(SKIPPED, 오프라인 등) lastTimestamp(마지막 메시지 시각) 휴리스틱으로 폴백해야
+ * 자정을 넘긴 대화에서 서버 일기 날짜와 어긋나지 않는다.
+ */
+class SessionSummariesTest {
+
+    private val mockMessageDao = mockk<MessageDao>()
+
+    // 첫 메시지 1/15 23:50 KST, 마지막 메시지 1/16 00:10 KST (자정 경계)
+    private val firstTimestamp = Instant.parse("2026-01-15T14:50:00Z").toEpochMilli()
+    private val lastTimestamp = Instant.parse("2026-01-15T15:10:00Z").toEpochMilli()
+    private val range = SessionRange(
+        conversationId = "conv-1",
+        firstTimestamp = firstTimestamp,
+        lastTimestamp = lastTimestamp
+    )
+
+    @Test
+    fun `resolveDateKey는 서버 diaryDate가 있으면 그 값을 그대로 사용한다`() {
+        // given: 서버가 이 세션을 1/17로 확정한 상황 (lastTimestamp 추정과는 다른 날짜)
+        val serverDiaryDate = "2026-01-17"
+
+        // when
+        val result = resolveDateKey(range, serverDiaryDate)
+
+        // then
+        assertEquals(serverDiaryDate, result)
+    }
+
+    @Test
+    fun `resolveDateKey는 diaryDate 매핑이 없으면 lastTimestamp 기준으로 폴백한다`() {
+        // when: 매핑 없음(null) - SKIPPED이거나 아직 /end 응답을 못 받은 세션
+        val result = resolveDateKey(range, linkedDiaryDate = null)
+
+        // then: 자정을 넘긴 대화이므로 1/15가 아니라 1/16(lastTimestamp 날짜)이어야 함
+        assertEquals("2026-01-16", result)
+    }
+
+    @Test
+    fun `buildSessionSummary는 전달받은 dateKey를 그대로 표시 날짜로 사용한다`() = runTest {
+        // given
+        val messages = listOf(
+            MessageEntity("m1", "conv-1", MessageEntity.ROLE_USER, "안녕하세요", firstTimestamp),
+            MessageEntity("m2", "conv-1", MessageEntity.ROLE_ASSISTANT, "안녕하세요, 오늘 하루 어떠셨나요?", lastTimestamp)
+        )
+        coEvery { mockMessageDao.getMessagesByConversationIdOnce("conv-1") } returns messages
+
+        // when: 호출부(DiaryViewModel)가 그룹핑에 쓴 것과 동일한 dateKey를 전달
+        val summary = buildSessionSummary(mockMessageDao, range, dateKey = "2026-01-17")
+
+        // then: buildSessionSummary가 내부적으로 다시 계산하지 않고 전달받은 dateKey를 그대로 반영해야
+        // 목록 그룹핑과 카드에 표시되는 날짜가 항상 일치함
+        assertEquals(formatKoreanDate("2026-01-17"), summary?.date)
+    }
+}

--- a/server/src/main/java/com/example/echo/conversation/dto/ConversationEndResponse.java
+++ b/server/src/main/java/com/example/echo/conversation/dto/ConversationEndResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Schema(description = "대화 종료 응답")
@@ -22,4 +23,9 @@ public class ConversationEndResponse {
 
     @Schema(description = "일기 생성 실패 사유 (성공·스킵 시 null)", example = "AI 일기 생성 실패: 상태코드 401")
     private String diaryError;
+
+    @Schema(description = "이번 대화가 기록된 일기 날짜(Asia/Seoul 기준, SKIPPED 시 null). " +
+            "클라이언트가 일기 탭에서 이 대화 세션을 날짜별로 묶을 때 로컬 타임스탬프 추정 대신 이 값을 신뢰해야 함",
+            example = "2026-03-07")
+    private LocalDate diaryDate;
 }

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 @Slf4j
@@ -143,6 +144,7 @@ public class ConversationService {
         String diaryStatus;
         Long diaryId = null;
         String diaryError = null;
+        LocalDate diaryDate = null;
 
         try {
             // 1. 컨텍스트 조회
@@ -157,6 +159,8 @@ public class ConversationService {
                 diaryStatus = diary.getStatus().name();
                 diaryId = diary.getId();
                 diaryError = diary.getFailureReason();
+                // 클라이언트가 이 세션을 일기 탭에서 로컬 타임스탬프 추정 대신 신뢰할 수 있도록 전달
+                diaryDate = diary.getDiaryDate();
             }
         } catch (Exception e) {
             log.error("일기 생성 실패 - userId: {}", userId, e);
@@ -174,6 +178,7 @@ public class ConversationService {
                 .diaryStatus(diaryStatus)
                 .diaryId(diaryId)
                 .diaryError(diaryError)
+                .diaryDate(diaryDate)
                 .build();
     }
 }

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -276,9 +276,10 @@ class ConversationServiceTest2 {
         @DisplayName("성공: 일기 생성 성공 시 응답에 diaryStatus=SUCCESS와 diaryId가 담긴다")
         void success_responseContainsDiaryStatus() {
             // given
+            LocalDate diaryDate = LocalDate.now();
             Diary diary = Diary.builder()
                     .userId(userId)
-                    .diaryDate(LocalDate.now())
+                    .diaryDate(diaryDate)
                     .content("오늘의 일기")
                     .status(DiaryStatus.SUCCESS)
                     .build();
@@ -293,6 +294,8 @@ class ConversationServiceTest2 {
             assertThat(response.getDiaryStatus()).isEqualTo("SUCCESS");
             assertThat(response.getDiaryError()).isNull();
             assertThat(response.getEndedAt()).isNotNull();
+            // 클라이언트가 일기 탭 날짜 버킷을 서버 값으로 신뢰할 수 있도록 diaryDate가 그대로 담겨야 함
+            assertThat(response.getDiaryDate()).isEqualTo(diaryDate);
         }
 
         @Test
@@ -333,6 +336,7 @@ class ConversationServiceTest2 {
             assertThat(response.getDiaryStatus()).isEqualTo("SKIPPED");
             assertThat(response.getDiaryId()).isNull();
             assertThat(response.getDiaryError()).isNull();
+            assertThat(response.getDiaryDate()).isNull();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Sonnet 5 서브에이전트 코드 리뷰(일기 탭 기능)에서 발견된 버그 수정
- Android가 로컬 대화 세션의 날짜 버킷을 세션 시작 시각(`firstTimestamp`)으로 추정했는데, 서버는 `/end` 호출 시점(대화 종료 시각) 기준 KST 날짜로 일기를 기록해서, 자정을 넘긴 대화에서 같은 대화가 서버 일기와 다른 날짜의 세션 카드로 중복 표시되던 문제
- 서버 `ConversationEndResponse`에 `diaryDate` 필드 추가 — 클라이언트가 이 세션이 실제로 어느 날짜에 기록됐는지 신뢰할 수 있는 값 제공
- Android에 `conversation_diary_link`(conversationId → diaryDate) Room 테이블 신설(마이그레이션 3→4). `DiaryViewModel`/`DiaryDetailScreen`이 이 매핑을 우선 신뢰하고, 매핑이 없는 세션(SKIPPED, 오프라인 등)은 기존 `lastTimestamp` 휴리스틱으로 폴백
- Room `exportSchema`를 켜고 실제 v3/v4 스키마 기반 마이그레이션 회귀 테스트 추가 — 컬럼 타입/NOT NULL 불일치 시 destructive fallback으로 기존 메시지가 삭제되는 위험을 방지
- (부수적으로 발견한 무관한 사전 존재 버그도 수정: `ConversationViewModelTest`에 `Log.i`/`Log.w`(3-arg) mock이 빠져있어 `endConversation` 관련 테스트 3개가 develop에서도 이미 실패하고 있었음)

## Test plan
- [x] `AppDatabaseMigrationTest` — 마이그레이션 3→4가 기존 messages/diaries 데이터를 보존하고 신규 테이블 컬럼이 엔티티와 정확히 일치하는지 검증
- [x] `SessionSummariesTest` — `resolveDateKey`가 서버 diaryDate를 우선 신뢰하고, 없으면 lastTimestamp로 폴백하는지 검증
- [x] `ConversationServiceTest2` — 응답의 diaryDate 필드 검증
- [x] `./gradlew testLocalDebugUnitTest` 전체 통과 (188 tests)
- [x] `./gradlew assembleLocalDebug` 통과
- [x] `./gradlew test` (서버, conversation/diary 패키지) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaArTGhszEAWffypfXFdWx