### PR TITLE
fix(diary-tab): 일기 갱신 실패와 완전 실패를 뱃지로 구분 표시

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/repository/DiaryRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/DiaryRepository.kt
@@ -1,5 +1,6 @@
 package com.example.graduation_project.data.repository
 
+import android.util.Log
 import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.api.DiaryApi
@@ -46,15 +47,25 @@ class DiaryRepository(
      */
     suspend fun getDiaryByDate(date: String): DiaryEntity? = diaryDao.getByDate(date)
 
-    private fun Diary.toEntity() = DiaryEntity(
-        date = date,
-        serverId = id,
-        title = title,
-        content = content,
-        status = status,
-        failureReason = failureReason,
-        weather = weather,
-        mood = mood,
-        updatedAt = updatedAt
-    )
+    private fun Diary.toEntity(): DiaryEntity {
+        if (status == "FAILED" && failureReason != null) {
+            // UI는 원문 대신 안내 문구만 보여주므로, 실제 사유는 여기서만 남김
+            Log.w(TAG, "일기 생성/갱신 실패: date=$date reason=$failureReason")
+        }
+        return DiaryEntity(
+            date = date,
+            serverId = id,
+            title = title,
+            content = content,
+            status = status,
+            failureReason = failureReason,
+            weather = weather,
+            mood = mood,
+            updatedAt = updatedAt
+        )
+    }
+
+    companion object {
+        private const val TAG = "DiaryRepository"
+    }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
@@ -191,7 +191,8 @@ fun DiaryDetailScreen(
 @Composable
 private fun DiaryContentCard(diary: DiaryEntity?) {
     val colors = LocalEchoColors.current
-    val isFailed = diary?.status == "FAILED"
+    val hasStaleContent = diary?.status == "FAILED" && diary.content != null
+    val isTotalFailure = diary?.status == "FAILED" && diary.content == null
 
     Surface(
         modifier = Modifier
@@ -217,7 +218,9 @@ private fun DiaryContentCard(diary: DiaryEntity?) {
                     fontFamily = OutfitFontFamily,
                     color = colors.textPrimary
                 )
-                if (isFailed) {
+                if (hasStaleContent) {
+                    FailureBadge(text = "갱신 실패", backgroundColor = colors.accentBlue)
+                } else if (isTotalFailure) {
                     FailureBadge()
                 }
             }
@@ -246,11 +249,19 @@ private fun DiaryContentCard(diary: DiaryEntity?) {
                     color = colors.textTertiary
                 )
             }
-            // 디버깅 단계: 실패 사유를 상세 화면에 그대로 노출
-            if (isFailed && diary?.failureReason != null) {
+            if (hasStaleContent) {
                 Spacer(Modifier.height(12.dp))
                 Text(
-                    text = "실패 사유: ${diary.failureReason}",
+                    text = "오늘 대화 내용이 아직 반영되지 않았어요.",
+                    fontSize = 14.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = colors.accentBlue,
+                    lineHeight = 20.sp
+                )
+            } else if (isTotalFailure) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "일기를 만들지 못했어요. 잠시 후 다시 확인해 주세요.",
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
                     color = colors.accentRed,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryScreen.kt
@@ -131,7 +131,8 @@ private fun DiaryCard(
     onClick: () -> Unit
 ) {
     val colors = LocalEchoColors.current
-    val isFailed = diary.status == "FAILED"
+    val hasStaleContent = diary.status == "FAILED" && diary.content != null
+    val isTotalFailure = diary.status == "FAILED" && diary.content == null
 
     Surface(
         modifier = Modifier
@@ -158,7 +159,9 @@ private fun DiaryCard(
                     fontFamily = OutfitFontFamily,
                     color = colors.textPrimary
                 )
-                if (isFailed) {
+                if (hasStaleContent) {
+                    FailureBadge(text = "갱신 실패", backgroundColor = colors.accentBlue)
+                } else if (isTotalFailure) {
                     FailureBadge()
                 }
             }
@@ -191,10 +194,19 @@ private fun DiaryCard(
                     lineHeight = 26.sp
                 )
             }
-            if (isFailed && diary.failureReason != null) {
+            if (hasStaleContent) {
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = diary.failureReason,
+                    text = "오늘 대화 내용이 아직 반영되지 않았어요.",
+                    fontSize = 14.sp,
+                    fontFamily = OutfitFontFamily,
+                    color = colors.accentBlue,
+                    maxLines = 1
+                )
+            } else if (isTotalFailure) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "일기를 만들지 못했어요. 잠시 후 다시 확인해 주세요.",
                     fontSize = 14.sp,
                     fontFamily = OutfitFontFamily,
                     color = colors.accentRed,
@@ -206,17 +218,20 @@ private fun DiaryCard(
 }
 
 @Composable
-internal fun FailureBadge() {
+internal fun FailureBadge(
+    text: String = "일기 생성 실패",
+    backgroundColor: Color? = null
+) {
     val colors = LocalEchoColors.current
     Text(
-        text = "일기 생성 실패",
+        text = text,
         fontSize = 12.sp,
         fontWeight = FontWeight.SemiBold,
         fontFamily = OutfitFontFamily,
         color = Color.White,
         modifier = Modifier
             .clip(RoundedCornerShape(8.dp))
-            .background(colors.accentRed)
+            .background(backgroundColor ?: colors.accentRed)
             .padding(horizontal = 8.dp, vertical = 2.dp)
     )
 }


### PR DESCRIPTION
## Summary
- `DiaryScreen.kt`/`DiaryDetailScreen.kt`: FAILED 상태에서 이전 content가 남아있는 경우(갱신만 실패)와 content가 없는 경우(완전 실패)를 시각적으로 구분. content 있음 → 파랑 "갱신 실패" 뱃지 + "오늘 대화 내용이 아직 반영되지 않았어요." / content 없음 → 기존 빨강 "일기 생성 실패" 뱃지 + "일기를 만들지 못했어요. 잠시 후 다시 확인해 주세요."
- 서버 에러 원문(`failureReason`)을 사용자 화면에 그대로 노출하던 부분(디버깅 단계 코드)을 제거하고 고정 안내 문구로 대체
- `DiaryRepository.toEntity()`에서 FAILED + failureReason이면 `Log.w`로 원문을 Logcat에만 남기도록 추가

## Background
QA 리뷰(`docs/diary-tab-qa-plan.md`) 4.1에서 발견된 이슈: `Diary.markFailed`(서버)가 content를 보존하는 것 자체는 의도적이나, Android 쪽에서 FAILED 뱃지 + 멀쩡한 이전 일기 본문이 동시에 노출돼 경도인지장애 어르신 사용자가 자신의 기록이 손상됐다고 오인할 수 있는 접근성 문제였음. 서버 계약/스키마 변경 없이 클라이언트 표시 로직만 수정.

## Test plan
- [x] `./gradlew compileLocalDebugKotlin` 통과
- [x] `./gradlew assembleLocalDebug` 통과
- [x] 에뮬레이터(Medium_Phone_API_36)에 로컬 Room DB로 두 케이스(FAILED+content / FAILED+no content) 시딩 후 일기 목록·상세 화면 스크린샷으로 직접 확인 — 의도한 배지 색상·문구 정상 표시

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KaArTGhszEAWffypfXFdWx