### PR TITLE
test(diary): DiaryService 동시성 재시도·이중 실패 시나리오 테스트 추가

### DIFF
--- a/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -163,5 +165,81 @@ class DiaryServiceTest {
         assertThat(result).isNull();
         verifyNoInteractions(aiService);
         verify(diaryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 저장 시 경합이 발생하면 재조회 후 갱신하여 SUCCESS로 저장한다")
+    void generateAndSaveDiary_retriesAndSucceedsOnConcurrentInsert() {
+        // given
+        UserContext context = contextWithUserMessage();
+        Diary racedDiary = Diary.builder()
+                .userId(TEST_USER_ID)
+                .diaryDate(TODAY)
+                .title("경합 상대가 만든 일기")
+                .content("경합 상대가 저장한 내용")
+                .status(DiaryStatus.SUCCESS)
+                .build();
+        when(diaryRepository.findByUserIdAndDiaryDate(TEST_USER_ID, TODAY))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(racedDiary));
+        when(promptService.buildDiaryPrompt(eq(context), isNull())).thenReturn("일기 프롬프트");
+        when(aiService.generateDiary("일기 프롬프트")).thenReturn("재시도로 저장된 새 내용");
+        when(diaryRepository.save(any(Diary.class)))
+                .thenThrow(new DataIntegrityViolationException("unique constraint violated"))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        Diary result = diaryService.generateAndSaveDiary(context);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(DiaryStatus.SUCCESS);
+        assertThat(result.getContent()).isEqualTo("재시도로 저장된 새 내용");
+        verify(diaryRepository, times(2)).findByUserIdAndDiaryDate(TEST_USER_ID, TODAY);
+        verify(diaryRepository, times(2)).save(any(Diary.class));
+    }
+
+    @Test
+    @DisplayName("경합 재시도 조회마저 실패하면 원래 예외가 전파되어 FAILED로 기록된다")
+    void generateAndSaveDiary_marksFailedWhenRetryAlsoFindsNothing() {
+        // given
+        UserContext context = contextWithUserMessage();
+        when(diaryRepository.findByUserIdAndDiaryDate(TEST_USER_ID, TODAY))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.empty());
+        when(promptService.buildDiaryPrompt(eq(context), isNull())).thenReturn("일기 프롬프트");
+        when(aiService.generateDiary("일기 프롬프트")).thenReturn("생성된 내용");
+        when(diaryRepository.save(any(Diary.class)))
+                .thenThrow(new DataIntegrityViolationException("unique constraint violated"))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        Diary result = diaryService.generateAndSaveDiary(context);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(DiaryStatus.FAILED);
+        assertThat(result.getFailureReason()).contains("unique constraint violated");
+        verify(diaryRepository, times(2)).findByUserIdAndDiaryDate(TEST_USER_ID, TODAY);
+        verify(aiService, times(1)).generateDiary(anyString());
+    }
+
+    @Test
+    @DisplayName("AI 생성 실패 후 실패 기록 저장마저 실패하면 예외를 던지지 않고 null을 반환한다")
+    void generateAndSaveDiary_returnsNullWhenFailureRecordSaveAlsoFails() {
+        // given
+        UserContext context = contextWithUserMessage();
+        when(diaryRepository.findByUserIdAndDiaryDate(TEST_USER_ID, TODAY)).thenReturn(Optional.empty());
+        when(promptService.buildDiaryPrompt(eq(context), isNull())).thenReturn("일기 프롬프트");
+        when(aiService.generateDiary("일기 프롬프트")).thenThrow(new AIException("AI 일기 생성 실패: 401"));
+        when(diaryRepository.save(any(Diary.class)))
+                .thenThrow(new DataAccessResourceFailureException("DB connection lost"));
+
+        // when
+        Diary result = diaryService.generateAndSaveDiary(context);
+
+        // then
+        assertThat(result).isNull();
+        verify(diaryRepository, times(1)).save(any(Diary.class));
     }
 }


### PR DESCRIPTION
## Summary
- `DiaryServiceTest.java`에 회귀 테스트 3종 추가 (기존 4종 + 신규 3종 = 7종 전부 통과)
  1. `generateAndSaveDiary_retriesAndSucceedsOnConcurrentInsert` — 신규 저장 시 유니크 제약 경합(`DataIntegrityViolationException`) 발생 시 재조회 후 갱신하여 SUCCESS로 저장되는지
  2. `generateAndSaveDiary_marksFailedWhenRetryAlsoFindsNothing` — 재시도 조회마저 빈 값이면 원래 예외가 전파되어 바깥 catch에서 FAILED로 정상 처리되는지
  3. `generateAndSaveDiary_returnsNullWhenFailureRecordSaveAlsoFails` — AI 생성 실패 후 실패 기록 저장(`saveFailure`)마저 실패하면 예외 없이 `null`을 반환하는지 (스킵 케이스와 구분 안 되는 그 `null` — 현재 동작을 테스트로 고정)

## Background
`docs/diary-tab-qa-plan.md` 4.1절에서 지적된 두 방어 로직(경합 재시도, 실패 기록 이중 실패)이 코드 리뷰로는 정합성이 확인됐지만 회귀를 막아줄 테스트가 없었음. 실행 계획은 `docs/diary-service-test-coverage-plan.md` 참고.

**스코프 밖**: `develop`은 아직 `fix/diary-skip-vs-fail-status`(반환 타입을 `Diary`→`DiaryOutcome`으로 바꾸는 별도 PR, 미승인)가 머지되지 않은 상태라 이 PR은 그 리팩터링에 의존하지 않고 현재 `Diary` nullable 반환 기준으로 작성함. Room DB 마이그레이션(Android, SQLCipher) 테스트도 별도 이슈로 분리.

## Test plan
- [x] `./gradlew test --tests "com.example.echo.diary.service.DiaryServiceTest"` — 7/7 통과
- [x] `./gradlew test` (서버 전체) — 신규/기존 diary 테스트 포함 정상 통과 확인. 실패한 15개는 로컬 환경에 `kakao.api.key`/`weather.api.key`가 없어서 Spring 컨텍스트가 못 뜨는 기존 통합 테스트들로, 이번 변경과 무관 (환경 미비로 별도 트래킹)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KaArTGhszEAWffypfXFdWx