### PR TITLE
fix(android): 권한 다이얼로그 표시 중 대화가 진행되던 문제 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -29,7 +29,10 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -103,11 +106,6 @@ fun ConversationScreen(
         }
     }
 
-    // 화면 진입 시 자동으로 대화 시작
-    LaunchedEffect(Unit) {
-        viewModel.startConversation()
-    }
-
     // Ended 상태가 되면 웨이브 애니메이션 + 작별 메시지를 보여준 후 뒤로 이동
     LaunchedEffect(uiState.conversationState) {
         if (uiState.conversationState is ConversationState.Ended) {
@@ -116,7 +114,22 @@ fun ConversationScreen(
         }
     }
 
+    // 자동 시작은 화면당 1회만. 권한 다이얼로그로 content가 컴포지션에서 빠졌다가
+    // 다시 들어오거나(설정 왕복), 회전으로 컴포지션이 재생성돼도 재발화하지 않도록
+    // 플래그를 권한 게이트 "바깥"에 둔다.
+    var autoStartRequested by rememberSaveable { mutableStateOf(false) }
+
     UnifiedPermissionHandler {
+        // 권한 흐름이 끝나고 마이크 권한이 확인된 뒤에만 컴포즈되므로,
+        // 세션 생성 / 알림 취소 / 위치·건강 수집 / TTS 재생이 권한 다이얼로그
+        // 뒤에서 선행 실행되지 않는다.
+        LaunchedEffect(Unit) {
+            if (!autoStartRequested) {
+                autoStartRequested = true
+                viewModel.startConversation()
+            }
+        }
+
         ConversationScreenContent(
             uiState = uiState,
             snackbarHostState = snackbarHostState,


### PR DESCRIPTION
## 문제

앱 수동 실행 중 발견. 홈에서 대화 시작 시 권한 요청 다이얼로그가 떠 있는 동안 이미 대화가 진행되고 있었다.

원인은 `ConversationScreen.kt`의 자동 시작 `LaunchedEffect(Unit)`이 권한 게이트 `UnifiedPermissionHandler` 블록 바깥에 있었기 때문. 권한 핸들러가 막는 것은 `content()`(화면 UI)뿐이고, 대화 세션 자체는 화면이 컴포즈되는 순간 무조건 시작됐다. 그래서 권한 다이얼로그가 떠 있는 동안 아래가 다이얼로그 뒤에서 먼저 진행됨:

- `ConversationAlarmReceiver.cancelNotification()` — 대화 알림 취소 (비가역)
- 위치/건강 데이터 수집
- `repository.startConversation(...)` — 서버 세션 생성
- `playAiAudio()` — TTS 스피커 재생

마이크 권한이 없어도 `startConversation()`은 실패하지 않아, 서버 세션·TTS는 그대로 진행되고 `startRecording()`에서만 재시도 후 실패 안내가 떴다.

도입 시점: PR #318 (`b71734c`, 2026-05-16). 중복 시작 화면을 없애려 자동 시작을 넣으면서 게이트보다 바깥에 배치됨.

## 수정

- 자동 시작 `LaunchedEffect`를 `UnifiedPermissionHandler`의 content 람다 **안**으로 이동. `content()`는 권한 흐름이 끝나고 마이크 권한이 확인된 뒤에만 컴포즈되므로 정확한 게이트가 된다.
- `onAllPermissionsHandled` 콜백은 사용하지 않음 — 호출 지점이 전부 HEALTH_CONNECT 단계를 통과해야 도달 가능한데, 이미 온보딩을 마친 사용자(대다수 실사용)는 `hasCompletedOnboarding` early-return 경로로 빠져 콜백이 절대 호출되지 않는다. 콜백 기반으로 고쳤다면 기존 사용자의 대화가 영영 시작되지 않는 회귀가 생겼을 것.
- 화면당 1회 시작을 보장하기 위해 `rememberSaveable` 플래그(`autoStartRequested`)를 게이트 **바깥**에 선언. 설정 앱 왕복(마이크 회수→재허용)이나 회전으로 content가 재진입해도 중복 시작을 막는다. 특히 `Ended` 상태에서 회전 시 `resetToIdle()`이 재진입 가드를 뚫어 새 세션이 생성되는 경로를 막는다.
- 백그라운드/포그라운드 처리, keepScreenOn, 에러 스낵바, Ended→뒤로가기 이펙트는 그대로 게이트 바깥에 유지 (근거는 커밋/코드 주석 참고 — 예: 백그라운드 이펙트를 게이트 안으로 옮기면 대화 중 content가 빠질 때 마이크·스피커가 계속 살아있게 됨).
- 범위: `ConversationScreen.kt` 1개 파일만 수정 (+18/-5줄). 권한 상태머신(`PermissionStep`), `PermissionChecker`, ViewModel은 무수정.

## 동작 변화 (의도된 것)

자동 시작이 실패해 Idle로 돌아온 뒤 화면을 회전하면, 이전에는 자동 재시도됐지만 이제는 되지 않는다. Idle 상태에서는 "대화 시작" 버튼이 노출되므로 사용자가 직접 재시도할 수 있다.

## 검증

- `./gradlew testLocalDebugUnitTest` — `ConversationViewModelTest`의 `endConversation` 관련 3개 실패는 원본(develop) 코드에서도 동일하게 재현됨을 확인(`android.util.Log` mockk 미모킹 이슈, 이번 변경과 무관, 범위 밖).
- 실기기 수동 검증 완료 (신규 설치 시 권한 다이얼로그 중 대화 미시작, 온보딩 완료 사용자 정상 자동 시작 등).

## 범위 밖

- exact-alarm 설정 화면의 fire-and-forget `startActivity` (`UnifiedPermissionHandler.kt`) — 같은 증상을 악화시키지만 성격이 달라 별도 이슈로 분리
- `HealthConnectPermissionSettingsDialog` onDismiss의 `onAllPermissionsHandled()` 누락 (현재 죽은 분기)