### PR TITLE
fix: enum 컬럼을 VARCHAR로 매핑해 운영 배포 실패 재발 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,13 @@ jobs:
                 --query "StandardOutputContent" --output text
               exit 0
             elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "--- StandardOutput (deploy.sh 진행 로그 + 컨테이너 로그) ---"
+              aws ssm get-command-invocation \
+                --region $AWS_REGION \
+                --command-id $COMMAND_ID \
+                --instance-id $EC2_INSTANCE_ID \
+                --query "StandardOutputContent" --output text
+              echo "--- StandardError ---"
               aws ssm get-command-invocation \
                 --region $AWS_REGION \
                 --command-id $COMMAND_ID \

--- a/server/src/main/java/com/example/echo/diary/entity/Diary.java
+++ b/server/src/main/java/com/example/echo/diary/entity/Diary.java
@@ -53,8 +53,12 @@ public class Diary {
     @Column(name = "weather", length = 100)
     private String weather;
 
+    /**
+     * columnDefinition을 지정하지 않으면 Hibernate가 네이티브 ENUM 컬럼을 만들어
+     * DiaryStatus에 값이 추가될 때마다 운영 DB에 ALTER가 필요해지므로 VARCHAR로 고정한다.
+     */
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
+    @Column(name = "status", nullable = false, length = 20, columnDefinition = "varchar(20)")
     private DiaryStatus status;
 
     @Column(name = "failure_reason", length = 500)

--- a/server/src/main/java/com/example/echo/prompt/entity/PromptTemplate.java
+++ b/server/src/main/java/com/example/echo/prompt/entity/PromptTemplate.java
@@ -37,11 +37,14 @@ public class PromptTemplate {
     private Long id;
 
     /**
-     * 프롬프트 타입 (SYSTEM, CONVERSATION, DIARY)
+     * 프롬프트 타입 (SYSTEM, CONVERSATION, DIARY, MEMORY)
      * DB에는 문자열로 저장됨 (EnumType.STRING)
+     *
+     * columnDefinition을 지정하지 않으면 Hibernate가 네이티브 ENUM 컬럼을 만들어
+     * PromptType에 값이 추가될 때마다 운영 DB에 ALTER가 필요해지므로 VARCHAR로 고정한다.
      */
     @Enumerated(EnumType.STRING)
-    @Column(name = "template_type", nullable = false)
+    @Column(name = "template_type", nullable = false, length = 20, columnDefinition = "varchar(20)")
     private PromptType type;
 
     /**


### PR DESCRIPTION
## 배경

PR #384(L3 장기기억) 머지 후 자동배포(run #50)가 실패했습니다. 빌드·ECR 푸시·컨테이너 실행까지 모두 성공했으나 앱이 부팅 중 죽어 헬스체크가 통과하지 못했습니다.

```
Caused by: java.sql.SQLException: Data truncated for column 'template_type' at row 1
```

원인:

- `PromptType`에 `MEMORY`가 추가됨
- Hibernate는 `@Enumerated(STRING)` 컬럼을 **네이티브 MySQL ENUM**으로 생성함 → 운영 컬럼이 `enum('CONVERSATION','DIARY','SYSTEM')`
- `ddl-auto: update`는 기존 컬럼 타입을 ALTER하지 않음(데이터 보호를 위한 의도된 동작)
- `sql.init.mode: always`라 부팅마다 `data.sql`이 실행되고, `MEMORY` INSERT가 MySQL 에러 1265로 실패

운영 DB에 ENUM 값을 추가해 복구는 완료했습니다(헬스체크 200 확인). 이 PR은 **같은 장애가 반복되는 구조 자체를 제거**합니다.

## 변경 사항

1. `PromptTemplate.type` → `columnDefinition = varchar(20)`
2. `Diary.status` → 동일 적용 (아직 장애로 드러나지 않았을 뿐 원인이 같음)
3. `deploy.yml` 배포 실패 시 SSM `StandardOutput`도 출력

`length`만으로는 네이티브 ENUM 생성을 막지 못합니다. 생성 DDL로 확인했습니다.

| | 변경 전 | 변경 후 |
|---|---|---|
| `prompt_templates.template_type` | `enum('CONVERSATION','DIARY','MEMORY','SYSTEM')` | `varchar(20)` |
| `diaries.status` | `enum('FAILED','SUCCESS')` | `varchar(20)` |

## ⚠️ 머지 후 필요한 작업 (DB)

코드 변경만으로는 기존 컬럼이 바뀌지 않습니다(`ddl-auto: update`는 ALTER 안 함). **운영 DB와 각자 로컬 DB에 1회 실행**해야 합니다.

```sql
ALTER TABLE prompt_templates MODIFY template_type VARCHAR(20) NOT NULL;
ALTER TABLE diaries MODIFY status VARCHAR(20) NOT NULL;
```

배포 전/후 어느 시점에 실행해도 무방합니다. `VARCHAR(20)`은 기존 값을 모두 수용합니다.

## 검증

- 생성 DDL에서 두 컬럼 모두 `varchar(20) not null` 확인
- `MemoryServicePersistenceTest` 통과
- 전체 `./gradlew test`는 15건 실패하나, 전부 `Could not resolve placeholder ''openrouter.api.key''`로 인한 컨텍스트 로드 실패로 **본 변경과 무관한 기존 로컬 환경 문제**입니다

## 범위 밖

- Flyway/Liquibase 도입 + `ddl-auto: validate` 전환 (베타 전 별도 작업 제안)
- CI의 `-x test` 제거 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)