### PR TITLE
fix: RDS 엔드포인트 변경(싱가포르 리전) 및 weather api 추가

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -49,3 +49,5 @@ application-dev.yaml
 .env
 nul
 .run/
+*.pem
+*.ppk

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
-    url: jdbc:mysql://echo-db.cd6842c0wli8.ap-northeast-2.rds.amazonaws.com:3306/echo_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
-    username: echouser
+    url: jdbc:mysql://echo-db.cjckiucsc2mo.ap-southeast-1.rds.amazonaws.com:3306/echo_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    username: admin
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
@@ -47,3 +47,8 @@ supertone:
 
 server:
   forward-headers-strategy: native
+
+weather:
+  api:
+    url: https://api.openweathermap.org
+    key: ${OPENWEATHER_API_KEY}

--- a/server/src/main/resources/application-prod.yaml
+++ b/server/src/main/resources/application-prod.yaml
@@ -17,6 +17,9 @@ spring:
     init:
       mode: always
 
+jwt:
+  secret: ${JWT_SECRET}
+
 openai:
   api:
     key: ${OPENAI_API_KEY}


### PR DESCRIPTION
## Summary
- RDS 인스턴스 리전 이전(ap-northeast-2 → ap-southeast-1)에 따른 엔드포인트/username(admin) 갱신
- weather api 설정 추가
- 로컬 SSH 개인키 파일(.pem, .ppk)이 실수로 커밋되지 않도록 .gitignore에 추가

## Test plan
- [ ] application-prod.yaml의 새 RDS 엔드포인트로 배포 후 정상 연결 확인
- [ ] weather api 설정 값 정상 로드 확인