### PR TITLE
feat: 일기 탭 첫 화면을 월간 캘린더 UI로 전환

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/api/DiaryApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/DiaryApi.kt
@@ -13,6 +13,15 @@ interface DiaryApi {
     @GET("/api/diaries")
     suspend fun getDiaries(@Query("days") days: Int = 30): List<Diary>
 
+    /**
+     * 날짜 범위(양끝 포함) 일기 목록 조회 (날짜 내림차순) - 캘린더 월 조회용
+     */
+    @GET("/api/diaries")
+    suspend fun getDiariesInRange(
+        @Query("startDate") startDate: String,
+        @Query("endDate") endDate: String
+    ): List<Diary>
+
     @GET("/api/diaries/{id}")
     suspend fun getDiary(@Path("id") id: Long): Diary
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/local/dao/DiaryDao.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/dao/DiaryDao.kt
@@ -34,4 +34,11 @@ interface DiaryDao {
      */
     @Query("SELECT * FROM diaries WHERE date = :date")
     suspend fun getByDate(date: String): DiaryEntity?
+
+    /**
+     * 날짜 범위(양끝 포함) 일기 조회 (최신 날짜순)
+     * - 일기 탭 캘린더에서 현재 보는 달만 관찰할 때 사용
+     */
+    @Query("SELECT * FROM diaries WHERE date BETWEEN :start AND :end ORDER BY date DESC")
+    fun observeByDateRange(start: String, end: String): Flow<List<DiaryEntity>>
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/DiaryRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/DiaryRepository.kt
@@ -9,6 +9,8 @@ import com.example.graduation_project.data.local.dao.DiaryDao
 import com.example.graduation_project.data.local.entity.DiaryEntity
 import com.example.graduation_project.data.model.Diary
 import kotlinx.coroutines.flow.Flow
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 
 /**
  * 일기 저장소
@@ -38,9 +40,34 @@ class DiaryRepository(
     }
 
     /**
+     * 서버에서 지정한 달(1일~말일) 일기를 받아 로컬 캐시 갱신
+     * 일기 탭 캘린더에서 달 이동 시 호출 - 실패 시 캐시는 그대로 유지됨
+     */
+    suspend fun refreshMonth(yearMonth: YearMonth): ApiResult<Unit> {
+        val startDate = yearMonth.atDay(1).format(DATE_FORMATTER)
+        val endDate = yearMonth.atEndOfMonth().format(DATE_FORMATTER)
+        return when (val result = safeApiCall { diaryApi.getDiariesInRange(startDate, endDate) }) {
+            is ApiResult.Success -> {
+                diaryDao.upsertAll(result.data.map { it.toEntity() })
+                ApiResult.Success(Unit)
+            }
+            is ApiResult.Error -> result
+        }
+    }
+
+    /**
      * 로컬 캐시의 일기 목록 구독 (최신 날짜순)
      */
     fun observeDiaries(): Flow<List<DiaryEntity>> = diaryDao.observeAll()
+
+    /**
+     * 지정한 달(1일~말일)의 캐시된 일기 구독 - 일기 탭 캘린더에서 사용
+     */
+    fun observeMonth(yearMonth: YearMonth): Flow<List<DiaryEntity>> {
+        val startDate = yearMonth.atDay(1).format(DATE_FORMATTER)
+        val endDate = yearMonth.atEndOfMonth().format(DATE_FORMATTER)
+        return diaryDao.observeByDateRange(startDate, endDate)
+    }
 
     /**
      * 특정 날짜의 캐시된 일기 조회
@@ -67,5 +94,6 @@ class DiaryRepository(
 
     companion object {
         private const val TAG = "DiaryRepository"
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
     }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryScreen.kt
@@ -8,19 +8,33 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,16 +46,24 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.data.local.entity.DiaryEntity
 import com.example.graduation_project.presentation.model.ConversationSummary
+import com.example.graduation_project.ui.theme.EchoColorScheme
 import com.example.graduation_project.ui.theme.LocalEchoColors
 import com.example.graduation_project.ui.theme.OutfitFontFamily
+import java.time.LocalDate
+import java.time.YearMonth
+
+private val WEEKDAY_LABELS = listOf("일", "월", "화", "수", "목", "금", "토")
 
 /**
  * 일기 탭 (기존 대화기록 탭 대체)
  *
- * 날짜 내림차순 목록:
- * - 일기가 있는 날 = 일기 카드 1개 (탭 → 일기 상세)
- * - 일기가 없는 날 = 그날의 대화 세션 카드 (탭 → 대화 말풍선 상세)
+ * 월간 캘린더로 날짜를 짚어 그날의 일기/대화 세션을 확인:
+ * - 일기가 있는 날 → 탭 시 일기 상세로 이동
+ * - 일기는 없고 세션이 1개인 날 → 탭 시 바로 대화 상세로 이동
+ * - 세션이 2개 이상인 날 → 탭 시 바텀시트로 목록을 보여주고 선택 시 이동
+ * - 아무 기록도 없는 날 → 탭 비활성
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiaryScreen(
     onDiaryClick: (String) -> Unit,
@@ -49,8 +71,11 @@ fun DiaryScreen(
     viewModel: DiaryViewModel = viewModel(factory = DiaryViewModel.Factory)
 ) {
     val uiState by viewModel.uiState.collectAsState()
-
     val colors = LocalEchoColors.current
+
+    var sheetSessions by remember { mutableStateOf<List<ConversationSummary>?>(null) }
+    val sheetState = rememberModalBottomSheetState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -90,33 +115,166 @@ fun DiaryScreen(
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(color = colors.accentGreen)
             }
-        } else if (uiState.items.isEmpty()) {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(
-                    text = "아직 일기가 없어요\n대화를 나누면 일기가 만들어져요",
-                    fontSize = 18.sp,
-                    color = colors.textTertiary,
-                    fontFamily = OutfitFontFamily,
-                    lineHeight = 26.sp
-                )
-            }
         } else {
+            MonthNavigationHeader(
+                currentMonth = uiState.currentMonth,
+                onPreviousMonth = { viewModel.changeMonth(-1) },
+                onNextMonth = { viewModel.changeMonth(1) }
+            )
+            CalendarLegend()
+            CalendarGrid(
+                currentMonth = uiState.currentMonth,
+                cellsByDate = uiState.cellsByDate,
+                onDateSelected = { state ->
+                    when (state) {
+                        is DayCellState.HasDiary -> onDiaryClick(state.diary.date)
+                        is DayCellState.HasSessions -> {
+                            if (state.sessions.size == 1) {
+                                onConversationClick(state.sessions.first().conversationId)
+                            } else {
+                                sheetSessions = state.sessions
+                            }
+                        }
+                        DayCellState.Empty -> Unit
+                    }
+                }
+            )
+        }
+    }
+
+    sheetSessions?.let { sessions ->
+        ModalBottomSheet(
+            onDismissRequest = { sheetSessions = null },
+            sheetState = sheetState
+        ) {
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
                 contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp)
             ) {
-                items(uiState.items) { item ->
-                    when (item) {
-                        is DiaryDayItem.DiaryCard -> DiaryCard(
-                            diary = item.diary,
-                            sessionCount = item.sessionCount,
-                            onClick = { onDiaryClick(item.diary.date) }
-                        )
-                        is DiaryDayItem.SessionCard -> SessionCard(
-                            summary = item.summary,
-                            onClick = { onConversationClick(item.summary.conversationId) }
-                        )
+                items(sessions) { summary ->
+                    SessionCard(
+                        summary = summary,
+                        showDate = false,
+                        onClick = {
+                            sheetSessions = null
+                            onConversationClick(summary.conversationId)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonthNavigationHeader(
+    currentMonth: YearMonth,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    val colors = LocalEchoColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp)) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "이전 달",
+                tint = colors.textPrimary
+            )
+        }
+        Text(
+            text = "${currentMonth.year}년 ${currentMonth.monthValue}월",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = OutfitFontFamily,
+            color = colors.textPrimary
+        )
+        IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp)) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "다음 달",
+                tint = colors.textPrimary
+            )
+        }
+    }
+}
+
+@Composable
+private fun CalendarLegend() {
+    val colors = LocalEchoColors.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        LegendItem(color = colors.accentGreen, label = "일기", colors = colors)
+        LegendItem(color = colors.accentCoral, label = "대화만", colors = colors)
+        LegendItem(color = colors.accentBlue, label = "갱신 실패", colors = colors)
+        LegendItem(color = colors.accentRed, label = "생성 실패", colors = colors)
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String, colors: EchoColorScheme) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(color)
+        )
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            fontFamily = OutfitFontFamily,
+            color = colors.textTertiary
+        )
+    }
+}
+
+@Composable
+private fun CalendarGrid(
+    currentMonth: YearMonth,
+    cellsByDate: Map<LocalDate, DayCellState>,
+    onDateSelected: (DayCellState) -> Unit
+) {
+    val colors = LocalEchoColors.current
+    val today = remember { LocalDate.now() }
+    val weeks = remember(currentMonth) { buildCalendarWeeks(currentMonth) }
+
+    Column(modifier = Modifier.padding(horizontal = 12.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            WEEKDAY_LABELS.forEach { label ->
+                Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = label,
+                        fontSize = 14.sp,
+                        fontFamily = OutfitFontFamily,
+                        color = colors.textTertiary
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        weeks.forEach { week ->
+            Row(modifier = Modifier.fillMaxWidth()) {
+                week.forEach { date ->
+                    Box(modifier = Modifier.weight(1f)) {
+                        if (date != null) {
+                            CalendarDayCell(
+                                date = date,
+                                isToday = date == today,
+                                state = cellsByDate[date] ?: DayCellState.Empty,
+                                onClick = onDateSelected
+                            )
+                        }
                     }
                 }
             }
@@ -125,96 +283,77 @@ fun DiaryScreen(
 }
 
 @Composable
-private fun DiaryCard(
-    diary: DiaryEntity,
-    sessionCount: Int,
-    onClick: () -> Unit
+private fun CalendarDayCell(
+    date: LocalDate,
+    isToday: Boolean,
+    state: DayCellState,
+    onClick: (DayCellState) -> Unit
 ) {
     val colors = LocalEchoColors.current
-    val hasStaleContent = diary.status == "FAILED" && diary.content != null
-    val isTotalFailure = diary.status == "FAILED" && diary.content == null
+    val isEnabled = state != DayCellState.Empty
 
-    Surface(
+    Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .shadow(2.dp, RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick),
-        shape = RoundedCornerShape(12.dp),
-        color = colors.bgCard,
-        tonalElevation = 0.dp
+            .aspectRatio(1f)
+            .padding(2.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (isToday) Modifier.background(colors.bgMuted) else Modifier
+            )
+            .clickable(enabled = isEnabled) { onClick(state) },
+        contentAlignment = Alignment.Center
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = formatKoreanDate(diary.date),
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.textPrimary
-                )
-                if (hasStaleContent) {
-                    FailureBadge(text = "갱신 실패", backgroundColor = colors.accentBlue)
-                } else if (isTotalFailure) {
-                    FailureBadge()
-                }
-            }
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (diary.weather != null) {
-                    Text(
-                        text = diary.weather,
-                        fontSize = 16.sp,
-                        fontFamily = OutfitFontFamily,
-                        color = colors.textTertiary
-                    )
-                    Text("·", fontSize = 16.sp, color = colors.textTertiary)
-                }
-                Text(
-                    text = if (sessionCount > 0) "대화 ${sessionCount}회" else "일기",
-                    fontSize = 16.sp,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.textTertiary
-                )
-            }
-            Spacer(Modifier.height(8.dp))
-            if (diary.content != null) {
-                Text(
-                    text = diary.content,
-                    fontSize = 18.sp,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.textSecondary,
-                    maxLines = 2,
-                    lineHeight = 26.sp
-                )
-            }
-            if (hasStaleContent) {
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = "오늘 대화 내용이 아직 반영되지 않았어요.",
-                    fontSize = 14.sp,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.accentBlue,
-                    maxLines = 1
-                )
-            } else if (isTotalFailure) {
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = "일기를 만들지 못했어요. 잠시 후 다시 확인해 주세요.",
-                    fontSize = 14.sp,
-                    fontFamily = OutfitFontFamily,
-                    color = colors.accentRed,
-                    maxLines = 1
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = date.dayOfMonth.toString(),
+                fontSize = 16.sp,
+                fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                fontFamily = OutfitFontFamily,
+                color = if (isEnabled) colors.textPrimary else colors.textTertiary
+            )
+            Spacer(Modifier.height(2.dp))
+            val dotColor = dayCellDotColor(state, colors)
+            if (dotColor != null) {
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(dotColor)
                 )
             }
         }
     }
+}
+
+private fun dayCellDotColor(state: DayCellState, colors: EchoColorScheme): Color? = when (state) {
+    is DayCellState.HasDiary -> {
+        val hasStaleContent = state.diary.status == "FAILED" && state.diary.content != null
+        val isTotalFailure = state.diary.status == "FAILED" && state.diary.content == null
+        when {
+            isTotalFailure -> colors.accentRed
+            hasStaleContent -> colors.accentBlue
+            else -> colors.accentGreen
+        }
+    }
+    is DayCellState.HasSessions -> colors.accentCoral
+    DayCellState.Empty -> null
+}
+
+/**
+ * 지정한 달을 일요일 시작 7일 단위 주(week) 목록으로 변환
+ * (이전/다음 달 여백은 null로 채워 클릭 비활성 처리)
+ */
+private fun buildCalendarWeeks(month: YearMonth): List<List<LocalDate?>> {
+    val firstDay = month.atDay(1)
+    val leadingEmpty = firstDay.dayOfWeek.value % 7 // MONDAY=1..SUNDAY=7 -> 일요일 시작 인덱스로 변환
+    val totalDays = month.lengthOfMonth()
+
+    val cells = mutableListOf<LocalDate?>()
+    repeat(leadingEmpty) { cells.add(null) }
+    for (day in 1..totalDays) cells.add(month.atDay(day))
+    while (cells.size % 7 != 0) cells.add(null)
+
+    return cells.chunked(7)
 }
 
 @Composable
@@ -237,7 +376,7 @@ internal fun FailureBadge(
 }
 
 /**
- * 일기가 없는 날의 대화 세션 카드 (기존 대화기록 탭 카드 스타일 유지)
+ * 대화 세션 카드 (캘린더에서 세션 2개 이상인 날의 바텀시트, 기존 대화기록 탭 카드 스타일 유지)
  */
 @Composable
 internal fun SessionCard(

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
@@ -13,13 +13,23 @@ import com.example.graduation_project.data.local.dao.SessionRange
 import com.example.graduation_project.data.local.entity.DiaryEntity
 import com.example.graduation_project.data.repository.DiaryRepository
 import com.example.graduation_project.presentation.model.ConversationSummary
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
-private data class DiaryTabSources(
+private val KST_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+private val DATE_KEY_FORMATTER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+private data class CalendarSources(
+    val month: YearMonth,
     val diaries: List<DiaryEntity>,
     val ranges: List<SessionRange>,
     val diaryDateByConversationId: Map<String, String>,
@@ -27,28 +37,31 @@ private data class DiaryTabSources(
 )
 
 /**
- * 일기 탭 목록 항목
+ * 일기 탭 캘린더의 날짜 셀 상태
  *
- * - DiaryCard: 일기 레코드가 있는 날 (하루 1개, FAILED 실패 기록 포함)
- * - SessionCard: 일기가 없는 날의 로컬 대화 세션 (일기 기능 이전의 과거 기록 등)
+ * - Empty: 일기도 세션도 없는 날 (탭 비활성)
+ * - HasSessions: 일기는 없고 그날의 대화 세션만 있는 날 (1개면 즉시 이동, 2개 이상이면 바텀시트)
+ * - HasDiary: 일기 레코드가 있는 날 (하루 1개, FAILED 실패/갱신 실패 기록 포함)
  */
-sealed class DiaryDayItem {
-    data class DiaryCard(val diary: DiaryEntity, val sessionCount: Int) : DiaryDayItem()
-    data class SessionCard(val summary: ConversationSummary) : DiaryDayItem()
+sealed class DayCellState {
+    data object Empty : DayCellState()
+    data class HasSessions(val sessions: List<ConversationSummary>) : DayCellState()
+    data class HasDiary(val diary: DiaryEntity, val sessionCount: Int) : DayCellState()
 }
 
-data class DiaryListUiState(
-    val items: List<DiaryDayItem> = emptyList(),
+data class DiaryCalendarUiState(
+    val currentMonth: YearMonth = YearMonth.now(KST_ZONE),
+    val cellsByDate: Map<LocalDate, DayCellState> = emptyMap(),
     val isLoading: Boolean = true,
     val syncError: String? = null
 )
 
 /**
- * 일기 탭 ViewModel
+ * 일기 탭 ViewModel (캘린더)
  *
  * 서버 일기 캐시(Room)와 로컬 대화 세션을 날짜 기준으로 병합해
- * 하나의 목록으로 제공. 진입 시 서버 동기화를 시도하고,
- * 실패해도 캐시를 그대로 보여주며 에러를 배너로 노출
+ * 현재 보고 있는 달의 날짜별 상태 맵으로 제공.
+ * 달 진입/이동 시 서버 동기화를 시도하고, 실패해도 캐시를 그대로 보여주며 에러를 배너로 노출
  */
 class DiaryViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -58,75 +71,100 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     private val conversationDiaryLinkDao = database.conversationDiaryLinkDao()
     private val diaryRepository = DiaryRepository(diaryDao)
 
+    private val currentMonth = MutableStateFlow(YearMonth.now(KST_ZONE))
     private val syncError = MutableStateFlow<String?>(null)
 
-    private val _uiState = MutableStateFlow(DiaryListUiState())
-    val uiState: StateFlow<DiaryListUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(DiaryCalendarUiState())
+    val uiState: StateFlow<DiaryCalendarUiState> = _uiState.asStateFlow()
 
     init {
-        refresh()
-        observeItems()
+        refreshCurrentMonth()
+        observeCalendar()
     }
 
     /**
-     * 서버에서 일기 동기화 (탭 진입 시 / 수동 재시도)
+     * 현재 보고 있는 달을 서버와 재동기화 (달 진입 시 / 수동 재시도)
      */
-    fun refresh() {
+    fun refresh() = refreshCurrentMonth()
+
+    /**
+     * 이전/다음 달로 이동 (delta: -1 = 이전 달, +1 = 다음 달)
+     */
+    fun changeMonth(delta: Int) {
+        currentMonth.value = currentMonth.value.plusMonths(delta.toLong())
+        refreshCurrentMonth()
+    }
+
+    private fun refreshCurrentMonth() {
+        val month = currentMonth.value
         viewModelScope.launch {
-            when (val result = diaryRepository.refresh()) {
+            when (val result = diaryRepository.refreshMonth(month)) {
                 is ApiResult.Success -> syncError.value = null
                 is ApiResult.Error -> syncError.value = result.exception.message
             }
         }
     }
 
-    private fun observeItems() {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeCalendar() {
         viewModelScope.launch {
-            combine(
-                diaryDao.observeAll(),
-                messageDao.getSessionRanges(),
-                conversationDiaryLinkDao.observeAll(),
-                syncError
-            ) { diaries, ranges, links, error ->
-                DiaryTabSources(diaries, ranges, links.associate { it.conversationId to it.diaryDate }, error)
-            }.collect { sources ->
-                _uiState.value = DiaryListUiState(
-                    items = buildItems(sources),
-                    isLoading = false,
-                    syncError = sources.syncError
-                )
-            }
+            currentMonth
+                .flatMapLatest { month ->
+                    combine(
+                        diaryRepository.observeMonth(month),
+                        messageDao.getSessionRanges(),
+                        conversationDiaryLinkDao.observeAll(),
+                        syncError
+                    ) { diaries, ranges, links, error ->
+                        CalendarSources(
+                            month = month,
+                            diaries = diaries,
+                            ranges = ranges,
+                            diaryDateByConversationId = links.associate { it.conversationId to it.diaryDate },
+                            syncError = error
+                        )
+                    }
+                }
+                .collect { sources ->
+                    _uiState.value = DiaryCalendarUiState(
+                        currentMonth = sources.month,
+                        cellsByDate = buildDayCellStates(sources),
+                        isLoading = false,
+                        syncError = sources.syncError
+                    )
+                }
         }
     }
 
     /**
-     * 병합 규칙: 날짜 내림차순으로,
-     * 일기가 있는 날 = 일기 카드 1개 / 없는 날 = 그날의 세션 카드 나열
+     * 병합 규칙: 일기가 있는 날 = HasDiary / 없고 세션만 있는 날 = HasSessions / 둘 다 없으면 Empty
+     * (세션의 날짜 버킷은 서버가 확정해 준 diaryDate를 우선하고, 없으면 세션 종료 시각 기준으로 폴백)
      */
-    private suspend fun buildItems(sources: DiaryTabSources): List<DiaryDayItem> {
+    private suspend fun buildDayCellStates(sources: CalendarSources): Map<LocalDate, DayCellState> {
         val diariesByDate = sources.diaries.associateBy { it.date }
         val sessionsByDate = sources.ranges.groupBy {
             resolveDateKey(it, sources.diaryDateByConversationId[it.conversationId])
         }
-        val allDates = (diariesByDate.keys + sessionsByDate.keys).sortedDescending()
 
-        val items = mutableListOf<DiaryDayItem>()
-        for (date in allDates) {
-            val diary = diariesByDate[date]
-            if (diary != null) {
-                items += DiaryDayItem.DiaryCard(
-                    diary = diary,
-                    sessionCount = sessionsByDate[date]?.size ?: 0
-                )
-            } else {
-                sessionsByDate[date]?.forEach { range ->
-                    buildSessionSummary(messageDao, range, date)?.let {
-                        items += DiaryDayItem.SessionCard(it)
+        val cells = mutableMapOf<LocalDate, DayCellState>()
+        for (day in 1..sources.month.lengthOfMonth()) {
+            val date = sources.month.atDay(day)
+            val dateKey = date.format(DATE_KEY_FORMATTER)
+            val diary = diariesByDate[dateKey]
+            val sessionsForDate = sessionsByDate[dateKey].orEmpty()
+
+            cells[date] = when {
+                diary != null -> DayCellState.HasDiary(diary, sessionsForDate.size)
+                sessionsForDate.isNotEmpty() -> {
+                    val summaries = sessionsForDate.mapNotNull { range ->
+                        buildSessionSummary(messageDao, range, dateKey)
                     }
+                    if (summaries.isEmpty()) DayCellState.Empty else DayCellState.HasSessions(summaries)
                 }
+                else -> DayCellState.Empty
             }
         }
-        return items
+        return cells
     }
 
     companion object {

--- a/server/src/main/java/com/example/echo/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/example/echo/diary/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.example.echo.diary.controller;
 
 import com.example.echo.common.auth.CurrentUser;
 import com.example.echo.diary.dto.DiaryResponse;
+import com.example.echo.diary.entity.Diary;
 import com.example.echo.diary.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,9 +13,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -33,22 +36,31 @@ public class DiaryController {
 
     @Operation(
             summary = "일기 목록 조회",
-            description = "최근 N일의 일기를 날짜 내림차순으로 조회합니다. 생성 실패 기록(status=FAILED)도 포함됩니다."
+            description = "최근 N일의 일기를 날짜 내림차순으로 조회합니다. 생성 실패 기록(status=FAILED)도 포함됩니다. "
+                    + "startDate/endDate를 모두 지정하면 days 대신 해당 날짜 범위(양끝 포함)로 조회합니다(캘린더 월 조회용)."
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
                     description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = DiaryResponse.class))
-            )
+            ),
+            @ApiResponse(responseCode = "400", description = "endDate가 startDate보다 이전")
     })
     @GetMapping
     public ResponseEntity<List<DiaryResponse>> getDiaries(
             @Parameter(hidden = true) @CurrentUser Long userId,
-            @Parameter(description = "조회 기간 (오늘 포함 최근 N일)", example = "30")
-            @RequestParam(defaultValue = "30") int days
+            @Parameter(description = "조회 기간 (오늘 포함 최근 N일). startDate/endDate가 함께 오면 무시됩니다.", example = "30")
+            @RequestParam(defaultValue = "30") int days,
+            @Parameter(description = "조회 시작일 (yyyy-MM-dd, endDate와 함께 지정 시 사용)")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일 (yyyy-MM-dd, startDate와 함께 지정 시 사용)")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
     ) {
-        List<DiaryResponse> diaries = diaryService.getDiaries(userId, days).stream()
+        List<Diary> result = (startDate != null && endDate != null)
+                ? diaryService.getDiariesInRange(userId, startDate, endDate)
+                : diaryService.getDiaries(userId, days);
+        List<DiaryResponse> diaries = result.stream()
                 .map(DiaryResponse::from)
                 .toList();
         return ResponseEntity.ok(diaries);

--- a/server/src/main/java/com/example/echo/diary/exception/InvalidDateRangeException.java
+++ b/server/src/main/java/com/example/echo/diary/exception/InvalidDateRangeException.java
@@ -1,0 +1,14 @@
+package com.example.echo.diary.exception;
+
+import com.example.echo.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+
+public class InvalidDateRangeException extends BaseException {
+
+    public InvalidDateRangeException(LocalDate startDate, LocalDate endDate) {
+        super(HttpStatus.BAD_REQUEST,
+                "endDate는 startDate보다 이전일 수 없습니다 - startDate: " + startDate + ", endDate: " + endDate);
+    }
+}

--- a/server/src/main/java/com/example/echo/diary/service/DiaryService.java
+++ b/server/src/main/java/com/example/echo/diary/service/DiaryService.java
@@ -6,6 +6,7 @@ import com.example.echo.context.domain.UserContext;
 import com.example.echo.diary.entity.Diary;
 import com.example.echo.diary.entity.DiaryStatus;
 import com.example.echo.diary.exception.DiaryNotFoundException;
+import com.example.echo.diary.exception.InvalidDateRangeException;
 import com.example.echo.diary.repository.DiaryRepository;
 import com.example.echo.prompt.service.PromptService;
 import lombok.RequiredArgsConstructor;
@@ -85,8 +86,21 @@ public class DiaryService {
     @Transactional(readOnly = true)
     public List<Diary> getDiaries(Long userId, int days) {
         LocalDate today = LocalDate.now(KST);
+        return getDiariesInRange(userId, today.minusDays(days - 1L), today);
+    }
+
+    /**
+     * 지정한 날짜 범위(양끝 포함)의 일기 조회 (날짜 내림차순)
+     *
+     * 캘린더 월 이동 등 임의 구간 조회에 사용 (일기 탭 캘린더 UI)
+     */
+    @Transactional(readOnly = true)
+    public List<Diary> getDiariesInRange(Long userId, LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new InvalidDateRangeException(startDate, endDate);
+        }
         return diaryRepository.findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(
-                userId, today.minusDays(days - 1L), today);
+                userId, startDate, endDate);
     }
 
     /**

--- a/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
+++ b/server/src/test/java/com/example/echo/diary/service/DiaryServiceTest.java
@@ -6,6 +6,7 @@ import com.example.echo.context.domain.ConversationTurn;
 import com.example.echo.context.domain.UserContext;
 import com.example.echo.diary.entity.Diary;
 import com.example.echo.diary.entity.DiaryStatus;
+import com.example.echo.diary.exception.InvalidDateRangeException;
 import com.example.echo.diary.repository.DiaryRepository;
 import com.example.echo.prompt.service.PromptService;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -265,6 +267,51 @@ class DiaryServiceTest {
         assertThat(result.getId()).isNull();
         assertThat(result.getStatus()).isEqualTo(DiaryStatus.FAILED);
         verify(diaryRepository, times(1)).save(any(Diary.class));
+    }
+
+    @Test
+    @DisplayName("getDiaries(days)는 오늘을 기준으로 today-(days-1)~today 범위로 위임한다")
+    void getDiaries_delegatesToRangeQuery() {
+        // given
+        LocalDate expectedStart = TODAY.minusDays(29L);
+        when(diaryRepository.findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(TEST_USER_ID, expectedStart, TODAY))
+                .thenReturn(List.of());
+
+        // when
+        diaryService.getDiaries(TEST_USER_ID, 30);
+
+        // then
+        verify(diaryRepository).findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(TEST_USER_ID, expectedStart, TODAY);
+    }
+
+    @Test
+    @DisplayName("getDiariesInRange는 지정한 시작/종료일 그대로 리포지토리에 위임한다")
+    void getDiariesInRange_delegatesGivenRange() {
+        // given
+        LocalDate start = TODAY.minusMonths(1);
+        LocalDate end = TODAY.minusDays(1);
+        Diary diary = Diary.builder().userId(TEST_USER_ID).diaryDate(start).status(DiaryStatus.SUCCESS).build();
+        when(diaryRepository.findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(TEST_USER_ID, start, end))
+                .thenReturn(List.of(diary));
+
+        // when
+        List<Diary> result = diaryService.getDiariesInRange(TEST_USER_ID, start, end);
+
+        // then
+        assertThat(result).containsExactly(diary);
+    }
+
+    @Test
+    @DisplayName("getDiariesInRange에 endDate가 startDate보다 이전이면 InvalidDateRangeException을 던진다")
+    void getDiariesInRange_throwsWhenEndBeforeStart() {
+        // given
+        LocalDate start = TODAY;
+        LocalDate end = TODAY.minusDays(1);
+
+        // when / then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> diaryService.getDiariesInRange(TEST_USER_ID, start, end))
+                .isInstanceOf(InvalidDateRangeException.class);
+        verifyNoInteractions(diaryRepository);
     }
 
     private static Diary processedDiary(DiaryOutcome outcome) {


### PR DESCRIPTION
## Summary
- 일기 탭 첫 화면을 날짜 내림차순 리스트에서 월간 캘린더 그리드로 전면 교체 (커스텀 Compose Grid, 신규 의존성 없음)
- 캘린더 임의 월 이동 시 데이터를 불러올 수 있도록 서버 `GET /api/diaries`에 `startDate`/`endDate` 범위 조회 옵션 추가 (`days` 파라미터 방식과 하위 호환)
- 날짜 셀 탭 동작: 일기 있음 → 일기 상세 이동 / 세션 1개 → 대화 상세 이동 / 세션 2개 이상 → 바텀시트 목록 / 데이터 없음 → 비활성
- 날짜별 상태를 초록(일기)/코랄(대화만)/파랑(갱신 실패)/빨강(생성 실패) 점 + 범례로 구분 표시

## Test plan
- [x] 서버: `DiaryServiceTest` 회귀 테스트 추가 (`getDiaries` 위임, `getDiariesInRange`, 잘못된 범위 예외) 전부 통과
- [x] Android: `compileLocalDebugKotlin` 경고 없이 빌드 성공
- [x] 에뮬레이터(prod 플레이버 + 테스트 계정)에서 실제 실행 확인 — 캘린더 그리드/월 헤더/범례 렌더링, 좌우 화살표로 이전·다음 달 이동(요일 정렬 재계산 포함), 빈 날짜 탭 시 무반응, 크래시 없음
- [ ] 일기/세션이 있는 실제 데이터로 날짜 탭 → 상세 이동, 바텀시트, 점 색상 구분은 테스트 계정에 데이터가 없어 미검증 (서버 배포 후 재확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xst6gZX47ZdoA8Zq7j1m9