### PR TITLE
feat(android): 일기 상세 화면 일기/대화 카드 배경색 구분

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
@@ -207,7 +207,7 @@ private fun DiaryContentCard(diary: DiaryEntity?) {
             .fillMaxWidth()
             .shadow(2.dp, RoundedCornerShape(12.dp)),
         shape = RoundedCornerShape(12.dp),
-        color = colors.bgCard,
+        color = colors.bgCardDiary,
         tonalElevation = 0.dp
     ) {
         Column(

--- a/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
+++ b/android/app/src/main/java/com/example/graduation_project/ui/theme/EchoColors.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 data class EchoColorScheme(
     val bgPage: Color,
     val bgCard: Color,
+    val bgCardDiary: Color,
     val bgMuted: Color,
     val accentGreen: Color,
     val accentBlue: Color,
@@ -21,6 +22,7 @@ data class EchoColorScheme(
 val defaultEchoColors = EchoColorScheme(
     bgPage        = Color(0xFFF5F4F1),
     bgCard        = Color(0xFFFFFFFF),
+    bgCardDiary   = Color(0xFFE6F2EA),  // 일기 카드 전용 - accentGreen을 은은하게 탄 톤
     bgMuted       = Color(0xFFEDECEA),
     accentGreen   = Color(0xFF3D8A5A),
     accentBlue    = Color(0xFF4A90D9),
@@ -36,6 +38,7 @@ val defaultEchoColors = EchoColorScheme(
 val highContrastEchoColors = EchoColorScheme(
     bgPage        = Color(0xFFFFFBF5),  // 따뜻한 오프화이트 — 노안 눈부심 감소
     bgCard        = Color(0xFFFFFFFF),
+    bgCardDiary   = Color(0xFFCFE0D6),  // 일기 카드 전용 - 고대비에서도 뚜렷이 구분되는 초록 톤
     bgMuted       = Color(0xFFEEECE8),
     accentGreen   = Color(0xFF1A5C38),  // 채도 유지하며 어둡게 — 버튼 가독성
     accentBlue    = Color(0xFF0D4D9C),


### PR DESCRIPTION
## Summary
- 일기 상세 화면(`DiaryDetailScreen`)에서 일기 본문 카드와 "그날의 대화" 세션 카드가 동일한 흰색 배경이라 구분이 어려웠던 문제 개선
- `EchoColorScheme`에 `bgCardDiary` 필드를 추가(일반/고대비 팔레트 양쪽 명시적 hex 지정)하고, 일기 본문 카드만 은은한 초록 톤 배경 적용 (대화 세션 카드는 기존 흰색 유지)

## Test plan
- [x] `compileLocalDebugKotlin` 경고 없이 빌드 성공
- [ ] 실제 일기 데이터가 있는 계정/기기에서 카드 배경색·가독성 육안 확인 (이번 작업 환경에는 테스트 계정에 일기 데이터가 없어 미확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xst6gZX47ZdoA8Zq7j1m9