### PR TITLE
fix(android): 계정 전환 시 다른 계정의 일기·대화 캐시 노출 수정

### DIFF
--- a/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/5.json
+++ b/android/app/schemas/com.example.graduation_project.data.local.AppDatabase/5.json
@@ -1,0 +1,187 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "93e92611b205219314b7bb47d7cd88a1",
+    "entities": [
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `userId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "location_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `date` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "diaries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `serverId` INTEGER NOT NULL, `title` TEXT, `content` TEXT, `status` TEXT NOT NULL, `failureReason` TEXT, `weather` TEXT, `mood` TEXT, `updatedAt` TEXT, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureReason",
+            "columnName": "failureReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "weather",
+            "columnName": "weather",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mood",
+            "columnName": "mood",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        }
+      },
+      {
+        "tableName": "conversation_diary_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationId` TEXT NOT NULL, `diaryDate` TEXT NOT NULL, PRIMARY KEY(`conversationId`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diaryDate",
+            "columnName": "diaryDate",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93e92611b205219314b7bb47d7cd88a1')"
+    ]
+  }
+}

--- a/android/app/src/main/java/com/example/graduation_project/App.kt
+++ b/android/app/src/main/java/com/example/graduation_project/App.kt
@@ -3,8 +3,12 @@ package com.example.graduation_project
 import android.app.Application
 import com.example.graduation_project.data.alarm.ConversationAlarmScheduler
 import com.example.graduation_project.data.api.ApiClient
+import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.TokenStorage
 import com.example.graduation_project.util.CrashReporter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class App : Application() {
     override fun onCreate() {
@@ -15,7 +19,16 @@ class App : Application() {
             CrashReporter.install(this)
         }
 
-        ApiClient.init(TokenStorage(this))
+        val tokenStorage = TokenStorage(this)
+        ApiClient.init(tokenStorage)
+
+        // DB v5 마이그레이션으로 생긴 소유자 미상(userId=-1) 메시지를 현재 로그인 사용자에게 귀속.
+        // 귀속할 행이 없으면 0건 갱신으로 끝나므로 매 실행 시 호출해도 안전(멱등)함.
+        CoroutineScope(Dispatchers.IO).launch {
+            tokenStorage.getCurrentUserId()?.let { userId ->
+                AppDatabase.getInstance(this@App).messageDao().backfillLegacyOwner(userId)
+            }
+        }
 
         // 강제 종료/딥 슬립 등으로 AlarmManager 등록이 사라진 경우 대비:
         // 다음날 알람은 오늘 알람이 울려야 예약되는 체인 구조라, 앱 실행 시마다 저장된 설정으로 복구

--- a/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/MainActivity.kt
@@ -183,7 +183,7 @@ private fun AppNavHost(
 ) {
     val context = LocalContext.current
     val application = context.applicationContext as Application
-    val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application)) }
+    val authRepository = remember { AuthRepository(tokenStorage = TokenStorage(application), application = application) }
     val userRepository = remember { UserRepository() }
     val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()

--- a/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/ApiClient.kt
@@ -46,8 +46,11 @@ object ApiClient {
         private set
     lateinit var weatherApi: WeatherApi
         private set
+    var tokenStorage: TokenStorage? = null
+        private set
 
     fun init(tokenStorage: TokenStorage) {
+        this.tokenStorage = tokenStorage
         val authenticatedClient = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
             .addInterceptor(AuthInterceptor(tokenStorage))

--- a/android/app/src/main/java/com/example/graduation_project/data/local/AppDatabase.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/AppDatabase.kt
@@ -29,7 +29,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
  */
 @Database(
     entities = [MessageEntity::class, LocationPointEntity::class, DiaryEntity::class, ConversationDiaryLinkEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -109,6 +109,25 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         /**
+         * Migration 4 → 5: 계정별 로컬 캐시 격리 (다른 계정으로 로그인해도
+         * 이전 계정의 일기·대화가 보이는 문제 수정)
+         *
+         * - messages: userId 컬럼 추가. 기존 행은 소유자를 알 수 없으므로 -1로 표시하고,
+         *   앱 시작 시 MessageDao.backfillLegacyOwner()가 현재 로그인 사용자에게 귀속시킴
+         *   (서버에 원본이 없는 유일한 사본이라 삭제 대신 이 방식으로 보존)
+         * - diaries / conversation_diary_link / location_points: 서버가 원본이거나
+         *   재수집 가능한 캐시라 안전하게 전체 삭제 (이미 유출된 기존 설치 기기 정리 포함)
+         */
+        internal val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE messages ADD COLUMN userId INTEGER NOT NULL DEFAULT -1")
+                db.execSQL("DELETE FROM diaries")
+                db.execSQL("DELETE FROM conversation_diary_link")
+                db.execSQL("DELETE FROM location_points")
+            }
+        }
+
+        /**
          * 데이터베이스 인스턴스 가져오기
          * - 스레드 안전한 싱글톤
          */
@@ -141,7 +160,7 @@ abstract class AppDatabase : RoomDatabase() {
                 DATABASE_NAME
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 // Migration 실패 시에만 fallback (안전망)
                 .fallbackToDestructiveMigration(dropAllTables = true)
                 .build()

--- a/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/TokenStorage.kt
@@ -62,6 +62,22 @@ class TokenStorage(private val context: Context) {
         }
     }
 
+    /**
+     * 현재 accessToken의 JWT payload(sub claim)에서 userId를 동기적으로 추출.
+     * 서명 검증은 하지 않음 - 로컬 캐시 격리용 식별자 용도이며, 실제 인가는 서버가 담당.
+     */
+    fun getCurrentUserId(): Long? {
+        val token = getAccessToken() ?: return null
+        return try {
+            val payload = token.split(".").getOrNull(1) ?: return null
+            val padded = payload.padEnd((payload.length + 3) / 4 * 4, '=')
+            val decoded = android.util.Base64.decode(padded, android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP)
+            org.json.JSONObject(String(decoded, Charsets.UTF_8)).optString("sub").toLongOrNull()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     private fun deletePrefsFile() {
         try {
             val file = java.io.File(

--- a/android/app/src/main/java/com/example/graduation_project/data/local/dao/ConversationDiaryLinkDao.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/dao/ConversationDiaryLinkDao.kt
@@ -32,4 +32,11 @@ interface ConversationDiaryLinkDao {
      */
     @Query("SELECT diaryDate FROM conversation_diary_link WHERE conversationId = :conversationId")
     suspend fun getDiaryDate(conversationId: String): String?
+
+    /**
+     * 전체 삭제 - 로그아웃/로그인/회원가입 시 계정 전환 캐시 정리용
+     * (서버 /end 응답으로 재생성 가능한 매핑이라 삭제해도 안전)
+     */
+    @Query("DELETE FROM conversation_diary_link")
+    suspend fun deleteAll()
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/local/dao/DiaryDao.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/dao/DiaryDao.kt
@@ -41,4 +41,11 @@ interface DiaryDao {
      */
     @Query("SELECT * FROM diaries WHERE date BETWEEN :start AND :end ORDER BY date DESC")
     fun observeByDateRange(start: String, end: String): Flow<List<DiaryEntity>>
+
+    /**
+     * 전체 삭제 - 로그아웃/로그인/회원가입 시 계정 전환 캐시 정리용
+     * (서버가 원본이라 삭제해도 다음 동기화 시 재수신됨)
+     */
+    @Query("DELETE FROM diaries")
+    suspend fun deleteAll()
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/local/dao/MessageDao.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/dao/MessageDao.kt
@@ -18,6 +18,11 @@ import kotlinx.coroutines.flow.Flow
  * ## Flow 사용
  * - Flow를 반환하면 데이터 변경 시 자동으로 UI 업데이트
  * - Compose의 collectAsState()와 함께 사용
+ *
+ * ## 계정 격리
+ * - 모든 조회/삭제 쿼리는 userId로 스코핑됨 (기기 공유·계정 전환 시 다른 계정의
+ *   대화 기록이 노출되지 않도록 함). DB v5 이전 레거시 행은 userId=-1로 저장되어
+ *   있으며 [backfillLegacyOwner]로 현재 로그인 사용자에게 1회성 귀속된다.
  */
 @Dao
 interface MessageDao {
@@ -40,22 +45,22 @@ interface MessageDao {
      * 특정 대화의 모든 메시지 조회 (시간순 정렬)
      * - Flow로 반환하여 실시간 업데이트 지원
      */
-    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp ASC")
-    fun getMessagesByConversationId(conversationId: String): Flow<List<MessageEntity>>
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId AND userId = :userId ORDER BY timestamp ASC")
+    fun getMessagesByConversationId(conversationId: String, userId: Long): Flow<List<MessageEntity>>
 
     /**
      * 특정 대화의 모든 메시지 조회 (일회성)
      * - Flow 없이 단순 조회
      */
-    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp ASC")
-    suspend fun getMessagesByConversationIdOnce(conversationId: String): List<MessageEntity>
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId AND userId = :userId ORDER BY timestamp ASC")
+    suspend fun getMessagesByConversationIdOnce(conversationId: String, userId: Long): List<MessageEntity>
 
     /**
      * 모든 대화 ID 목록 조회 (최신순)
      * - 대화 목록 화면에서 사용
      */
-    @Query("SELECT DISTINCT conversationId FROM messages ORDER BY timestamp DESC")
-    fun getAllConversationIds(): Flow<List<String>>
+    @Query("SELECT DISTINCT conversationId FROM messages WHERE userId = :userId ORDER BY timestamp DESC")
+    fun getAllConversationIds(userId: Long): Flow<List<String>>
 
     /**
      * 세션별 시작/종료 시각 조회 (최신순)
@@ -64,34 +69,42 @@ interface MessageDao {
      */
     @Query("""
         SELECT conversationId, MIN(timestamp) AS firstTimestamp, MAX(timestamp) AS lastTimestamp
-        FROM messages GROUP BY conversationId ORDER BY firstTimestamp DESC
+        FROM messages WHERE userId = :userId GROUP BY conversationId ORDER BY firstTimestamp DESC
     """)
-    fun getSessionRanges(): Flow<List<SessionRange>>
+    fun getSessionRanges(userId: Long): Flow<List<SessionRange>>
 
     /**
      * 특정 대화의 모든 메시지 삭제
      */
-    @Query("DELETE FROM messages WHERE conversationId = :conversationId")
-    suspend fun deleteMessagesByConversationId(conversationId: String)
+    @Query("DELETE FROM messages WHERE conversationId = :conversationId AND userId = :userId")
+    suspend fun deleteMessagesByConversationId(conversationId: String, userId: Long)
 
     /**
-     * 모든 메시지 삭제
-     * - 주의: 모든 대화 기록이 삭제됨
+     * 특정 계정의 모든 메시지 삭제
+     * - 주의: 해당 계정의 모든 대화 기록이 삭제됨
      */
-    @Query("DELETE FROM messages")
-    suspend fun deleteAllMessages()
+    @Query("DELETE FROM messages WHERE userId = :userId")
+    suspend fun deleteAllMessages(userId: Long)
 
     /**
      * 특정 대화의 메시지 개수 조회
      */
-    @Query("SELECT COUNT(*) FROM messages WHERE conversationId = :conversationId")
-    suspend fun getMessageCount(conversationId: String): Int
+    @Query("SELECT COUNT(*) FROM messages WHERE conversationId = :conversationId AND userId = :userId")
+    suspend fun getMessageCount(conversationId: String, userId: Long): Int
 
     /**
      * 특정 대화의 마지막 메시지 조회
      */
-    @Query("SELECT * FROM messages WHERE conversationId = :conversationId ORDER BY timestamp DESC LIMIT 1")
-    suspend fun getLastMessage(conversationId: String): MessageEntity?
+    @Query("SELECT * FROM messages WHERE conversationId = :conversationId AND userId = :userId ORDER BY timestamp DESC LIMIT 1")
+    suspend fun getLastMessage(conversationId: String, userId: Long): MessageEntity?
+
+    /**
+     * DB v5 마이그레이션 직후 남아있는 레거시 행(userId=-1)을 현재 로그인 사용자에게 귀속.
+     * 이미 귀속된 행은 없으므로 앱 시작 시마다 호출해도 안전(멱등)함.
+     * @return 갱신된 행 수
+     */
+    @Query("UPDATE messages SET userId = :userId WHERE userId = -1")
+    suspend fun backfillLegacyOwner(userId: Long): Int
 }
 
 /**

--- a/android/app/src/main/java/com/example/graduation_project/data/local/entity/MessageEntity.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/entity/MessageEntity.kt
@@ -15,6 +15,7 @@ import androidx.room.PrimaryKey
  * @param role 발화자 역할 ("user" 또는 "assistant")
  * @param content 메시지 내용
  * @param timestamp 메시지 생성 시간 (밀리초)
+ * @param userId 메시지 소유자 (계정별 로컬 캐시 격리용, DB v5부터 추가 - 레거시 행은 -1)
  */
 @Entity(tableName = "messages")
 data class MessageEntity(
@@ -23,7 +24,8 @@ data class MessageEntity(
     val conversationId: String,
     val role: String,
     val content: String,
-    val timestamp: Long
+    val timestamp: Long,
+    val userId: Long
 ) {
     companion object {
         const val ROLE_USER = "user"

--- a/android/app/src/main/java/com/example/graduation_project/data/local/mapper/MessageMapper.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/local/mapper/MessageMapper.kt
@@ -12,7 +12,7 @@ import com.example.graduation_project.presentation.model.MessageUiModel
  * val uiModel = entity.toUiModel()
  *
  * // UiModel -> Entity
- * val entity = uiModel.toEntity(conversationId = "session-123")
+ * val entity = uiModel.toEntity(conversationId = "session-123", userId = 1L)
  * ```
  */
 
@@ -31,14 +31,16 @@ fun MessageEntity.toUiModel(): MessageUiModel {
 /**
  * MessageUiModel을 MessageEntity로 변환
  * @param conversationId 대화 세션 ID (Entity에 필요)
+ * @param userId 메시지 소유자 (계정별 로컬 캐시 격리용)
  */
-fun MessageUiModel.toEntity(conversationId: String): MessageEntity {
+fun MessageUiModel.toEntity(conversationId: String, userId: Long): MessageEntity {
     return MessageEntity(
         id = this.id,
         conversationId = conversationId,
         role = if (this.isFromUser) MessageEntity.ROLE_USER else MessageEntity.ROLE_ASSISTANT,
         content = this.text,
-        timestamp = this.timestamp
+        timestamp = this.timestamp,
+        userId = userId
     )
 }
 
@@ -52,6 +54,6 @@ fun List<MessageEntity>.toUiModels(): List<MessageUiModel> {
 /**
  * MessageUiModel 리스트를 MessageEntity 리스트로 변환
  */
-fun List<MessageUiModel>.toEntities(conversationId: String): List<MessageEntity> {
-    return this.map { it.toEntity(conversationId) }
+fun List<MessageUiModel>.toEntities(conversationId: String, userId: Long): List<MessageEntity> {
+    return this.map { it.toEntity(conversationId, userId) }
 }

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/AuthRepository.kt
@@ -1,10 +1,15 @@
 package com.example.graduation_project.data.repository
 
+import android.app.Application
 import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.api.AuthApi
 import com.example.graduation_project.data.api.safeApiCall
+import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.TokenStorage
+import com.example.graduation_project.data.local.dao.ConversationDiaryLinkDao
+import com.example.graduation_project.data.local.dao.DiaryDao
+import com.example.graduation_project.data.local.dao.LocationPointDao
 import com.example.graduation_project.data.model.LoginRequest
 import com.example.graduation_project.data.model.RefreshRequest
 import com.example.graduation_project.data.model.SignupRequest
@@ -12,7 +17,12 @@ import com.example.graduation_project.data.model.TokenResponse
 
 class AuthRepository(
     private val tokenStorage: TokenStorage,
-    private val authApi: AuthApi = ApiClient.authApi
+    application: Application,
+    private val authApi: AuthApi = ApiClient.authApi,
+    private val diaryDao: DiaryDao = AppDatabase.getInstance(application).diaryDao(),
+    private val conversationDiaryLinkDao: ConversationDiaryLinkDao =
+        AppDatabase.getInstance(application).conversationDiaryLinkDao(),
+    private val locationPointDao: LocationPointDao = AppDatabase.getInstance(application).locationPointDao()
 ) {
 
     suspend fun signup(loginId: String, password: String, name: String): ApiResult<TokenResponse> {
@@ -20,6 +30,7 @@ class AuthRepository(
             authApi.signup(SignupRequest(loginId, password, name))
         }
         if (result is ApiResult.Success) {
+            clearOtherAccountCache()
             tokenStorage.saveTokens(result.data.accessToken, result.data.refreshToken)
         }
         return result
@@ -30,6 +41,7 @@ class AuthRepository(
             authApi.login(LoginRequest(loginId, password))
         }
         if (result is ApiResult.Success) {
+            clearOtherAccountCache()
             tokenStorage.saveTokens(result.data.accessToken, result.data.refreshToken)
         }
         return result
@@ -46,8 +58,20 @@ class AuthRepository(
             ApiResult.Success(Unit)
         }
         tokenStorage.clear()
+        clearOtherAccountCache()
         return result
     }
 
     fun hasAccessToken(): Boolean = tokenStorage.getAccessToken() != null
+
+    /**
+     * 계정 전환 시 다른 계정의 일기/위치 캐시가 남아 노출되지 않도록 정리.
+     * messages는 여기서 지우지 않음 - userId로 격리되어 있고 서버에 원본이 없는
+     * 유일한 사본이라 계정별로 보존됨 (MessageDao 참조)
+     */
+    private suspend fun clearOtherAccountCache() {
+        diaryDao.deleteAll()
+        conversationDiaryLinkDao.deleteAll()
+        locationPointDao.deleteAll()
+    }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/LoginViewModel.kt
@@ -28,7 +28,8 @@ data class LoginUiState(
 class LoginViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository: AuthRepository = AuthRepository(
-        tokenStorage = TokenStorage(application)
+        tokenStorage = TokenStorage(application),
+        application = application
     )
 
     private val _uiState = MutableStateFlow(LoginUiState())

--- a/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/auth/SignupViewModel.kt
@@ -32,7 +32,8 @@ data class SignupUiState(
 class SignupViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository: AuthRepository = AuthRepository(
-        tokenStorage = TokenStorage(application)
+        tokenStorage = TokenStorage(application),
+        application = application
     )
 
     private val _uiState = MutableStateFlow(SignupUiState())

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.graduation_project.data.alarm.ConversationAlarmReceiver
+import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiException
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.health.HealthConnectManager
@@ -87,6 +88,9 @@ class ConversationViewModel(
 ) : AndroidViewModel(application) {
 
     private val getHealthDataUseCase = GetHealthDataUseCase(healthRepository)
+
+    // 로컬 메시지 캐시 격리용 - 계정 전환 시 다른 계정의 대화가 섞이지 않도록 함
+    private val currentUserId: Long = ApiClient.tokenStorage?.getCurrentUserId() ?: -1L
 
     // 내부에서만 수정 가능한 상태
     private val _uiState = MutableStateFlow(ConversationUiState())
@@ -814,7 +818,8 @@ class ConversationViewModel(
                     conversationId = convId,
                     role = if (message.isFromUser) MessageEntity.ROLE_USER else MessageEntity.ROLE_ASSISTANT,
                     content = message.text,
-                    timestamp = message.timestamp
+                    timestamp = message.timestamp,
+                    userId = currentUserId
                 )
             )
         }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.entity.DiaryEntity
 import com.example.graduation_project.presentation.model.ConversationSummary
@@ -71,6 +72,7 @@ class DiaryDetailViewModel(
     private val messageDao = database.messageDao()
     private val diaryDao = database.diaryDao()
     private val conversationDiaryLinkDao = database.conversationDiaryLinkDao()
+    private val currentUserId: Long = ApiClient.tokenStorage?.getCurrentUserId() ?: -1L
 
     private val _uiState = MutableStateFlow(DiaryDetailUiState())
     val uiState: StateFlow<DiaryDetailUiState> = _uiState.asStateFlow()
@@ -82,7 +84,7 @@ class DiaryDetailViewModel(
     private fun load() {
         viewModelScope.launch {
             combine(
-                messageDao.getSessionRanges(),
+                messageDao.getSessionRanges(currentUserId),
                 conversationDiaryLinkDao.observeAll()
             ) { ranges, links -> ranges to links.associate { it.conversationId to it.diaryDate } }
                 .collect { (ranges, linkedDates) ->
@@ -90,7 +92,7 @@ class DiaryDetailViewModel(
                     // 없으면 lastTimestamp 휴리스틱으로 폴백
                     val sessions = ranges
                         .filter { resolveDateKey(it, linkedDates[it.conversationId]) == date }
-                        .mapNotNull { buildSessionSummary(messageDao, it, date) }
+                        .mapNotNull { buildSessionSummary(messageDao, it, date, currentUserId) }
                     _uiState.value = DiaryDetailUiState(
                         diary = diaryDao.getByDate(date),
                         sessions = sessions,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/DiaryViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.api.ApiResult
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.dao.SessionRange
@@ -70,6 +71,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     private val diaryDao = database.diaryDao()
     private val conversationDiaryLinkDao = database.conversationDiaryLinkDao()
     private val diaryRepository = DiaryRepository(diaryDao)
+    private val currentUserId: Long = ApiClient.tokenStorage?.getCurrentUserId() ?: -1L
 
     private val currentMonth = MutableStateFlow(YearMonth.now(KST_ZONE))
     private val syncError = MutableStateFlow<String?>(null)
@@ -112,7 +114,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 .flatMapLatest { month ->
                     combine(
                         diaryRepository.observeMonth(month),
-                        messageDao.getSessionRanges(),
+                        messageDao.getSessionRanges(currentUserId),
                         conversationDiaryLinkDao.observeAll(),
                         syncError
                     ) { diaries, ranges, links, error ->
@@ -157,7 +159,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 diary != null -> DayCellState.HasDiary(diary, sessionsForDate.size)
                 sessionsForDate.isNotEmpty() -> {
                     val summaries = sessionsForDate.mapNotNull { range ->
-                        buildSessionSummary(messageDao, range, dateKey)
+                        buildSessionSummary(messageDao, range, dateKey, currentUserId)
                     }
                     if (summaries.isEmpty()) DayCellState.Empty else DayCellState.HasSessions(summaries)
                 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/diary/SessionSummaries.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/diary/SessionSummaries.kt
@@ -54,9 +54,10 @@ internal fun formatKoreanTime(timestamp: Long): String =
 internal suspend fun buildSessionSummary(
     messageDao: MessageDao,
     range: SessionRange,
-    dateKey: String
+    dateKey: String,
+    userId: Long
 ): ConversationSummary? {
-    val messages = messageDao.getMessagesByConversationIdOnce(range.conversationId)
+    val messages = messageDao.getMessagesByConversationIdOnce(range.conversationId, userId)
     if (messages.isEmpty()) return null
 
     val first = messages.first()

--- a/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryDetailScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/history/ConversationHistoryDetailScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.graduation_project.data.api.ApiClient
 import com.example.graduation_project.data.local.AppDatabase
 import com.example.graduation_project.data.local.entity.MessageEntity
 import com.example.graduation_project.presentation.conversation.components.MessageItem
@@ -64,6 +65,7 @@ class ConversationHistoryDetailViewModel(
 ) : AndroidViewModel(application) {
 
     private val messageDao = AppDatabase.getInstance(application).messageDao()
+    private val currentUserId: Long = ApiClient.tokenStorage?.getCurrentUserId() ?: -1L
 
     private val _uiState = MutableStateFlow(HistoryDetailUiState())
     val uiState: StateFlow<HistoryDetailUiState> = _uiState.asStateFlow()
@@ -74,7 +76,7 @@ class ConversationHistoryDetailViewModel(
 
     private fun loadMessages() {
         viewModelScope.launch {
-            messageDao.getMessagesByConversationId(conversationId).collect { entities ->
+            messageDao.getMessagesByConversationId(conversationId, currentUserId).collect { entities ->
                 val uiModels = entities.map {
                     MessageUiModel(
                         id = it.id,

--- a/android/app/src/test/java/com/example/graduation_project/data/local/AppDatabaseMigrationTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/local/AppDatabaseMigrationTest.kt
@@ -57,6 +57,81 @@ class AppDatabaseMigrationTest {
         return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
     }
 
+    /** v3 스키마 + MIGRATION_3_4가 만드는 conversation_diary_link (app/schemas/.../4.json 기준) */
+    private fun openV4Database(): SupportSQLiteDatabase {
+        val config = SupportSQLiteOpenHelper.Configuration.builder(ApplicationProvider.getApplicationContext())
+            .name(null) // in-memory
+            .callback(object : SupportSQLiteOpenHelper.Callback(4) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `messages` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, " +
+                            "`role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`id`))"
+                    )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `location_points` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                            "`latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `date` TEXT NOT NULL)"
+                    )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `diaries` (`date` TEXT NOT NULL, `serverId` INTEGER NOT NULL, " +
+                            "`title` TEXT, `content` TEXT, `status` TEXT NOT NULL, `failureReason` TEXT, `weather` TEXT, " +
+                            "`mood` TEXT, `updatedAt` TEXT, PRIMARY KEY(`date`))"
+                    )
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `conversation_diary_link` (`conversationId` TEXT NOT NULL, " +
+                            "`diaryDate` TEXT NOT NULL, PRIMARY KEY(`conversationId`))"
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+            })
+            .build()
+        return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
+    }
+
+    @Test
+    fun `MIGRATION_4_5는 messages를 보존하며 userId를 -1로 채우고 diaries conversation_diary_link location_points는 비운다`() {
+        // given: v4 상태의 DB를 만들고, 계정 구분 없이 쌓여있던 기존 데이터를 채운다 (유출 재현 상황)
+        val db = openV4Database()
+        db.execSQL(
+            "INSERT INTO messages (id, conversationId, role, content, timestamp) " +
+                "VALUES ('m1', 'conv-1', 'user', '안녕하세요', 1000)"
+        )
+        db.execSQL(
+            "INSERT INTO diaries (date, serverId, title, content, status, failureReason, weather, mood, updatedAt) " +
+                "VALUES ('2026-01-15', 1, '1월 15일의 일기', '오늘 하루', 'SUCCESS', NULL, '맑음', NULL, '2026-01-15T20:00:00')"
+        )
+        db.execSQL("INSERT INTO conversation_diary_link (conversationId, diaryDate) VALUES ('conv-1', '2026-01-15')")
+        db.execSQL(
+            "INSERT INTO location_points (latitude, longitude, timestamp, date) VALUES (37.5, 127.0, 1000, '2026-01-15')"
+        )
+
+        // when: 프로덕션 코드의 MIGRATION_4_5를 그대로 실행
+        AppDatabase.MIGRATION_4_5.migrate(db)
+
+        // then: messages는 삭제되지 않고 보존되며(서버에 원본이 없는 유일한 사본), userId는 -1(소유자 미상)로 채워짐
+        db.query("SELECT id, userId FROM messages WHERE id = 'm1'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("m1", cursor.getString(cursor.getColumnIndexOrThrow("id")))
+            assertEquals(-1L, cursor.getLong(cursor.getColumnIndexOrThrow("userId")))
+        }
+
+        // then: diaries / conversation_diary_link / location_points는 계정 구분 없이 캐시된 데이터라 전부 비워짐
+        db.query("SELECT COUNT(*) FROM diaries").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM conversation_diary_link").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM location_points").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        db.close()
+    }
+
     @Test
     fun `MIGRATION_3_4는 기존 messages diaries 데이터를 보존하고 conversation_diary_link 테이블을 정확히 만든다`() {
         // given: v3 상태의 DB를 만들고 기존 데이터를 채운다

--- a/android/app/src/test/java/com/example/graduation_project/presentation/diary/SessionSummariesTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/diary/SessionSummariesTest.kt
@@ -56,13 +56,13 @@ class SessionSummariesTest {
     fun `buildSessionSummary는 전달받은 dateKey를 그대로 표시 날짜로 사용한다`() = runTest {
         // given
         val messages = listOf(
-            MessageEntity("m1", "conv-1", MessageEntity.ROLE_USER, "안녕하세요", firstTimestamp),
-            MessageEntity("m2", "conv-1", MessageEntity.ROLE_ASSISTANT, "안녕하세요, 오늘 하루 어떠셨나요?", lastTimestamp)
+            MessageEntity("m1", "conv-1", MessageEntity.ROLE_USER, "안녕하세요", firstTimestamp, userId = 1L),
+            MessageEntity("m2", "conv-1", MessageEntity.ROLE_ASSISTANT, "안녕하세요, 오늘 하루 어떠셨나요?", lastTimestamp, userId = 1L)
         )
-        coEvery { mockMessageDao.getMessagesByConversationIdOnce("conv-1") } returns messages
+        coEvery { mockMessageDao.getMessagesByConversationIdOnce("conv-1", 1L) } returns messages
 
         // when: 호출부(DiaryViewModel)가 그룹핑에 쓴 것과 동일한 dateKey를 전달
-        val summary = buildSessionSummary(mockMessageDao, range, dateKey = "2026-01-17")
+        val summary = buildSessionSummary(mockMessageDao, range, dateKey = "2026-01-17", userId = 1L)
 
         // then: buildSessionSummary가 내부적으로 다시 계산하지 않고 전달받은 dateKey를 그대로 반영해야
         // 목록 그룹핑과 카드에 표시되는 날짜가 항상 일치함


### PR DESCRIPTION
## Summary
- 같은 기기에서 로그아웃 후 다른 계정으로 로그인하면 이전 계정의 일기·대화 내용이 그대로 노출되던 버그 수정
- 근본 원인: 로컬 Room 캐시(`diaries`/`messages`/`conversation_diary_link`)가 계정 구분 컬럼 없이 저장되고, `AuthRepository.logout()`이 토큰만 지우고 로컬 DB는 정리하지 않았음
- `messages`(서버에 원본 없는 유일한 사본)는 `userId` 컬럼으로 계정별 격리하여 보존, `diaries`/`conversation_diary_link`/`location_points`(서버 재동기화 가능한 캐시)는 로그아웃/로그인/회원가입 시 전체 삭제
- DB v4→v5 마이그레이션: 레거시 메시지는 `userId=-1`로 표시 후 앱 시작 시 현재 로그인 사용자에게 백필(기존 설치 기기의 유출 데이터 정리 포함)

## Test plan
- [x] `./gradlew testLocalDebugUnitTest` 전체 통과 (신규 `MIGRATION_4_5` 회귀 테스트 포함)
- [x] `./gradlew assembleDebug` 빌드 성공
- [ ] 실기기/에뮬레이터에서 계정 A로 대화·일기 생성 → 로그아웃 → 계정 B 로그인 → A의 데이터 미노출 확인
- [ ] 계정 A로 재로그인 시 A의 대화 내역 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdxuadyGaVxT8Nw6cw27Yg