### PR TITLE
fix(android): 홈 화면 대화 시작 시간이 설정 변경 후 갱신 안 되는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.graduation_project.R
 import com.example.graduation_project.data.model.WeatherResponse
@@ -54,6 +58,18 @@ fun HomeScreen(
     )
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // 설정 화면 등에서 대화 시간을 바꾸고 돌아왔을 때 최신 값을 반영
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refresh()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     HomeScreenContent(
         userName = uiState.userName,

--- a/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/home/HomeViewModel.kt
@@ -56,6 +56,17 @@ class HomeViewModel(
         }
     }
 
+    /**
+     * 홈 화면 재진입 시 사용자 정보(대화 시간 등)를 서버와 다시 동기화.
+     * 설정 화면에서 값을 바꾸고 돌아와도 홈 ViewModel 인스턴스는 그대로 유지되므로
+     * (NavBackStackEntry 스코프), init 시점의 값만으론 최신 상태를 반영하지 못함.
+     */
+    fun refresh() {
+        viewModelScope.launch {
+            loadUserPreferences()
+        }
+    }
+
     private suspend fun loadUserPreferences() {
         when (val result = userRepository.getPreferences()) {
             is ApiResult.Success -> {


### PR DESCRIPTION
## Summary
- 설정 화면에서 대화 시간을 변경하고 홈으로 돌아와도 예전 값이 계속 표시되던 문제 수정
- 원인: `HomeViewModel`이 `init` 시점에만 서버 사용자 정보(대화 시간 등)를 조회하는데, Home 화면의 `viewModel()`이 NavBackStackEntry에 스코프되어 있어 설정 화면을 다녀와도 같은 인스턴스가 재사용되고 init이 재실행되지 않음
- 이미 코드베이스에 쓰이고 있는 `DisposableEffect` + `ON_RESUME` 패턴(`SettingsScreen`, `HealthConnectPermissionHandler`, `UnifiedPermissionHandler`, `ConversationScreen`과 동일)을 Home 화면에도 적용해, 화면 재진입 시마다 `HomeViewModel.refresh()`로 사용자 정보(대화 시간 + 이름)를 다시 동기화

## Test plan
- [x] `./gradlew testLocalDebugUnitTest` 통과
- [x] `./gradlew assembleDebug` 빌드 성공
- [ ] 실기기/에뮬레이터에서 설정 화면에서 대화 시간 변경 → 홈으로 복귀 시 새 시간이 바로 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdxuadyGaVxT8Nw6cw27Yg