### PR TITLE
ci: SSH 기반 EC2 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-ssh.yml
+++ b/.github/workflows/deploy-ssh.yml
@@ -1,0 +1,56 @@
+name: CD - Deploy to EC2 via SSH
+
+on:
+  push:
+    branches: [develop]
+    paths: ['server/**']
+  workflow_dispatch:   # 수동 실행도 가능하게
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: gradle
+
+      - name: Build with Gradle
+        working-directory: server
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      - name: Copy JAR to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "server/build/libs/echo-0.0.1-SNAPSHOT.jar"
+          target: "/home/ec2-user/"
+          strip_components: 3   # server/build/libs 경로 제거 → 홈에 파일만 배치
+
+      - name: Restart service on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            sudo systemctl restart echo
+            sleep 40
+            if sudo ss -ltnp | grep -q ':8080'; then
+              echo "Deploy success: 8080 is listening"
+            else
+              echo "Deploy failed: 8080 not listening"
+              sudo journalctl -u echo -n 20 --no-pager
+              exit 1
+            fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: CI/CD - Build and Deploy to EC2
+name: CI/CD - Build and Deploy to EC2 (DISABLED - legacy ECR/SSM, old account)
 
+# 자동 실행 비활성화: 예전 계정(서울, ECR/SSM/액세스키) 전용이라 새 계정에서는 동작 불가.
+# 새 배포는 deploy-ssh.yml(SSH 방식) 사용. 이 파일은 참고용으로 보존하며 수동으로만 실행 가능.
 on:
-  push:
-    branches: [develop]
-    paths: ['server/**']
+  workflow_dispatch:
 
 env:
   AWS_REGION: ap-northeast-2


### PR DESCRIPTION
## 개요
새 AWS 계정(싱가포르) 환경에 맞는 SSH 기반 자동 배포 워크플로우를 추가합니다.

## 변경 내용
- **deploy-ssh.yml (신규)**: `develop` 브랜치에 `server/**` 변경이 push되면 자동 실행
  - JDK 17 빌드 (`gradlew build -x test`)
  - `scp`로 jar를 EC2에 전송
  - `systemctl restart echo` 후 8080 LISTEN 확인
- **deploy.yml (기존)**: ECR/SSM/액세스키 기반 예전 계정(서울) 전용이라 자동 트리거 비활성화(`workflow_dispatch`만). 참고용으로 파일은 보존.

## 인증 방식
- 액세스 키·ECR 없이, GitHub Secrets에 등록한 **배포 전용 SSH 키**로 EC2 접속
- Secrets: `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
- 환경변수(API 키·DB 암호)는 EC2의 `/etc/echo/echo.env`에 유지되므로 jar만 교체·재시작

## 주의
- 이 PR이 develop에 머지되면 이후 `server/**` push 시 자동 배포가 작동합니다.
- 서버 설정 PR(RDS 엔드포인트, jwt.secret 등)이 먼저 머지된 뒤 머지하는 것을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)