### PR TITLE
chore: ElevenLabs TTS voice-id 및 model 변경

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -77,6 +77,6 @@ jwt:
 # ElevenLabs TTS 설정
 elevenlabs:
   base-url: https://api.elevenlabs.io/v1
-  voice-id: kcQkGnn0HAT2JRDQ4Ljp
-  model: eleven_multilingual_v2
+  voice-id: zmh5xhBvMzqR4ZlXgcgL
+  model: eleven_v3
   # api-key는 application-local.yaml에서 설정 (예: api-key: your-key-here)

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -77,6 +77,6 @@ jwt:
 # ElevenLabs TTS 설정
 elevenlabs:
   base-url: https://api.elevenlabs.io/v1
-  voice-id: sf8Bpb1IU97NI9BHSMRf
+  voice-id: kcQkGnn0HAT2JRDQ4Ljp
   model: eleven_multilingual_v2
   # api-key는 application-local.yaml에서 설정 (예: api-key: your-key-here)


### PR DESCRIPTION
## Summary
- ElevenLabs TTS voice-id 변경: `sf8Bpb1IU97NI9BHSMRf` → `zmh5xhBvMzqR4ZlXgcgL`
- ElevenLabs TTS model 변경: `eleven_multilingual_v2` → `eleven_v3`

## Test plan
- [x] `./gradlew build` 통과 확인
- [x] 로컬에서 서버 구동 후 대화 시작 → 새 voice-id/model로 TTS 생성 확인

https://claude.ai/code/session_01T9vQ72p9u22e5u1fFUvctr