### PR TITLE
perf: 대화 종료 시 장기기억 추출을 백그라운드로 분리

### DIFF
--- a/server/lombok.config
+++ b/server/lombok.config
@@ -1,0 +1,6 @@
+# Lombok이 생성하는 생성자 파라미터로 복사할 애노테이션 목록.
+# Spring 6.1부터 LocalVariableTable 기반 파라미터명 추론이 제거되어,
+# Lombok 생성자에서는 이름으로 빈을 구분할 수 없다. 따라서 같은 타입의 빈이
+# 둘 이상일 때는 @Qualifier가 생성자 파라미터까지 전달돼야 한다.
+config.stopBubbling = true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -21,6 +21,7 @@ import com.example.echo.prompt.service.PromptService;
 import com.example.echo.voice.service.VoiceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,6 +41,9 @@ public class ConversationService {
     private final DiaryService diaryService;
     private final HealthDataService healthDataService;
     private final MemoryService memoryService;
+    // @EnableScheduling이 만드는 taskScheduler도 TaskExecutor라 타입만으로는 모호하다.
+    // application.yaml의 spring.task.execution 설정을 받는 쪽을 명시적으로 지정한다.
+    @Qualifier("applicationTaskExecutor")
     private final TaskExecutor taskExecutor;
 
     public ConversationStartResponse startConversation(Long userId, HealthData healthData, RawLocationData rawLocationData) {

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -21,6 +21,7 @@ import com.example.echo.prompt.service.PromptService;
 import com.example.echo.voice.service.VoiceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -39,6 +40,7 @@ public class ConversationService {
     private final DiaryService diaryService;
     private final HealthDataService healthDataService;
     private final MemoryService memoryService;
+    private final TaskExecutor taskExecutor;
 
     public ConversationStartResponse startConversation(Long userId, HealthData healthData, RawLocationData rawLocationData) {
         // 0. 건강 데이터 저장 (Android에서 수신한 경우)
@@ -148,6 +150,21 @@ public class ConversationService {
         }
     }
 
+    /**
+     * 비동기 기억 추출에 넘길 컨텍스트 스냅샷
+     *
+     * finalizeContext()가 원본을 contextStore에서 제거하고, 같은 userId로 새 대화가 시작되면
+     * 새 UserContext가 만들어진다. UserContext는 가변(@Data)이므로 추출에 실제로 쓰이는 값만
+     * 불변으로 복사해 백그라운드 작업을 세션 수명과 분리한다.
+     */
+    private UserContext snapshotForMemoryExtraction(UserContext context) {
+        return UserContext.builder()
+                .userId(context.getUserId())
+                .preferences(context.getPreferences())
+                .conversationHistory(List.copyOf(context.getConversationHistory()))
+                .build();
+    }
+
     public TtsRetryResponse retryTts(Long userId) {
         UserContext context = contextService.getContext(userId);
 
@@ -190,13 +207,16 @@ public class ConversationService {
                 diaryStatus = "SKIPPED";
             }
 
-            // 3. 장기기억 추출 (동기) - 일기와 독립적이며, 실패해도 대화 종료·일기 결과에 영향 없음
-            //    대화 원문은 아래 finalizeContext에서 사라지므로 반드시 그 전에 추출해야 함
-            try {
-                memoryService.extractAndSaveMemories(context);
-            } catch (Exception e) {
-                log.warn("장기기억 추출 실패 - userId: {}", userId, e);
-            }
+            // 3. 장기기억 추출 (비동기) - 응답에 실리지 않으므로 사용자를 기다리게 하지 않음
+            //    대화 원문은 아래 finalizeContext에서 사라지므로, 넘기기 전에 스냅샷을 뜸
+            UserContext snapshot = snapshotForMemoryExtraction(context);
+            taskExecutor.execute(() -> {
+                try {
+                    memoryService.extractAndSaveMemories(snapshot);
+                } catch (Exception e) {
+                    log.warn("장기기억 추출 실패 - userId: {}", userId, e);
+                }
+            });
         } catch (Exception e) {
             log.error("일기 생성 실패 - userId: {}", userId, e);
             diaryStatus = "FAILED";

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -25,6 +25,13 @@ spring:
     init:
       mode: always  # 매 시작마다 data.sql 실행 (개발용)
 
+  # 비동기 작업(장기기억 추출 등) 스레드풀 - 배포/재시작 시 진행 중인 작업을 최대한 마치고 종료
+  task:
+    execution:
+      shutdown:
+        await-termination: true
+        await-termination-period: 30s
+
 openai:
   api:
     url: https://api.openai.com/v1

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest.java
@@ -60,7 +60,7 @@ class ConversationServiceTest {
 
     @BeforeEach
     void setUp() {
-        // 직접 생성자로 주입
+        // 직접 생성자로 주입 (taskExecutor는 제출 즉시 실행하는 동기 구현으로 대체)
         conversationService = new ConversationService(
                 voiceService,
                 promptService,
@@ -68,7 +68,8 @@ class ConversationServiceTest {
                 contextService,
                 diaryService,
                 healthDataService,
-                memoryService
+                memoryService,
+                Runnable::run
         );
         mockContext = createMockContext();
     }

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -67,6 +68,9 @@ class ConversationServiceTest2 {
 
     @Mock
     private MemoryService memoryService;
+
+    @Mock
+    private TaskExecutor taskExecutor;
 
     private Long userId;
     private UserContext mockContext;
@@ -394,19 +398,39 @@ class ConversationServiceTest2 {
         }
 
         @Test
-        @DisplayName("성공: 대화 원문이 사라지기 전에 장기기억을 추출한다")
-        void success_extractsMemoriesBeforeContextIsFinalized() {
+        @DisplayName("성공: 장기기억 추출은 컨텍스트 정리 전에 백그라운드로 제출되고, 원본과 분리된 스냅샷이 전달된다")
+        void success_submitsMemoryExtractionBeforeContextIsFinalizedWithSnapshot() {
             // given
+            mockContext.getConversationHistory().add(
+                    ConversationTurn.builder()
+                            .userMessage("테스트")
+                            .aiResponse("응답")
+                            .timestamp(LocalDateTime.now())
+                            .build()
+            );
             given(contextService.getContext(userId)).willReturn(mockContext);
             willDoNothing().given(contextService).finalizeContext(userId);
 
             // when
             conversationService.endConversation(userId);
 
-            // then: finalizeContext가 대화 원문을 지우므로 추출이 반드시 그 전이어야 함
-            var inOrder = inOrder(memoryService, contextService);
-            inOrder.verify(memoryService).extractAndSaveMemories(mockContext);
+            // then: taskExecutor 제출이 finalizeContext보다 먼저여야 함 (제출 시점에 원본 대화 원문이 아직 살아있어야 함)
+            var inOrder = inOrder(taskExecutor, contextService);
+            inOrder.verify(taskExecutor).execute(any(Runnable.class));
             inOrder.verify(contextService).finalizeContext(userId);
+
+            // 그리고: 백그라운드 작업이 실제로 실행되면, 넘겨받는 컨텍스트는 원본과 다른 인스턴스이되
+            // 대화 원문은 그대로 담고 있어야 함 (finalizeContext가 원본을 지워도 영향받지 않도록)
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            then(taskExecutor).should().execute(taskCaptor.capture());
+            taskCaptor.getValue().run();
+
+            ArgumentCaptor<UserContext> snapshotCaptor = ArgumentCaptor.forClass(UserContext.class);
+            then(memoryService).should().extractAndSaveMemories(snapshotCaptor.capture());
+            UserContext snapshot = snapshotCaptor.getValue();
+            assertThat(snapshot).isNotSameAs(mockContext);
+            assertThat(snapshot.getUserId()).isEqualTo(mockContext.getUserId());
+            assertThat(snapshot.getConversationHistory()).isEqualTo(mockContext.getConversationHistory());
         }
 
         @Test
@@ -422,7 +446,11 @@ class ConversationServiceTest2 {
             given(contextService.getContext(userId)).willReturn(mockContext);
             given(diaryService.generateAndSaveDiary(mockContext)).willReturn(new DiaryOutcome.Processed(diary));
             willThrow(new RuntimeException("기억 추출 실패"))
-                    .given(memoryService).extractAndSaveMemories(mockContext);
+                    .given(memoryService).extractAndSaveMemories(any());
+            willAnswer(invocation -> {
+                invocation.getArgument(0, Runnable.class).run();
+                return null;
+            }).given(taskExecutor).execute(any(Runnable.class));
             willDoNothing().given(contextService).finalizeContext(userId);
 
             // when


### PR DESCRIPTION
## Summary
- `POST /api/conversations/end`가 일기 생성(동기)에 이어 장기기억 추출까지 동기로 기다리게 하고 있었음. 추출 결과는 `ConversationEndResponse`에 실리지 않는 순수 부수효과라 사용자가 기다릴 이유가 없었음
- `ConversationService`에 `TaskExecutor`를 주입해 `endConversation()`의 기억 추출을 백그라운드로 제출. `finalizeContext()`가 컨텍스트를 지우기 전에 추출에 필요한 값(`userId`/`preferences`/대화이력)만 스냅샷으로 복사해 넘김
- 배포/재시작 시 진행 중인 추출을 최대한 마치도록 `spring.task.execution.shutdown.await-termination` 설정 추가

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `ConversationServiceTest`, `ConversationServiceTest2` (endConversation 7건, 스냅샷/제출 순서 검증 포함) 통과
- [x] `MemoryServiceTest`, `MemoryServicePersistenceTest` 무변경 통과 (회귀 없음)
- [x] `./gradlew build` 성공
- [ ] 로컬/스테이징에서 대화 종료 후 로그 순서 확인: `=== 대화 종료 완료 ===`가 `장기기억 갱신 완료`보다 먼저 찍히는지 (분리 성공 확인)