### PR TITLE
fix: 집 등록 위치 획득 진단 로그 및 정확도/타임아웃 강화

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationManager.kt
@@ -3,6 +3,7 @@ package com.example.graduation_project.data.location
 import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -20,7 +21,9 @@ class LocationManager @VisibleForTesting internal constructor(
     )
 
     companion object {
-        private const val LOCATION_TIMEOUT_MS = 5_000L
+        private const val TAG = "LocationManager"
+        // 집 등록은 사용자가 한 번 누르는 액션이라 정확도를 위해 여유 있게 대기
+        private const val LOCATION_TIMEOUT_MS = 15_000L
     }
 
     @SuppressLint("MissingPermission")
@@ -30,11 +33,13 @@ class LocationManager @VisibleForTesting internal constructor(
                 val cancellationToken = CancellationTokenSource()
 
                 fusedLocationClient.getCurrentLocation(
-                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                    Priority.PRIORITY_HIGH_ACCURACY,
                     cancellationToken.token
                 ).addOnSuccessListener { loc ->
+                    Log.d(TAG, "getCurrentLocation success: ${loc?.let { "(${it.latitude}, ${it.longitude})" } ?: "null"}")
                     continuation.resume(loc)
-                }.addOnFailureListener {
+                }.addOnFailureListener { e ->
+                    Log.w(TAG, "getCurrentLocation failed", e)
                     continuation.resume(null)
                 }
 
@@ -44,6 +49,9 @@ class LocationManager @VisibleForTesting internal constructor(
             }
         }
 
+        if (location == null) {
+            Log.w(TAG, "getCurrentLocation null (타임아웃 ${LOCATION_TIMEOUT_MS}ms 또는 미가용) → lastLocation 폴백")
+        }
         return location ?: getLastKnownLocation()
     }
 
@@ -51,7 +59,13 @@ class LocationManager @VisibleForTesting internal constructor(
     private suspend fun getLastKnownLocation(): Location? =
         suspendCancellableCoroutine { continuation ->
             fusedLocationClient.lastLocation
-                .addOnSuccessListener { loc -> continuation.resume(loc) }
-                .addOnFailureListener { continuation.resume(null) }
+                .addOnSuccessListener { loc ->
+                    Log.d(TAG, "lastLocation: ${loc?.let { "(${it.latitude}, ${it.longitude})" } ?: "null"}")
+                    continuation.resume(loc)
+                }
+                .addOnFailureListener { e ->
+                    Log.w(TAG, "lastLocation failed", e)
+                    continuation.resume(null)
+                }
         }
 }

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -422,19 +422,35 @@ class SettingsViewModel(
             _uiState.update { it.copy(errorMessage = "위치 권한이 필요합니다. 권한을 허용한 뒤 다시 시도해주세요.") }
             return
         }
+        // 권한이 있어도 기기 위치(GPS) 토글이 꺼져 있으면 좌표를 받을 수 없음 → 명확히 안내
+        val sysLm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        val locationEnabled = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            sysLm.isLocationEnabled
+        } else {
+            sysLm.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
+                sysLm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+        }
+        if (!locationEnabled) {
+            android.util.Log.w("SettingsVM", "집 등록: 기기 위치(GPS) 꺼짐")
+            _uiState.update { it.copy(errorMessage = "기기의 위치(GPS)가 꺼져 있어요. 위치를 켜고 다시 시도해주세요.") }
+            return
+        }
         viewModelScope.launch {
             _uiState.update { it.copy(isRegisteringHome = true) }
+            android.util.Log.d("SettingsVM", "집 등록: 현재 위치 요청 시작")
             val location = com.example.graduation_project.data.location.LocationManager(context)
                 .getCurrentLocation()
             if (location == null) {
+                android.util.Log.w("SettingsVM", "집 등록: 위치 null (getCurrentLocation + lastLocation 모두 실패)")
                 _uiState.update {
                     it.copy(
                         isRegisteringHome = false,
-                        errorMessage = "현재 위치를 가져오지 못했습니다. 잠시 후 다시 시도해주세요."
+                        errorMessage = "현재 위치를 가져오지 못했습니다. 실외에서 잠시 후 다시 시도해주세요."
                     )
                 }
                 return@launch
             }
+            android.util.Log.d("SettingsVM", "집 등록: 위치 획득 (${location.latitude}, ${location.longitude}) → 서버 저장")
             when (val result = userRepository.updateHomeLocation(location.latitude, location.longitude)) {
                 is ApiResult.Success -> _uiState.update {
                     applyPrefs(it, result.data).copy(
@@ -442,8 +458,11 @@ class SettingsViewModel(
                         savedMessage = "현재 위치를 집으로 등록했습니다"
                     )
                 }
-                is ApiResult.Error -> _uiState.update {
-                    it.copy(isRegisteringHome = false, errorMessage = "집 등록에 실패했습니다. 다시 시도해주세요.")
+                is ApiResult.Error -> {
+                    android.util.Log.w("SettingsVM", "집 등록: 서버 저장 실패 - ${result.exception.message}")
+                    _uiState.update {
+                        it.copy(isRegisteringHome = false, errorMessage = "집 등록에 실패했습니다. 다시 시도해주세요.")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 요약
"위치 권한은 켜져 있는데 집 등록이 안 잡힘" 현상을 진단할 수 있도록 각 단계에 로그를 남기고, 집 등록처럼 사용자가 한 번 누르는 액션에 맞게 위치 획득 설정을 더 튼튼하게 만들었습니다.

> #401(거주지 기반 대화)이 머지된 뒤, 그 PR에서 실제 기기 테스트 중 발견된 후속 수정입니다.

## 변경 사항
- **LocationManager**
  - 타임아웃 5초 → **15초** (집 등록은 한 번 누르는 액션이라 여유 있게 대기)
  - 정확도 `PRIORITY_BALANCED_POWER_ACCURACY` → **`PRIORITY_HIGH_ACCURACY`**
  - `getCurrentLocation`/`lastLocation` 각 단계 성공·실패 로그 추가
- **SettingsViewModel.registerCurrentLocationAsHome**
  - 위치 **권한**은 있어도 기기 **위치(GPS) 토글**이 꺼져 있으면 좌표를 못 받는 문제를 사전 체크해 "기기의 위치(GPS)가 꺼져 있어요"로 명확히 구분 안내
  - 요청 시작 → 위치 획득 → 서버 저장까지 단계별 `Log.d`/`Log.w` 추가 (logcat `SettingsVM`/`LocationManager` 태그로 원인 바로 확인 가능)

## 테스트
- `compileProdDebugKotlin` 통과
- 실기기에서 집 등록 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
