### PR TITLE
chore: OpenRouter 채팅 모델 풀 업데이트 (2026-08 신모델 반영)

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -39,17 +39,18 @@ openai:
     model: whisper-1
     language: ko
 
-# OpenRouter (채팅 전용) - 매일 아래 목록에서 하나가 자동 선택됨 (ModelRotationService)
+# OpenRouter (채팅 전용) - 대화 세션마다 아래 목록에서 순서대로 하나씩 선택됨 (ModelRotationService)
 openrouter:
   api:
     url: https://openrouter.ai/api/v1
   chat:
     models:
       - openai/gpt-5.5
+      - openai/gpt-5.6-terra
       - anthropic/claude-sonnet-5
-      - google/gemini-3.1-flash-lite
       - anthropic/claude-haiku-4.5
-      - openai/gpt-4o-mini
+      - google/gemini-3.6-flash
+      - google/gemini-3.5-flash-lite
     temperature: 0.7
     max-tokens: 1024
 


### PR DESCRIPTION
## 요약
OpenRouter 채팅 모델 풀을 2026-08 기준 신모델로 교체했습니다. `openai/gpt-4o-mini`, `google/gemini-3.1-flash-lite`를 후속 세대로 바꾸고, 팀 실측 평가에서 가장 좋았던 `openai/gpt-5.5`는 그대로 유지했습니다.

## 변경 후 모델 풀
```yaml
models:
  - openai/gpt-5.5
  - openai/gpt-5.6-terra
  - anthropic/claude-sonnet-5
  - anthropic/claude-haiku-4.5
  - google/gemini-3.6-flash
  - google/gemini-3.5-flash-lite
```

## 판단 근거
- **`gpt-5.5` 유지**: 팀 실측 평가에서 가장 좋은 결과 → 벤치마크 스펙보다 실측 우선
- **`gpt-4o-mini` → `gpt-5.6-terra`**: GPT-5.5와 경쟁력 있는 품질에 ~2배 저렴
- **`gemini-3.1-flash-lite` → `gemini-3.6-flash`**: 최신 세대, 3.5 Flash 대비 출력 토큰 17% 절감 + 더 저렴 (3.5 Flash를 같이 넣는 건 같은 세대 중복이라 제외하고 3.6만 선택)
- **`gemini-3.5-flash-lite` 신규 추가**: 경량 슬롯
- **Claude(Sonnet 5, Haiku 4.5)**: 이미 각 티어 최신이라 변경 없음

## 검토 후 제외한 것
- **Grok(4.6 등)**: 의도적으로 필터가 느슨한 설계 철학 + 실제 콘텐츠 모더레이션 사고 이력이 있어, MCI 어르신 대상 안전 프로토콜(자살/자해 대응 등)과 상충
- **Gemini 3.1 Pro / GPT-5.6 Sol**: 추론·코딩·에이전트 특화 플래그십이라 Echo의 짧고 따뜻한 대화 응답 용도와 안 맞고, 비용·지연 모두 불리
- **GPT-5.6 Luna**: 보류. 최소 티어라 Echo의 길고 촘촘한 시스템 프롬프트(4단계 흐름, 안전 프로토콜 등) 준수력을 별도 검증한 뒤 추가 여부 결정 예정

## 배포 노트
- `application.yaml`은 jar에 패키징되므로 **재빌드 필요**
- OpenRouter 계정 **Settings → Privacy → Data Policies**의 "Non-frontier" ZDR 토글이 켜져 있으면 신규 모델 중 일부가 라우팅 안 될 수 있음 → 배포 전 **Eligibility Preview**에서 6개 모델 ID 전부 초록 체크인지 확인 권장

## 테스트
- 컴파일 통과, `ModelRotationServiceTest`/`AIServiceTest` 통과 (모델 목록은 각 테스트가 자체 fixture를 쓰므로 이 변경으로 깨지는 테스트 없음)
- `displayName()`이 신규 모델 ID를 정상 변환하는지 수동 검증 완료 (예: `gpt-5.6-terra` → "GPT 5.6 Terra", `gemini-3.6-flash` → "Gemini 3.6 Flash")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
