### PR TITLE
fix: 세션 모델 누락 + 빈 STT로 인한 대화 중 서버 오류 2건 수정

### DIFF
--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -181,6 +181,7 @@ public class ConversationService {
                 .userId(context.getUserId())
                 .preferences(context.getPreferences())
                 .conversationHistory(List.copyOf(context.getConversationHistory()))
+                .sessionModel(context.getSessionModel())
                 .build();
     }
 

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -36,6 +36,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ConversationService {
 
+    // STT 결과가 빈 문자열이면(무음·너무 짧은 녹음) AI를 호출하지 않고 바로 이 안내로 응답한다.
+    // 빈 user 메시지를 그대로 보내면 일부 프로바이더(Gemini 계열)가 "메시지가 model 턴으로
+    // 끝난다"며 400을 반환하는 문제가 있어, 애초에 빈 메시지를 만들지 않는 쪽으로 막는다.
+    private static final String EMPTY_STT_FALLBACK_RESPONSE = "죄송해요, 잘 못 들었어요. 다시 한 번 말씀해 주시겠어요?";
+
     private final VoiceService voiceService;
     private final PromptService promptService;
     private final AIService aiService;
@@ -98,17 +103,27 @@ public class ConversationService {
 
         // 2. STT 변환
         String userMessage = voiceService.speechToText(audioFile);
+        boolean sttEmpty = userMessage.isBlank();
 
         // 3. AI 응답 생성 (OpenAI 권장 방식: messages 배열)
-        String systemPrompt = context.getSystemPrompt();
-        List<ConversationTurn> history = context.getConversationHistory();
-        String aiResponse = aiService.generateResponse(systemPrompt, history, userMessage, context.getSessionModel());
+        //    STT 결과가 비어있으면(무음 등) AI를 호출하지 않고 바로 재요청 안내로 응답한다.
+        String aiResponse;
+        if (sttEmpty) {
+            log.info("STT 결과가 비어있어 AI 호출 없이 재요청 안내로 응답 - userId: {}", userId);
+            aiResponse = EMPTY_STT_FALLBACK_RESPONSE;
+        } else {
+            String systemPrompt = context.getSystemPrompt();
+            List<ConversationTurn> history = context.getConversationHistory();
+            aiResponse = aiService.generateResponse(systemPrompt, history, userMessage, context.getSessionModel());
+        }
 
         // 4. TTS 변환
         byte[] audioData = voiceService.textToSpeech(aiResponse, context.getPreferences().getVoiceSettings());
 
         // 5. 히스토리 업데이트 (동기)
-        contextService.addConversationTurn(userId, userMessage, aiResponse);
+        //    빈 user 메시지는 기록하지 않는다(null이면 첫 인사 턴처럼 AI 발화만 기록됨) -
+        //    이후 턴에서 이 히스토리가 다시 messages 배열에 실릴 때 빈 user 메시지가 섞이지 않도록.
+        contextService.addConversationTurn(userId, sttEmpty ? null : userMessage, aiResponse);
 
         return ConversationResponse.builder()
                 .userMessage(userMessage)

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -422,6 +422,7 @@ class ConversationServiceTest2 {
                             .timestamp(LocalDateTime.now())
                             .build()
             );
+            mockContext.setSessionModel("anthropic/claude-sonnet-5");
             given(contextService.getContext(userId)).willReturn(mockContext);
             willDoNothing().given(contextService).finalizeContext(userId);
 
@@ -445,6 +446,8 @@ class ConversationServiceTest2 {
             assertThat(snapshot).isNotSameAs(mockContext);
             assertThat(snapshot.getUserId()).isEqualTo(mockContext.getUserId());
             assertThat(snapshot.getConversationHistory()).isEqualTo(mockContext.getConversationHistory());
+            // 회귀 방지: sessionModel 누락 시 기억 추출 API 호출이 "No models provided"로 실패했었음
+            assertThat(snapshot.getSessionModel()).isEqualTo(mockContext.getSessionModel());
         }
 
         @Test

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -299,6 +299,36 @@ class ConversationServiceTest2 {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("Context not found");
         }
+
+        @Test
+        @DisplayName("성공: STT 결과가 비어있으면(무음 등) AI를 호출하지 않고 재요청 안내로 응답한다")
+        void success_emptySttSkipsAiCallAndAsksToRepeat() {
+            // given: 무음/너무 짧은 녹음이라 Whisper가 빈 문자열을 반환하는 상황
+            MultipartFile audioFile = new MockMultipartFile(
+                    "audio", "silence.mp3", "audio/mpeg", "silence".getBytes()
+            );
+            String systemPrompt = "시스템 프롬프트";
+            byte[] responseAudio = "response audio".getBytes();
+
+            mockContext.setSystemPrompt(systemPrompt);
+
+            given(contextService.getContext(userId)).willReturn(mockContext);
+            given(voiceService.speechToText(audioFile)).willReturn("");
+            given(voiceService.textToSpeech(anyString(), eq(mockVoiceSettings))).willReturn(responseAudio);
+
+            // when
+            ConversationResponse result = conversationService.processUserMessage(userId, audioFile);
+
+            // then: AI를 호출하지 않고 바로 재요청 안내로 응답
+            then(aiService).shouldHaveNoInteractions();
+            assertThat(result.getUserMessage()).isEmpty();
+            assertThat(result.getAiResponse()).contains("다시 한 번 말씀해");
+            assertThat(result.getAudioData()).isEqualTo(responseAudio);
+
+            // 그리고: 히스토리에는 빈 user 메시지 대신 null이 기록되어야 함
+            // (다음 턴에서 이 히스토리가 messages 배열에 실릴 때 빈 메시지가 섞이지 않도록)
+            then(contextService).should().addConversationTurn(eq(userId), isNull(), anyString());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 요약
실기기 3인 동시 테스트 중 발견된 **두 가지 버그**를 수정했습니다.

## 1. 백그라운드 기억 추출에서 세션 모델 누락 (조용한 데이터 유실)

매 대화 종료마다 백그라운드 장기기억 추출이 `"No models provided"` 400으로 실패하고 있었는데, 예외가 백그라운드 태스크의 `catch(Exception)`에 잡혀 사용자에게는 아무 에러도 안 보이는 상태였습니다.

**원인**: #403(세션별 모델 로테이션)에서 `UserContext.sessionModel`을 추가했는데, `ConversationService.endConversation()`의 `snapshotForMemoryExtraction()`이 백그라운드 작업용으로 컨텍스트를 축소 복사하면서 `userId`/`preferences`/`conversationHistory`만 옮기고 **`sessionModel`을 빠뜨렸습니다.** 일기 생성(`diaryService.generateAndSaveDiary`)은 원본 `context`를 직접 쓰기 때문에 영향 없습니다.

**영향**: 대화 자체는 정상이지만, 매 세션 종료마다 그 대화에서 나온 이야기가 `memories` 테이블에 저장되지 않아, 회상 주제 로테이션(#400)이 계속 "발굴 모드"에만 머물고 `[어르신의 지난 이야기]`가 영구히 비어있게 됨 — 회상요법의 핵심(누적된 기억)이 전혀 작동 안 하는 상태였음.

**수정**: `snapshotForMemoryExtraction()`에 `.sessionModel(context.getSessionModel())` 추가.

## 2. STT 결과가 비어있을 때 "model turn" 400 에러

`Requests ending with a model turn are not supported` (AI 응답 생성 실패)의 원인.

**원인**: Whisper STT가 무음/너무 짧은 녹음에서 빈 문자열을 반환할 수 있는데(`VoiceServiceImpl.speechToText`는 `null`만 체크하고 빈 문자열은 통과시킴), 이게 그대로 `messages` 배열 마지막에 `{role:"user", content:""}`로 들어가면서 일부 프로바이더(Gemini 계열)가 빈 메시지를 버리고 "model 턴으로 끝난다"며 요청을 거부. 세션별 순차 로테이션(#403) 특성상 그 세션에 마침 Gemini가 뽑혔을 때만 재현되어 팀원마다 들쭉날쭉해 보였던 것으로 추정.

**수정**: `ConversationService.processUserMessage`에서 STT 결과가 `isBlank()`면 AI를 호출하지 않고 바로 "다시 한 번 말씀해 주시겠어요?"로 응답. 히스토리에도 빈 user 메시지 대신 `null`을 기록(첫 인사 턴과 동일 패턴).

## 테스트
- `ConversationServiceTest`/`ConversationServiceTest2` 전체 통과 (18/18)
- 스냅샷 sessionModel 회귀 방지 어서션 추가
- 빈 STT → AI 미호출·재요청 응답·히스토리 null 기록 검증 테스트 추가
- 실서버 로그로 두 버그 모두 재현 확인

## 참고 — 같이 발견했지만 별개 사안
- ElevenLabs 401 — 재현 시도 시 정상(200) 응답, 동시 테스트로 인한 일시적 현상으로 추정. 재발하면 다시 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
