### PR TITLE
feat: 빈 STT 재요청 안내를 연속 횟수에 따라 3단계로 에스컬레이션

### DIFF
--- a/server/src/main/java/com/example/echo/context/domain/UserContext.java
+++ b/server/src/main/java/com/example/echo/context/domain/UserContext.java
@@ -43,6 +43,13 @@ public class UserContext {
      */
     private String sessionModel;
 
+    /**
+     * STT 결과가 비어있던(무음·너무 짧은 녹음 등) 연속 횟수.
+     * 알아들을 수 있는 발화가 들어오면 0으로 리셋된다. 연속 횟수에 따라
+     * 재요청 안내 문구를 단계적으로 바꾸는 데 쓰인다([이탈 발화 및 무응답 대응]과 같은 패턴).
+     */
+    private int consecutiveEmptySttCount;
+
     private LocalDateTime lastAccessTime;
     private boolean isActive;
 }

--- a/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
+++ b/server/src/main/java/com/example/echo/conversation/service/ConversationService.java
@@ -36,10 +36,23 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ConversationService {
 
-    // STT 결과가 빈 문자열이면(무음·너무 짧은 녹음) AI를 호출하지 않고 바로 이 안내로 응답한다.
+    // STT 결과가 빈 문자열이면(무음·너무 짧은 녹음) AI를 호출하지 않고 바로 안내로 응답한다.
     // 빈 user 메시지를 그대로 보내면 일부 프로바이더(Gemini 계열)가 "메시지가 model 턴으로
     // 끝난다"며 400을 반환하는 문제가 있어, 애초에 빈 메시지를 만들지 않는 쪽으로 막는다.
-    private static final String EMPTY_STT_FALLBACK_RESPONSE = "죄송해요, 잘 못 들었어요. 다시 한 번 말씀해 주시겠어요?";
+    // 연속 횟수에 따라 문구를 단계적으로 바꾼다 - 시스템 프롬프트의 [이탈 발화 및 무응답 대응]과
+    // 같은 3단계 패턴(1회 재요청 → 2회 화제 전환 제안 → 3회 마무리 유도).
+    private static final String EMPTY_STT_RETRY = "죄송해요, 잘 못 들었어요. 다시 한 번 말씀해 주시겠어요?";
+    private static final String EMPTY_STT_OFFER_TOPIC_SWITCH = "괜찮아요, 천천히 하셔도 돼요. 편하게 다른 이야기 해보셔도 좋아요.";
+    private static final String EMPTY_STT_WRAP_UP = "오늘은 여기까지 이야기 나눌까요? 다음에 또 편하게 말씀해 주세요.";
+
+    private static String emptySttFallbackResponse(int consecutiveCount) {
+        if (consecutiveCount <= 1) {
+            return EMPTY_STT_RETRY;
+        } else if (consecutiveCount == 2) {
+            return EMPTY_STT_OFFER_TOPIC_SWITCH;
+        }
+        return EMPTY_STT_WRAP_UP;
+    }
 
     private final VoiceService voiceService;
     private final PromptService promptService;
@@ -107,11 +120,15 @@ public class ConversationService {
 
         // 3. AI 응답 생성 (OpenAI 권장 방식: messages 배열)
         //    STT 결과가 비어있으면(무음 등) AI를 호출하지 않고 바로 재요청 안내로 응답한다.
+        //    연속 횟수에 따라 문구를 단계적으로 바꾸고, 알아들을 수 있는 발화가 들어오면 리셋한다.
         String aiResponse;
         if (sttEmpty) {
-            log.info("STT 결과가 비어있어 AI 호출 없이 재요청 안내로 응답 - userId: {}", userId);
-            aiResponse = EMPTY_STT_FALLBACK_RESPONSE;
+            context.setConsecutiveEmptySttCount(context.getConsecutiveEmptySttCount() + 1);
+            log.info("STT 결과가 비어있어 AI 호출 없이 안내로 응답 - userId: {}, 연속 {}회",
+                    userId, context.getConsecutiveEmptySttCount());
+            aiResponse = emptySttFallbackResponse(context.getConsecutiveEmptySttCount());
         } else {
+            context.setConsecutiveEmptySttCount(0);
             String systemPrompt = context.getSystemPrompt();
             List<ConversationTurn> history = context.getConversationHistory();
             aiResponse = aiService.generateResponse(systemPrompt, history, userMessage, context.getSessionModel());

--- a/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
+++ b/server/src/test/java/com/example/echo/conversation/service/ConversationServiceTest2.java
@@ -301,7 +301,7 @@ class ConversationServiceTest2 {
         }
 
         @Test
-        @DisplayName("성공: STT 결과가 비어있으면(무음 등) AI를 호출하지 않고 재요청 안내로 응답한다")
+        @DisplayName("성공: STT 결과가 처음 비어있으면(무음 등) AI를 호출하지 않고 1단계 재요청 안내로 응답한다")
         void success_emptySttSkipsAiCallAndAsksToRepeat() {
             // given: 무음/너무 짧은 녹음이라 Whisper가 빈 문자열을 반환하는 상황
             MultipartFile audioFile = new MockMultipartFile(
@@ -328,6 +328,76 @@ class ConversationServiceTest2 {
             // 그리고: 히스토리에는 빈 user 메시지 대신 null이 기록되어야 함
             // (다음 턴에서 이 히스토리가 messages 배열에 실릴 때 빈 메시지가 섞이지 않도록)
             then(contextService).should().addConversationTurn(eq(userId), isNull(), anyString());
+        }
+
+        @Test
+        @DisplayName("성공: STT가 연속 2번 비어있으면 화제 전환을 제안하는 2단계 안내로 바뀐다")
+        void success_secondConsecutiveEmptyStt_offersTopicSwitch() {
+            // given
+            MultipartFile audioFile = new MockMultipartFile(
+                    "audio", "silence.mp3", "audio/mpeg", "silence".getBytes()
+            );
+            given(contextService.getContext(userId)).willReturn(mockContext);
+            given(voiceService.speechToText(audioFile)).willReturn("");
+            given(voiceService.textToSpeech(anyString(), eq(mockVoiceSettings))).willReturn("audio".getBytes());
+
+            // when: 같은 세션에서 연속 2번
+            conversationService.processUserMessage(userId, audioFile);
+            ConversationResponse result = conversationService.processUserMessage(userId, audioFile);
+
+            // then
+            assertThat(result.getAiResponse()).contains("다른 이야기");
+            then(aiService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("성공: STT가 연속 3번 이상 비어있으면 마무리를 유도하는 3단계 안내로 바뀐다")
+        void success_thirdConsecutiveEmptyStt_suggestsWrapUp() {
+            // given
+            MultipartFile audioFile = new MockMultipartFile(
+                    "audio", "silence.mp3", "audio/mpeg", "silence".getBytes()
+            );
+            given(contextService.getContext(userId)).willReturn(mockContext);
+            given(voiceService.speechToText(audioFile)).willReturn("");
+            given(voiceService.textToSpeech(anyString(), eq(mockVoiceSettings))).willReturn("audio".getBytes());
+
+            // when: 같은 세션에서 연속 3번
+            conversationService.processUserMessage(userId, audioFile);
+            conversationService.processUserMessage(userId, audioFile);
+            ConversationResponse result = conversationService.processUserMessage(userId, audioFile);
+
+            // then
+            assertThat(result.getAiResponse()).contains("여기까지");
+        }
+
+        @Test
+        @DisplayName("성공: 중간에 알아들을 수 있는 발화가 들어오면 연속 카운트가 리셋되어 다시 1단계로 돌아간다")
+        void success_understoodSpeechResetsConsecutiveEmptyCount() {
+            // given
+            MultipartFile silentAudio = new MockMultipartFile(
+                    "audio", "silence.mp3", "audio/mpeg", "silence".getBytes()
+            );
+            MultipartFile realAudio = new MockMultipartFile(
+                    "audio", "real.mp3", "audio/mpeg", "real".getBytes()
+            );
+            String systemPrompt = "시스템 프롬프트";
+            String userMessage = "오늘 날씨가 좋네요";
+            mockContext.setSystemPrompt(systemPrompt);
+
+            given(contextService.getContext(userId)).willReturn(mockContext);
+            given(voiceService.speechToText(silentAudio)).willReturn("");
+            given(voiceService.speechToText(realAudio)).willReturn(userMessage);
+            given(aiService.generateResponse(eq(systemPrompt), any(), eq(userMessage), any()))
+                    .willReturn("AI 응답");
+            given(voiceService.textToSpeech(anyString(), eq(mockVoiceSettings))).willReturn("audio".getBytes());
+
+            // when: 무음 1회 → 알아들을 수 있는 발화 1회 → 다시 무음 1회
+            conversationService.processUserMessage(userId, silentAudio);
+            conversationService.processUserMessage(userId, realAudio);
+            ConversationResponse result = conversationService.processUserMessage(userId, silentAudio);
+
+            // then: 리셋되었으므로 2단계가 아니라 다시 1단계 문구여야 함
+            assertThat(result.getAiResponse()).contains("다시 한 번 말씀해");
         }
     }
 


### PR DESCRIPTION
## 요약
#405(빈 STT → AI 미호출 재요청 안내)가 머지된 뒤 추가로 커밋한 내용이 빠져있어 별도 PR로 올립니다. 빈 STT 안내 문구를 고정된 한 문구가 아니라, 연속 횟수에 따라 3단계로 에스컬레이션합니다.

## 배경
고정된 한 문구만 반복하면 무음이 여러 번 겹칠 때(마이크 타이밍 문제, 잘 못 들으심 등) 기계적으로 들릴 수 있어, 시스템 프롬프트의 `[이탈 발화 및 무응답 대응]`과 같은 3단계 패턴을 재사용했습니다.

| 연속 횟수 | 응답 |
|-----------|------|
| 1회 | "죄송해요, 잘 못 들었어요. 다시 한 번 말씀해 주시겠어요?" |
| 2회 | "괜찮아요, 천천히 하셔도 돼요. 편하게 다른 이야기 해보셔도 좋아요." |
| 3회 이상 | "오늘은 여기까지 이야기 나눌까요? 다음에 또 편하게 말씀해 주세요." |

알아들을 수 있는 발화가 들어오면 카운트가 리셋되어, 다음에 또 무음이 나오면 다시 1단계부터 시작합니다.

## 변경
- `UserContext.consecutiveEmptySttCount`: 세션 내 연속 빈 STT 횟수 (systemPrompt/sessionModel과 같은 세션 스코프 상태)
- `ConversationService`: 빈 STT 시 카운트 증가 후 단계별 문구 선택, 정상 STT 시 카운트 리셋
- `ConversationServiceTest2`: 1/2/3단계 및 리셋 동작 검증 테스트 추가

## 테스트
- `ProcessUserMessage` 7/7 통과, 관련 전체 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
