### PR TITLE
chore: OpenRouter 모델 풀을 Sonnet 5 / GPT-5.6 Terra / Haiku 4.5 3개로 축소

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -45,12 +45,9 @@ openrouter:
     url: https://openrouter.ai/api/v1
   chat:
     models:
-      - openai/gpt-5.5
-      - openai/gpt-5.6-terra
       - anthropic/claude-sonnet-5
+      - openai/gpt-5.6-terra
       - anthropic/claude-haiku-4.5
-      - google/gemini-3.6-flash
-      - google/gemini-3.5-flash-lite
     temperature: 0.7
     max-tokens: 1024
 


### PR DESCRIPTION
## 요약
OpenRouter 채팅 모델 풀을 팀 판단에 따라 3개로 축소했습니다.

```yaml
models:
  - anthropic/claude-sonnet-5
  - openai/gpt-5.6-terra
  - anthropic/claude-haiku-4.5
```

## 변경
- `openai/gpt-5.5` 제거 — `gpt-5.6-terra`가 대체(경쟁력 있는 품질에 절반 가격)
- `google/gemini-3.6-flash`, `google/gemini-3.5-flash-lite` 제거

## 참고
Gemini 계열이 로테이션에서 빠지면서, #406에서 다룬 "빈 STT가 Gemini에서만 model-turn 400을 유발하던" 노출 빈도도 자연히 줄어듭니다(다만 #406의 근본 수정 자체는 프로바이더 무관하게 여전히 유효하니 별도로 유지).

## 테스트
- 컴파일 통과 (모델 목록은 설정값이라 기존 단위 테스트는 각자 fixture를 쓰므로 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
