### PR TITLE
chore: ElevenLabs TTS 기본 stability 값 상향 (0.5 -> 0.7)

### DIFF
--- a/server/src/main/java/com/example/echo/voice/provider/ElevenLabsTtsProvider.java
+++ b/server/src/main/java/com/example/echo/voice/provider/ElevenLabsTtsProvider.java
@@ -33,7 +33,7 @@ public class ElevenLabsTtsProvider implements TtsProvider {
     private String model;
 
     private static final ElevenLabsTtsRequest.VoiceParams DEFAULT_VOICE_PARAMS =
-        ElevenLabsTtsRequest.VoiceParams.builder().stability(0.5).similarityBoost(0.75).build();
+        ElevenLabsTtsRequest.VoiceParams.builder().stability(0.7).similarityBoost(0.75).build();
 
     // voiceTone → ElevenLabs voice_settings(stability, similarity_boost) 매핑
     private static final Map<String, ElevenLabsTtsRequest.VoiceParams> TONE_TO_VOICE_PARAMS = Map.of(

--- a/server/src/test/java/com/example/echo/voice/provider/ElevenLabsTtsProviderTest.java
+++ b/server/src/test/java/com/example/echo/voice/provider/ElevenLabsTtsProviderTest.java
@@ -141,4 +141,17 @@ class ElevenLabsTtsProviderTest {
             req.getVoiceSettings().getStability() == 0.7
         ));
     }
+
+    @Test
+    @DisplayName("voiceTone이 없으면 DEFAULT_VOICE_PARAMS(stability=0.7)가 사용됨")
+    void noVoiceTone_usesDefaultVoiceParams() {
+        when(elevenLabsClient.synthesize(any(), any())).thenReturn("audio".getBytes());
+
+        provider.synthesize("테스트", null);
+
+        verify(elevenLabsClient).synthesize(eq("sf8Bpb1IU97NI9BHSMRf"), argThat(req ->
+            req.getVoiceSettings().getStability() == 0.7
+                && req.getVoiceSettings().getSimilarityBoost() == 0.75
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- ElevenLabsTtsProvider의 DEFAULT_VOICE_PARAMS.stability를 0.5 → 0.7로 상향 (voiceTone 미지정/미매칭 시 사용되는 기본값)
- 발화 톤 편차를 줄여 더 일관되고 차분한 음성을 목표로 함 (ElevenLabs 공식 가이드상 0.60~0.85가 "consistent/steady" 구간)
- TONE_TO_VOICE_PARAMS(warm/calm/bright/gentle) 4개 매핑은 이번 변경 대상 아님

## 제외된 범위
- TTS 속도(speed) 조정은 이번 PR에 포함하지 않음: 현재 설정된 모델(eleven_v3)은 ElevenLabs 공식 문서상 speed 파라미터를 지원하지 않음 (v2/turbo v2.5/flash v2.5 등에서만 지원). 모델 전환은 음질/표현력에 영향을 주는 별도 결정이 필요해 스코프 제외.

## Test plan
- [x] `ElevenLabsTtsProviderTest` 전체 통과 (voiceTone 없음 케이스에 stability=0.7 검증 테스트 추가)
- [x] `voice` 패키지 테스트 전체 통과 (`./gradlew test --tests "com.example.echo.voice.*"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXkFLSG8oAsFNJ8JT8ZYGt