### PR TITLE
feat: AI 음성 재생 완료 후 발화 대기 전환에 0.8초 여백 추가

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -245,9 +245,8 @@ class ConversationViewModel(
             }
 
             override fun onPlaybackComplete() {
-                // 재생 완료 → LISTENING + playbackStatus 초기화
+                // 재생 완료 → playbackStatus 초기화 (오디오 자체는 이미 끝났으므로 즉시 반영)
                 isServerRetryInProgress = false
-                transitionTo(ConversationState.Listening)
                 _uiState.update {
                     it.copy(
                         playbackStatus = PlaybackStatus.NONE,
@@ -258,8 +257,16 @@ class ConversationViewModel(
                         isSpeechDetected = false
                     )
                 }
-                // 다음 발화 대기 시작
-                startRecording()
+                // LISTENING 전환 + 다음 발화 대기 시작은 자연스러운 턴 전환 여백을 두고 진행.
+                // 그 사이 endConversation() 등으로 상태가 바뀌었으면(더 이상 Playing이 아니면)
+                // 건너뛴다 - 종료 중인데 뒤늦게 LISTENING으로 되돌리고 마이크를 켜면 안 되므로.
+                viewModelScope.launch {
+                    delay(LISTENING_TRANSITION_DELAY_MS)
+                    if (_uiState.value.conversationState is ConversationState.Playing) {
+                        transitionTo(ConversationState.Listening)
+                        startRecording()
+                    }
+                }
             }
 
             override fun onRetrying(currentAttempt: Int, maxAttempts: Int) {
@@ -1035,6 +1042,11 @@ class ConversationViewModel(
 
         // 녹음 오류 자동 복구 전 대기 시간 (즉시 재시도 시 같은 오류 반복 방지)
         private const val RECORDER_RECOVERY_DELAY_MS = 1000L
+
+        // AI 음성 재생 완료 후 다음 발화 대기(마이크 On) 전 대기 시간
+        // - 재생 종료 즉시 듣기 시작하면 자연스러운 대화 턴 전환 여백이 없어 급하게 느껴짐
+        // - 특히 어르신은 "이제 내 차례"를 인지하고 말을 준비하는 데 시간이 더 필요함
+        private const val LISTENING_TRANSITION_DELAY_MS = 800L
 
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")

--- a/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
@@ -16,6 +16,7 @@ import com.example.graduation_project.data.voice.AudioPlayerManager
 import com.example.graduation_project.data.voice.AudioRecordManager
 import com.example.graduation_project.domain.health.HealthConnectAvailability
 import com.example.graduation_project.domain.health.IHealthRepository
+import com.example.graduation_project.domain.voice.AudioPlayListener
 import com.example.graduation_project.domain.voice.AudioRecordException
 import com.example.graduation_project.domain.voice.AudioRecordListener
 import com.example.graduation_project.domain.voice.AudioRecordState
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -82,6 +84,7 @@ class ConversationViewModelTest {
 
     private lateinit var viewModel: ConversationViewModel
     private val audioRecordListenerSlot: CapturingSlot<AudioRecordListener> = slot()
+    private val audioPlayListenerSlot: CapturingSlot<AudioPlayListener> = slot()
 
     @Before
     fun setUp() {
@@ -106,6 +109,7 @@ class ConversationViewModelTest {
 
         every { mockAudioRecordManager.state } returns mockAudioRecordState
         every { mockAudioRecordManager.setListener(capture(audioRecordListenerSlot)) } just Runs
+        every { mockAudioPlayerManager.setListener(capture(audioPlayListenerSlot)) } just Runs
         every { mockHealthRepository.getAvailability() } returns HealthConnectAvailability.NotSupported
 
         viewModel = ConversationViewModel(
@@ -255,6 +259,49 @@ class ConversationViewModelTest {
             advanceUntilIdle()
 
             // 재생 중에도 대화 종료가 동작해야 함 (기존에는 조용히 무시되던 버그)
+            assertEquals(ConversationState.Ended, viewModel.uiState.value.conversationState)
+        }
+
+    // ===== 재생 완료 후 발화 대기 전환(여백) 테스트 =====
+
+    @Test
+    fun `재생 완료 후 대기 시간이 지나면 Listening으로 전환되고 녹음이 시작된다`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            coEvery { mockRepository.startConversation(any(), any()) } returns
+                ApiResult.Success(ConversationStartResponse(message = "안녕하세요", audioData = "dummy-audio"))
+            viewModel.startConversation()
+            advanceUntilIdle()
+            assertEquals(ConversationState.Playing, viewModel.uiState.value.conversationState)
+
+            // when: 재생 완료 콜백 발생 (실제 재생 종료 시 AudioPlayerManager가 호출하는 것과 동일)
+            audioPlayListenerSlot.captured.onPlaybackComplete()
+            advanceUntilIdle()
+
+            // then: 여백 후 Listening 전환 + 녹음 시작
+            assertEquals(ConversationState.Listening, viewModel.uiState.value.conversationState)
+            verify { mockAudioRecordManager.start() }
+        }
+
+    @Test
+    fun `재생 완료 후 여백 대기 중 endConversation이 호출되면 뒤늦게 Listening으로 되돌아가지 않는다`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            // given: AI가 말하는 중(Playing)
+            coEvery { mockRepository.startConversation(any(), any()) } returns
+                ApiResult.Success(ConversationStartResponse(message = "안녕하세요", audioData = "dummy-audio"))
+            viewModel.startConversation()
+            advanceUntilIdle()
+            assertEquals(ConversationState.Playing, viewModel.uiState.value.conversationState)
+
+            coEvery { mockRepository.endConversation() } returns
+                ApiResult.Success(ConversationEndResponse())
+
+            // when: 재생 완료로 Listening 전환 여백이 예약된 직후, 그 여백이 끝나기 전에 대화 종료
+            audioPlayListenerSlot.captured.onPlaybackComplete()
+            viewModel.endConversation()
+            advanceUntilIdle()
+
+            // then: 지연된 전환이 뒤늦게 실행되어 Ended를 덮어쓰면 안 됨
+            // (종료 중인데 마이크가 다시 켜지는 버그 방지)
             assertEquals(ConversationState.Ended, viewModel.uiState.value.conversationState)
         }
 


### PR DESCRIPTION
## 요약
AI 음성 재생이 끝나자마자 텀 없이 바로 마이크가 켜지고 사용자 응답 대기로 넘어가던 문제를 수정했습니다. 재생 완료 후 **0.8초 여백**을 두고 LISTENING 전환 + 녹음 시작이 이뤄지도록 변경했습니다.

## 배경
자연스러운 대화에서도 상대가 말을 마친 직후 바로 대답을 기대하지는 않습니다. 특히 MCI(경도인지장애) 어르신은 "이제 내 차례"임을 인지하고 말을 준비하는 데 더 많은 시간이 필요한데, 기존 코드는 `onPlaybackComplete()`에서 지연 없이 즉시 `startRecording()`을 호출해 급하게 느껴졌습니다.

## 변경
- `ConversationViewModel.onPlaybackComplete`: `LISTENING_TRANSITION_DELAY_MS`(800ms) 만큼 지연 후 `transitionTo(Listening)` + `startRecording()` 실행
- `playbackStatus` 등 오디오 자체와 직결된 상태는 즉시 리셋(재생이 실제로 끝난 사실은 바로 반영), **대화 흐름 전환만** 지연
- **레이스 컨디션 방지**: 지연 도중 `endConversation()` 등으로 상태가 바뀌면(더 이상 `Playing`이 아니면) 지연된 전환을 건너뜀 — 종료 중인데 뒤늦게 LISTENING으로 되돌리고 마이크를 켜는 버그 방지 (기존 `RECORDER_RECOVERY_DELAY_MS` 처리와 동일한 패턴)

## 테스트
- `AudioPlayListener` capture 추가해 실제 `onPlaybackComplete()` 콜백을 테스트에서 트리거하도록 인프라 보강 (기존 테스트는 상태를 직접 강제 설정해 이 콜백 경로를 검증하지 못했음)
- 정상 전환(재생 완료 → 여백 후 Listening + 녹음 시작) 테스트 추가
- 레이스 가드(여백 중 종료 호출 시 Ended 유지) 테스트 추가
- `ConversationViewModelTest` 16/16 통과 (기존 14 + 신규 2)
- 코루틴 가상시간(`StandardTestDispatcher`) 덕분에 기존 테스트는 변경 없이 그대로 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
