### PR TITLE
feat: 응답 대기 중에도 AI 발화 텍스트 화면에 유지

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -243,10 +243,15 @@ private fun StateTextSection(
     )
 
     val subText = when {
-        state is ConversationState.Playing && !currentAiMessage.isNullOrBlank() ->
-            currentAiMessage.take(80) + if (currentAiMessage.length > 80) "…" else ""
+        // 사용자 실시간 발화 텍스트가 있으면 최우선 표시
         state is ConversationState.Listening && !currentUserSpeech.isNullOrBlank() ->
             currentUserSpeech
+        // AI가 마지막으로 한 말: 재생 중뿐 아니라 응답을 기다리는 동안(Listening, Recording)에도 유지
+        !currentAiMessage.isNullOrBlank() &&
+            (state is ConversationState.Playing ||
+                state is ConversationState.Listening ||
+                state is ConversationState.Recording) ->
+            currentAiMessage
         else -> null
     }
 


### PR DESCRIPTION
## Summary
- Playing 상태에서만 보이던 AI 발화 텍스트를 Listening/Recording 상태에서도 유지
- 80자 절단(`take(80) + "…"`) 제거, 전문 표시 (화면은 이미 스크롤 가능)
- `currentUserSpeech` 우선순위는 기존과 동일하게 유지

## Test plan
- [ ] `./gradlew compileLocalDebugKotlin` 빌드 확인 (완료)
- [ ] 실기기/에뮬레이터에서 대화 진행: AI 응답 재생 후 Listening 상태로 넘어가도 방금 들은 문장이 화면에 남아있는지 확인
- [ ] 긴 AI 응답이 잘리지 않고 줄바꿈되는지 확인
- [ ] 가로모드에서 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXsQioRik83RRqae3TPLcN