### PR TITLE
chore: OpenRouter 모델 풀에 GPT-5.5 다시 추가

### DIFF
--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ openrouter:
       - anthropic/claude-sonnet-5
       - openai/gpt-5.6-terra
       - anthropic/claude-haiku-4.5
+      - openai/gpt-5.5
     temperature: 0.7
     max-tokens: 1024
 


### PR DESCRIPTION
## 요약
OpenRouter 채팅 모델 풀에 `openai/gpt-5.5`를 다시 추가해 4개 구성으로 변경했습니다.

```yaml
models:
  - anthropic/claude-sonnet-5
  - openai/gpt-5.6-terra
  - anthropic/claude-haiku-4.5
  - openai/gpt-5.5
```

## 테스트
- 컴파일 통과 (모델 목록은 설정값이라 단위 테스트는 각자 fixture를 쓰므로 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
