### PR TITLE
fix: 대화 시작 실패 시 홈 화면으로 자동 복귀

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationScreen.kt
@@ -114,6 +114,15 @@ fun ConversationScreen(
         }
     }
 
+    // 대화 시작 실패 시 에러 메시지를 잠깐 보여준 뒤 홈으로 복귀
+    LaunchedEffect(uiState.startFailed) {
+        if (uiState.startFailed) {
+            delay(2000L)
+            viewModel.consumeStartFailedEvent()
+            onBack()
+        }
+    }
+
     // 자동 시작은 화면당 1회만. 권한 다이얼로그로 content가 컴포지션에서 빠졌다가
     // 다시 들어오거나(설정 왕복), 회전으로 컴포지션이 재생성돼도 재발화하지 않도록
     // 플래그를 권한 게이트 "바깥"에 둔다.

--- a/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/conversation/ConversationViewModel.kt
@@ -443,6 +443,7 @@ class ConversationViewModel(
                     // Sending → Idle
                     transitionTo(ConversationState.Idle)
                     handleApiError(result.exception)
+                    _uiState.update { it.copy(startFailed = true) }
                 }
             }
         }
@@ -738,6 +739,14 @@ class ConversationViewModel(
      */
     fun dismissError() {
         _uiState.update { it.copy(errorMessage = null, currentError = null) }
+    }
+
+    /**
+     * 대화 시작 실패로 인한 홈 복귀 이벤트를 처리 완료로 표시합니다.
+     * - ConversationScreen에서 홈으로 복귀하기 직전 호출
+     */
+    fun consumeStartFailedEvent() {
+        _uiState.update { it.copy(startFailed = false) }
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/presentation/model/ConversationUiState.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/model/ConversationUiState.kt
@@ -59,6 +59,7 @@ data class MessageUiModel(
  * @param userRetryCount 사용자 재시도 버튼 클릭 횟수 (네트워크/서버 오류)
  * @param isRetryButtonEnabled 재시도 버튼 활성화 여부
  * @param showContactSupport 고객센터 연결 버튼 표시 여부 (재시도 3회 초과)
+ * @param startFailed 대화 시작 실패 여부 (true면 화면이 잠시 후 홈으로 복귀)
  * @param showFarewellDialog 종료 확인 다이얼로그 표시 여부
  */
 data class ConversationUiState(
@@ -85,6 +86,8 @@ data class ConversationUiState(
     val userRetryCount: Int = 0,
     val isRetryButtonEnabled: Boolean = false,
     val showContactSupport: Boolean = false,
+    // 대화 시작 실패 → 홈 복귀 (1회성 이벤트, 소비 후 false로 리셋)
+    val startFailed: Boolean = false,
     // 종료 다이얼로그
     val showFarewellDialog: Boolean = false,
     // 음성 감지 여부 (VAD)

--- a/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/presentation/conversation/ConversationViewModelTest.kt
@@ -49,6 +49,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -195,6 +197,44 @@ class ConversationViewModelTest {
             advanceUntilIdle()
 
             assertEquals(ConversationState.Idle, viewModel.uiState.value.conversationState)
+        }
+
+    @Test
+    fun `startConversation 실패 시 startFailed가 true가 된다`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            coEvery { mockRepository.startConversation(any(), any()) } returns
+                ApiResult.Error(ApiException.NetworkError())
+
+            viewModel.startConversation()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.startFailed)
+        }
+
+    @Test
+    fun `consumeStartFailedEvent 호출 시 startFailed가 false로 리셋된다`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            coEvery { mockRepository.startConversation(any(), any()) } returns
+                ApiResult.Error(ApiException.NetworkError())
+
+            viewModel.startConversation()
+            advanceUntilIdle()
+            viewModel.consumeStartFailedEvent()
+
+            assertFalse(viewModel.uiState.value.startFailed)
+        }
+
+    @Test
+    fun `sendMessage 실패 시에는 startFailed가 true로 바뀌지 않는다`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            setupListeningState()
+            coEvery { mockRepository.sendMessage(any()) } returns
+                ApiResult.Error(ApiException.NetworkError())
+
+            viewModel.sendMessage(ByteArray(0))
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.startFailed)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- `startConversation()`이 서버/네트워크 오류(NetworkError/ServerError/ClientError/UnknownError 전체)로 실패하면, 상태만 `Idle`로 되돌아갈 뿐 화면 전환이 없어 탭바 없는 `ConversationScreen`에 그대로 남던 문제를 수정
- `ConversationUiState`에 1회성 이벤트 플래그 `startFailed`를 추가하고, `ConversationScreen`에서 이를 감지해 에러 메시지를 잠깐 보여준 뒤(2초) 자동으로 홈 화면으로 복귀(`onBack()`)하도록 구현
- 화면 최초 진입 시(자동 시작 전 기본값이 Idle) 잘못 튕겨나가지 않도록, `conversationState is Idle` 대신 시작 실패 전용 플래그를 사용
- 범위: `startConversation()` 실패만 대상. `sendMessage()` 등 대화 중간 오류는 기존 동작(Listening 복구, 화면 유지) 그대로 유지

## Test plan
- [x] `./gradlew testProdDebugUnitTest --tests "*.ConversationViewModelTest"` 통과 (신규 테스트 3개 포함)
- [x] `./gradlew assembleDebug lintVitalProdRelease` 통과
- [ ] 실기기/에뮬레이터에서 서버 다운 상태로 "대화 시작" 탭 → 에러 스낵바 노출 후 홈 화면(하단 탭바 포함)으로 자동 복귀하는지 수동 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013npGehrwc5TwdWxHdsompQ