### PR TITLE
chore: OpenRouter 모델을 terra 단일 모델로 고정

### DIFF
--- a/server/src/main/java/com/example/echo/ai/service/AIService.java
+++ b/server/src/main/java/com/example/echo/ai/service/AIService.java
@@ -2,17 +2,17 @@
  * AI 응답 생성 서비스
  *
  * 역할: OpenRouter API를 호출하여 AI 응답 생성
- * - generateGreeting(): 대화 시작 시 첫 인사 생성 (오늘의 로테이션 모델을 음성으로 안내하는 문장 포함)
+ * - generateGreeting(): 대화 시작 시 첫 인사 생성
  * - generateResponse(): 사용자 메시지에 대한 응답 생성
  *
  * 데이터 흐름:
  *   PromptService에서 조합된 프롬프트(String) 수신
  *   → OpenRouter Chat Completion API 호출 (모델은 대화 세션 시작 시 ModelRotationService가
- *     1회 순차 선택해 UserContext.sessionModel에 저장, 세션 내내 재사용)
+ *     UserContext.sessionModel에 저장해 세션 내내 재사용)
  *   → 응답 텍스트 반환
  *
  * 설정값 (application.yaml):
- *   - openrouter.chat.models: 로테이션 후보 모델 목록
+ *   - openrouter.chat.models: 사용할 모델 (단일 모델 고정)
  *   - openrouter.chat.temperature: 창의성 (0.7)
  *   - openrouter.chat.max-tokens: 최대 토큰 (1024)
  */
@@ -38,10 +38,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AIService {
 
-    private static final String MODEL_ANNOUNCEMENT_FORMAT = "이번에는 %s 모델과 함께 대화를 나눠요. ";
-
     private final OpenRouterClient openRouterClient;
-    private final ModelRotationService modelRotationService;
     private final OpenRouterChatProperties chatProperties;
 
     /**
@@ -81,10 +78,9 @@ public class AIService {
         try {
             ChatCompletionResponse response = openRouterClient.createChatCompletion(request);
             String greeting = extractContent(response);
-            String announcedGreeting = String.format(MODEL_ANNOUNCEMENT_FORMAT, modelRotationService.displayName(model)) + greeting;
 
-            log.debug("Generated greeting - length: {}", announcedGreeting.length());
-            return announcedGreeting;
+            log.debug("Generated greeting - length: {}", greeting.length());
+            return greeting;
         } catch (FeignException e) {
             log.error("OpenRouter API 호출 실패 - 상태코드: {}, 메시지: {}", e.status(), e.getMessage());
             throw new AIException("AI 인사 생성 실패: " + e.getMessage(), e);

--- a/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
+++ b/server/src/main/java/com/example/echo/ai/service/ModelRotationService.java
@@ -44,29 +44,4 @@ public class ModelRotationService {
         log.info("OpenRouter 이번 세션 모델(순차 로테이션): {}", picked);
         return picked;
     }
-
-    /**
-     * 모델 ID를 사람이 읽기 좋은(음성으로 발화 가능한) 이름으로 반환한다.
-     * 예: "anthropic/claude-sonnet-5" -> "Claude Sonnet 5", "openai/gpt-5.5" -> "GPT 5.5"
-     */
-    public String displayName(String modelId) {
-        String slug = modelId.contains("/") ? modelId.substring(modelId.indexOf('/') + 1) : modelId;
-        String[] parts = slug.split("-");
-
-        StringBuilder displayName = new StringBuilder();
-        for (String part : parts) {
-            if (displayName.length() > 0) {
-                displayName.append(' ');
-            }
-            displayName.append("gpt".equalsIgnoreCase(part) ? "GPT" : capitalize(part));
-        }
-        return displayName.toString();
-    }
-
-    private static String capitalize(String word) {
-        if (word.isEmpty()) {
-            return word;
-        }
-        return Character.toUpperCase(word.charAt(0)) + word.substring(1);
-    }
 }

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -39,16 +39,13 @@ openai:
     model: whisper-1
     language: ko
 
-# OpenRouter (채팅 전용) - 대화 세션마다 아래 목록에서 순서대로 하나씩 선택됨 (ModelRotationService)
+# OpenRouter (채팅 전용) - 단일 모델(terra)로 고정
 openrouter:
   api:
     url: https://openrouter.ai/api/v1
   chat:
     models:
-      - anthropic/claude-sonnet-5
       - openai/gpt-5.6-terra
-      - anthropic/claude-haiku-4.5
-      - openai/gpt-5.5
     temperature: 0.7
     max-tokens: 1024
 

--- a/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/AIServiceTest.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,9 +39,6 @@ class AIServiceTest {
 
     @Mock
     private OpenRouterClient openRouterClient;
-
-    @Mock
-    private ModelRotationService modelRotationService;
 
     private AIService aiService;
 
@@ -55,13 +51,11 @@ class AIServiceTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(modelRotationService.displayName(TEST_MODEL)).thenReturn("Claude Sonnet 5");
-
         OpenRouterChatProperties chatProperties = new OpenRouterChatProperties();
         chatProperties.setTemperature(0.7);
         chatProperties.setMaxTokens(1024);
 
-        aiService = new AIService(openRouterClient, modelRotationService, chatProperties);
+        aiService = new AIService(openRouterClient, chatProperties);
 
         context = UserContext.builder()
                 .userId(1L)
@@ -104,7 +98,7 @@ class AIServiceTest {
         String result = aiService.generateGreeting(systemPrompt, context);
 
         // Then
-        assertThat(result).isEqualTo("이번에는 Claude Sonnet 5 모델과 함께 대화를 나눠요. 안녕하세요! 오늘 하루는 어떠셨어요?");
+        assertThat(result).isEqualTo("안녕하세요! 오늘 하루는 어떠셨어요?");
 
         // 메시지 구조 검증
         ArgumentCaptor<ChatCompletionRequest> captor = ArgumentCaptor.forClass(ChatCompletionRequest.class);

--- a/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
+++ b/server/src/test/java/com/example/echo/ai/service/ModelRotationServiceTest.java
@@ -73,16 +73,4 @@ class ModelRotationServiceTest {
         ModelRotationService fresh = service(MODELS);
         assertThat(fresh.pickModelForSession()).isEqualTo(MODELS.get(0));
     }
-
-    @Test
-    @DisplayName("displayName - 후보 5개 모두 음성으로 자연스러운 표시 이름으로 변환")
-    void displayName_forEachCandidate() {
-        ModelRotationService service = service(MODELS);
-
-        assertThat(service.displayName("openai/gpt-5.5")).isEqualTo("GPT 5.5");
-        assertThat(service.displayName("anthropic/claude-sonnet-5")).isEqualTo("Claude Sonnet 5");
-        assertThat(service.displayName("google/gemini-3.1-flash-lite")).isEqualTo("Gemini 3.1 Flash Lite");
-        assertThat(service.displayName("anthropic/claude-haiku-4.5")).isEqualTo("Claude Haiku 4.5");
-        assertThat(service.displayName("openai/gpt-4o-mini")).isEqualTo("GPT 4o Mini");
-    }
 }


### PR DESCRIPTION
## Summary
- 여러 모델을 세션마다 로테이션하던 방식을 그만두고, `openai/gpt-5.6-terra` 하나만 쓰도록 고정
- 대화 시작 인사에서 "이번에는 OO 모델과 함께 대화를 나눠요" 식으로 모델명을 음성 안내하던 로직 제거
- 더 이상 쓰이지 않는 `ModelRotationService.displayName()` / `capitalize()` 및 관련 테스트 삭제

## Test plan
- [x] `AIServiceTest`, `ModelRotationServiceTest`, `ConversationServiceTest`, `ConversationServiceTest2` 통과 확인
- [ ] 배포 후 대화 시작 시 모델명 안내 문구 없이 인사가 나오는지 실제 통화로 확인