### PR TITLE
fix: STT 환각(hallucination) 응답 방지 - 트리밍/최소길이·에너지/신뢰도/백스톱 필터

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/voice/VoiceRecordingManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/voice/VoiceRecordingManager.kt
@@ -182,9 +182,20 @@ class VoiceRecordingManager(
         audioBuffer.reset()
         isSpeechActive = false
 
+        // 발화 종료 후 붙은 무음 꼬리 제거 (VAD hangover로 인해 최대 silenceDurationMs만큼
+        // 무음이 함께 쌓이므로, STT 환각 방지를 위해 전송 전에 잘라낸다)
+        val trimmedPcmData = WavConverter.trimTrailingSilence(
+            pcmData = pcmData,
+            sampleRate = config.sampleRate,
+            frameSizeBytes = config.frameSize * 2,
+            thresholdDbfs = config.silenceTrimThresholdDbfs,
+            paddingMs = config.silenceTrimPaddingMs
+        )
+        Log.d(TAG, "finalizeSpeech() - trimmed PCM data size: ${trimmedPcmData.size} bytes")
+
         // PCM → WAV 변환
         val wavData = WavConverter.pcmToWav(
-            pcmData = pcmData,
+            pcmData = trimmedPcmData,
             sampleRate = config.sampleRate,
             channels = VadConfig.CHANNELS_MONO,
             bitsPerSample = VadConfig.BITS_PER_SAMPLE

--- a/android/app/src/main/java/com/example/graduation_project/data/voice/WavConverter.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/voice/WavConverter.kt
@@ -3,6 +3,9 @@ package com.example.graduation_project.data.voice
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.ceil
+import kotlin.math.log10
+import kotlin.math.sqrt
 
 /**
  * PCM → WAV 변환 유틸리티
@@ -11,6 +14,7 @@ import java.nio.ByteOrder
 object WavConverter {
 
     private const val WAV_HEADER_SIZE = 44
+    private const val MAX_16BIT_AMPLITUDE = 32768.0
 
     /**
      * PCM 데이터를 WAV 포맷으로 변환
@@ -63,6 +67,76 @@ object WavConverter {
     ): ByteArray {
         val byteData = shortArrayToByteArray(pcmData)
         return pcmToWav(byteData, sampleRate, channels, 16)
+    }
+
+    /**
+     * 발화 종료 후 뒤에 붙은 무음 꼬리를 잘라낸다.
+     *
+     * Silero VAD의 hangover(silenceDurationMs)로 인해 실제 발화가 끝난 뒤에도
+     * 무음 구간이 그대로 버퍼에 쌓이는데, 이렇게 정보량이 적은 오디오를 그대로
+     * STT에 넘기면 환각(hallucination) 응답을 유발하기 쉽다.
+     * VAD의 isSpeech() 값은 이미 hangover로 스무딩되어 있어 트리밍에 쓸 수 없으므로,
+     * 원본 PCM에서 프레임 단위로 에너지(dBFS)를 다시 계산해 뒤쪽 무음만 잘라낸다.
+     *
+     * @param pcmData 16-bit PCM raw bytes (little endian)
+     * @param sampleRate 샘플 레이트 (Hz)
+     * @param frameSizeBytes 프레임 크기 (bytes) - VAD 프레임 크기와 동일하게 맞춤
+     * @param thresholdDbfs 이 값 미만이면 무음으로 판정 (dBFS)
+     * @param paddingMs 마지막 유효 프레임 뒤에 남겨둘 여유 시간 (어미 보존용)
+     * @return 트리밍된 PCM 데이터. 전체가 임계값 미만이면(엣지 케이스) 원본을 그대로 반환한다.
+     */
+    fun trimTrailingSilence(
+        pcmData: ByteArray,
+        sampleRate: Int,
+        frameSizeBytes: Int,
+        thresholdDbfs: Double,
+        paddingMs: Int
+    ): ByteArray {
+        if (frameSizeBytes <= 0 || pcmData.size < frameSizeBytes) {
+            return pcmData
+        }
+
+        val frameCount = pcmData.size / frameSizeBytes
+        var lastLoudFrame = -1
+        for (i in frameCount - 1 downTo 0) {
+            val start = i * frameSizeBytes
+            if (frameDbfs(pcmData, start, start + frameSizeBytes) >= thresholdDbfs) {
+                lastLoudFrame = i
+                break
+            }
+        }
+
+        // 전체가 임계값 미만이면 과도하게 잘라내지 않고 원본 유지
+        if (lastLoudFrame == -1) {
+            return pcmData
+        }
+
+        val samplesPerFrame = frameSizeBytes / 2
+        val frameDurationMs = samplesPerFrame.toDouble() / sampleRate * 1000
+        val paddingFrames = ceil(paddingMs / frameDurationMs).toInt()
+
+        val keepFrames = (lastLoudFrame + 1 + paddingFrames).coerceAtMost(frameCount)
+        val keepBytes = keepFrames * frameSizeBytes
+        return if (keepBytes >= pcmData.size) pcmData else pcmData.copyOf(keepBytes)
+    }
+
+    /**
+     * 16-bit PCM 프레임 구간의 RMS 에너지를 dBFS로 계산
+     */
+    private fun frameDbfs(data: ByteArray, start: Int, end: Int): Double {
+        var sumOfSquares = 0.0
+        var sampleCount = 0
+        var i = start
+        while (i + 1 < end) {
+            val sample = ((data[i + 1].toInt() shl 8) or (data[i].toInt() and 0xFF)).toShort()
+            sumOfSquares += sample.toDouble() * sample.toDouble()
+            sampleCount++
+            i += 2
+        }
+        if (sampleCount == 0) return Double.NEGATIVE_INFINITY
+        val rms = sqrt(sumOfSquares / sampleCount)
+        if (rms <= 0.0) return Double.NEGATIVE_INFINITY
+        return 20.0 * log10(rms / MAX_16BIT_AMPLITUDE)
     }
 
     /**

--- a/android/app/src/main/java/com/example/graduation_project/domain/voice/VadConfig.kt
+++ b/android/app/src/main/java/com/example/graduation_project/domain/voice/VadConfig.kt
@@ -58,7 +58,23 @@ data class VadConfig(
      * - AGGRESSIVE: 소음이 많은 환경
      * - VERY_AGGRESSIVE: 매우 시끄러운 환경
      */
-    val mode: VadMode = VadMode.NORMAL
+    val mode: VadMode = VadMode.NORMAL,
+
+    /**
+     * 발화 종료 후 무음 꼬리 트리밍 임계값 (dBFS)
+     *
+     * Silero VAD의 isSpeech()는 silenceDurationMs 동안 hangover로 스무딩되어
+     * true를 반환하므로, 실제 발화가 끝난 뒤에도 무음이 버퍼에 함께 쌓임.
+     * WAV로 변환하기 직전 원본 PCM에서 프레임별 에너지를 다시 계산해
+     * 이 값 미만인 뒤쪽 구간을 잘라낸다. (STT 환각 방지)
+     */
+    val silenceTrimThresholdDbfs: Double = DEFAULT_SILENCE_TRIM_THRESHOLD_DBFS,
+
+    /**
+     * 무음 트리밍 시 마지막 유효 프레임 뒤에 남겨둘 여유 시간 (ms)
+     * 어미가 잘리지 않도록 약간의 여유를 둠
+     */
+    val silenceTrimPaddingMs: Int = DEFAULT_SILENCE_TRIM_PADDING_MS
 ) {
     companion object {
         // 샘플 레이트
@@ -88,6 +104,12 @@ data class VadConfig(
 
         /** AI 응답 후 녹음 시작까지의 대기 시간: 1.5초 */
         const val DEFAULT_POST_RESPONSE_DELAY_MS = 1500L
+
+        /** 기본 무음 트리밍 임계값: -40dBFS (일반적인 무음 판정 기준) */
+        const val DEFAULT_SILENCE_TRIM_THRESHOLD_DBFS = -40.0
+
+        /** 기본 무음 트리밍 여유 시간: 300ms (어미 보존) */
+        const val DEFAULT_SILENCE_TRIM_PADDING_MS = 300
     }
 }
 

--- a/android/app/src/test/java/com/example/graduation_project/data/voice/WavConverterTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/voice/WavConverterTest.kt
@@ -1,0 +1,113 @@
+package com.example.graduation_project.data.voice
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * WavConverter.trimTrailingSilence 검증
+ *
+ * STT 환각(hallucination) 방지를 위해, 발화 종료 후 VAD hangover로 인해
+ * 버퍼에 쌓인 무음 꼬리를 잘라내는 로직을 테스트한다.
+ */
+class WavConverterTest {
+
+    private val sampleRate = 16000
+    private val samplesPerFrame = 512
+    private val frameSizeBytes = samplesPerFrame * 2 // 16-bit PCM
+    private val thresholdDbfs = -40.0
+
+    /** frameDurationMs = 512 / 16000 * 1000 = 32ms */
+    private val frameDurationMs = samplesPerFrame.toDouble() / sampleRate * 1000
+
+    @Test
+    fun `trailing silence frames are trimmed`() {
+        val loudFrames = repeatFrame(loudFrame(), 5)
+        val silenceFrames = repeatFrame(silenceFrame(), 20)
+        val pcmData = loudFrames + silenceFrames
+
+        val result = WavConverter.trimTrailingSilence(
+            pcmData = pcmData,
+            sampleRate = sampleRate,
+            frameSizeBytes = frameSizeBytes,
+            thresholdDbfs = thresholdDbfs,
+            paddingMs = 0
+        )
+
+        assertEquals(loudFrames.size, result.size)
+        assertArrayEquals(loudFrames, result)
+    }
+
+    @Test
+    fun `padding after last loud frame is preserved`() {
+        val loudFrames = repeatFrame(loudFrame(), 5)
+        val silenceFrames = repeatFrame(silenceFrame(), 20)
+        val pcmData = loudFrames + silenceFrames
+        val paddingMs = (frameDurationMs * 3).toInt() // 3프레임 분량
+
+        val result = WavConverter.trimTrailingSilence(
+            pcmData = pcmData,
+            sampleRate = sampleRate,
+            frameSizeBytes = frameSizeBytes,
+            thresholdDbfs = thresholdDbfs,
+            paddingMs = paddingMs
+        )
+
+        assertEquals((5 + 3) * frameSizeBytes, result.size)
+    }
+
+    @Test
+    fun `short silence in the middle of an utterance is preserved`() {
+        val pcmData = repeatFrame(loudFrame(), 3) +
+            repeatFrame(silenceFrame(), 2) +
+            repeatFrame(loudFrame(), 3)
+
+        val result = WavConverter.trimTrailingSilence(
+            pcmData = pcmData,
+            sampleRate = sampleRate,
+            frameSizeBytes = frameSizeBytes,
+            thresholdDbfs = thresholdDbfs,
+            paddingMs = 0
+        )
+
+        // 마지막 프레임이 발화이므로 트리밍 대상이 없어 원본 그대로 유지
+        assertArrayEquals(pcmData, result)
+    }
+
+    @Test
+    fun `entirely silent audio is not over-trimmed`() {
+        val pcmData = repeatFrame(silenceFrame(), 10)
+
+        val result = WavConverter.trimTrailingSilence(
+            pcmData = pcmData,
+            sampleRate = sampleRate,
+            frameSizeBytes = frameSizeBytes,
+            thresholdDbfs = thresholdDbfs,
+            paddingMs = 300
+        )
+
+        assertArrayEquals(pcmData, result)
+    }
+
+    private fun repeatFrame(frame: ByteArray, count: Int): ByteArray {
+        val result = ByteArray(frame.size * count)
+        for (i in 0 until count) {
+            frame.copyInto(result, destinationOffset = i * frame.size)
+        }
+        return result
+    }
+
+    /** 최대 진폭에 가까운(또렷한 발화를 흉내낸) 프레임 */
+    private fun loudFrame(): ByteArray = makeFrame(amplitude = 20000)
+
+    /** 진폭이 0인(무음) 프레임 */
+    private fun silenceFrame(): ByteArray = makeFrame(amplitude = 0)
+
+    private fun makeFrame(amplitude: Short): ByteArray {
+        val buffer = ByteBuffer.allocate(frameSizeBytes).order(ByteOrder.LITTLE_ENDIAN)
+        repeat(samplesPerFrame) { buffer.putShort(amplitude) }
+        return buffer.array()
+    }
+}

--- a/server/src/main/java/com/example/echo/voice/dto/WhisperTranscriptionResponse.java
+++ b/server/src/main/java/com/example/echo/voice/dto/WhisperTranscriptionResponse.java
@@ -3,11 +3,30 @@ WhisperTranscriptionResponse: OpenAI 답장 받는 그릇
 */
 package com.example.echo.voice.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
 public class WhisperTranscriptionResponse {
     private String text;
+
+    // response_format=verbose_json일 때만 채워짐 (신뢰도 기반 환각 필터링에 사용)
+    private List<Segment> segments;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Segment {
+        @JsonProperty("no_speech_prob")
+        private double noSpeechProb;
+
+        @JsonProperty("avg_logprob")
+        private double avgLogprob;
+
+        @JsonProperty("compression_ratio")
+        private double compressionRatio;
+    }
 }

--- a/server/src/main/java/com/example/echo/voice/service/VoiceServiceImpl.java
+++ b/server/src/main/java/com/example/echo/voice/service/VoiceServiceImpl.java
@@ -20,8 +20,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -41,6 +45,35 @@ public class VoiceServiceImpl implements VoiceService {
 
     @Value("${tts.provider:elevenlabs}")
     private String ttsProvider;
+
+    // [STT 환각 방지] 오디오가 이보다 짧고(ms) 동시에 이보다 조용하면(dBFS) 사실상 빈 오디오로 보고 Whisper 호출을 건너뜀
+    @Value("${openai.whisper.min-duration-ms:300}")
+    private long minDurationMs;
+
+    @Value("${openai.whisper.min-energy-dbfs:-45.0}")
+    private double minEnergyDbfs;
+
+    // [STT 환각 방지] Whisper 공식 CLI가 자체 디코딩에서 쓰는 기본 임계값과 동일
+    @Value("${openai.whisper.no-speech-threshold:0.6}")
+    private double noSpeechThreshold;
+
+    @Value("${openai.whisper.logprob-threshold:-1.0}")
+    private double logprobThreshold;
+
+    @Value("${openai.whisper.compression-ratio-threshold:2.4}")
+    private double compressionRatioThreshold;
+
+    // [STT 환각 방지] Whisper가 정보량 적은 오디오에서 유튜브 자막체로 수렴하는, 잘 알려진 환각 문구 백스톱 필터
+    private static final Set<String> KNOWN_HALLUCINATION_PHRASES = Set.of(
+            "시청해주셔서 감사합니다",
+            "구독과 좋아요 부탁드립니다",
+            "구독과 좋아요 눌러주세요",
+            "다음 영상에서 만나요",
+            "다음 시간에 만나요",
+            "이 영상이 도움이 되셨다면 구독과 좋아요 부탁드립니다"
+    );
+
+    private static final int WAV_HEADER_SIZE = 44;
 
     public VoiceServiceImpl(STTClient sttClient, List<TtsProvider> ttsProviders) {
         this.sttClient = sttClient;
@@ -65,25 +98,41 @@ public class VoiceServiceImpl implements VoiceService {
         // 1. 검증
         validateAudioFile(audioFile);
 
+        // 2. [STT 환각 방지] 사실상 빈 오디오(짧고 동시에 조용함)면 Whisper 호출 자체를 건너뜀
+        if (isEffectivelySilent(audioFile)) {
+            log.info("오디오 길이/에너지 기준 미달로 STT 호출을 건너뜀 - {} bytes", audioFile.getSize());
+            return "";
+        }
+
         try {
-            // 2. API 호출
+            // 3. API 호출 (신뢰도 지표를 받기 위해 verbose_json 사용)
             WhisperTranscriptionResponse response = sttClient.transcribe(
                     audioFile,
                     whisperModel,
                     defaultLanguage,
-                    "json"
+                    "verbose_json"
             );
 
-            // 3. 응답 확인
+            // 4. 응답 확인
             if (response == null || response.getText() == null) {
                 throw new VoiceProcessingException("Whisper API 응답이 비어있습니다.");
             }
 
-            log.info("STT 변환 완료: {} bytes -> {} chars",
-                    audioFile.getSize(),
-                    response.getText().length());
+            // 5. [STT 환각 방지] Whisper 자체 신뢰도 지표로 필터링
+            if (isLowConfidence(response)) {
+                return "";
+            }
 
-            return response.getText();
+            // 6. [STT 환각 방지] 알려진 환각 문구 백스톱 필터
+            String text = response.getText();
+            if (isKnownHallucinationPhrase(text)) {
+                log.info("알려진 STT 환각 문구 감지 - 필터링: {}", text);
+                return "";
+            }
+
+            log.info("STT 변환 완료: {} bytes -> {} chars", audioFile.getSize(), text.length());
+
+            return text;
 
         } catch (VoiceProcessingException e) {
             throw e;
@@ -91,6 +140,102 @@ public class VoiceServiceImpl implements VoiceService {
             log.error("STT 처리 중 오류 발생: {}", e.getMessage(), e);
             throw new VoiceProcessingException("음성을 텍스트로 변환하는 중 오류가 발생했습니다.", e);
         }
+    }
+
+    /**
+     * [STT 환각 방지] 오디오가 최소 길이(minDurationMs) 미만이면서 동시에
+     * 최소 에너지(minEnergyDbfs) 미만이면 사실상 빈 오디오로 판정한다.
+     * AND 조건인 이유: "네!"처럼 짧지만 또렷한 정상 발화까지 길이만으로 걸러지는 걸 방지하기 위함.
+     * WAV 포맷일 때만 판정하며(헤더 구조가 달라 오탐 방지), 그 외 포맷은 그대로 통과시킨다.
+     */
+    private boolean isEffectivelySilent(MultipartFile audioFile) {
+        String contentType = audioFile.getContentType();
+        if (contentType == null || !isWavContentType(contentType)) {
+            return false;
+        }
+
+        try {
+            byte[] bytes = audioFile.getBytes();
+            if (bytes.length <= WAV_HEADER_SIZE) {
+                return true;
+            }
+
+            ByteBuffer header = ByteBuffer.wrap(bytes, 0, WAV_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+            int sampleRate = header.getInt(24);
+            short bitsPerSample = header.getShort(34);
+            if (sampleRate <= 0 || bitsPerSample != 16) {
+                return false; // 예상 못한 포맷 - 판단하지 않고 통과
+            }
+
+            int dataSize = bytes.length - WAV_HEADER_SIZE;
+            double durationMs = (dataSize / 2.0) / sampleRate * 1000;
+            double energyDbfs = calculateRmsDbfs(bytes, WAV_HEADER_SIZE, bytes.length);
+
+            return durationMs < minDurationMs && energyDbfs < minEnergyDbfs;
+        } catch (IOException e) {
+            log.warn("오디오 길이/에너지 계산 실패 - 필터링 없이 진행: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private double calculateRmsDbfs(byte[] bytes, int start, int end) {
+        long sumOfSquares = 0;
+        int sampleCount = 0;
+        for (int i = start; i + 1 < end; i += 2) {
+            short sample = (short) ((bytes[i + 1] << 8) | (bytes[i] & 0xFF));
+            sumOfSquares += (long) sample * sample;
+            sampleCount++;
+        }
+        if (sampleCount == 0) {
+            return Double.NEGATIVE_INFINITY;
+        }
+        double rms = Math.sqrt((double) sumOfSquares / sampleCount);
+        if (rms <= 0.0) {
+            return Double.NEGATIVE_INFINITY;
+        }
+        return 20.0 * Math.log10(rms / 32768.0);
+    }
+
+    private boolean isWavContentType(String contentType) {
+        return contentType.equals("audio/wav") ||
+                contentType.equals("audio/x-wav") ||
+                contentType.equals("audio/wave");
+    }
+
+    /**
+     * [STT 환각 방지] Whisper 공식 CLI가 자체 디코딩에서 쓰는 기본 임계값과 동일한 기준으로,
+     * verbose_json 응답의 세그먼트별 신뢰도 지표를 종합해 환각 여부를 판정한다.
+     */
+    private boolean isLowConfidence(WhisperTranscriptionResponse response) {
+        List<WhisperTranscriptionResponse.Segment> segments = response.getSegments();
+        if (segments == null || segments.isEmpty()) {
+            return false;
+        }
+
+        double maxNoSpeechProb = segments.stream()
+                .mapToDouble(WhisperTranscriptionResponse.Segment::getNoSpeechProb)
+                .max().orElse(0.0);
+        double minAvgLogprob = segments.stream()
+                .mapToDouble(WhisperTranscriptionResponse.Segment::getAvgLogprob)
+                .min().orElse(0.0);
+        double maxCompressionRatio = segments.stream()
+                .mapToDouble(WhisperTranscriptionResponse.Segment::getCompressionRatio)
+                .max().orElse(0.0);
+
+        boolean noSpeechAndLowConfidence = maxNoSpeechProb > noSpeechThreshold && minAvgLogprob < logprobThreshold;
+        boolean repetitive = maxCompressionRatio > compressionRatioThreshold;
+
+        if (noSpeechAndLowConfidence || repetitive) {
+            log.info("STT 신뢰도 필터링 발동 - no_speech_prob: {}, avg_logprob: {}, compression_ratio: {}",
+                    maxNoSpeechProb, minAvgLogprob, maxCompressionRatio);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isKnownHallucinationPhrase(String text) {
+        String normalized = text.strip().replaceAll("[.!?~,\\s]+$", "");
+        return KNOWN_HALLUCINATION_PHRASES.contains(normalized);
     }
 
     /*

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -38,6 +38,12 @@ openai:
   whisper:
     model: whisper-1
     language: ko
+    # [STT 환각 방지] 아래는 모두 기본값 - 필요 시 환경별로 override
+    min-duration-ms: 300
+    min-energy-dbfs: -45.0
+    no-speech-threshold: 0.6
+    logprob-threshold: -1.0
+    compression-ratio-threshold: 2.4
 
 # OpenRouter (채팅 전용) - 단일 모델(terra)로 고정
 openrouter:

--- a/server/src/test/java/com/example/echo/voice/service/VoiceServiceImplTest.java
+++ b/server/src/test/java/com/example/echo/voice/service/VoiceServiceImplTest.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +52,46 @@ class VoiceServiceImplTest {
         ReflectionTestUtils.setField(voiceService, "whisperModel", "whisper-1");
         ReflectionTestUtils.setField(voiceService, "defaultLanguage", "ko");
         ReflectionTestUtils.setField(voiceService, "ttsProvider", "elevenlabs");
+        ReflectionTestUtils.setField(voiceService, "minDurationMs", 300L);
+        ReflectionTestUtils.setField(voiceService, "minEnergyDbfs", -45.0);
+        ReflectionTestUtils.setField(voiceService, "noSpeechThreshold", 0.6);
+        ReflectionTestUtils.setField(voiceService, "logprobThreshold", -1.0);
+        ReflectionTestUtils.setField(voiceService, "compressionRatioThreshold", 2.4);
+    }
+
+    /** 44바이트 표준 PCM WAV 헤더 + 지정한 진폭의 무음/발화를 흉내낸 PCM 데이터를 생성 */
+    private static byte[] buildWavBytes(int sampleRate, int durationMs, short amplitude) {
+        int numSamples = sampleRate * durationMs / 1000;
+        int dataSize = numSamples * 2; // 16-bit mono
+        int byteRate = sampleRate * 2;
+
+        ByteBuffer buffer = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.put("RIFF".getBytes());
+        buffer.putInt(36 + dataSize);
+        buffer.put("WAVE".getBytes());
+        buffer.put("fmt ".getBytes());
+        buffer.putInt(16);
+        buffer.putShort((short) 1);
+        buffer.putShort((short) 1);
+        buffer.putInt(sampleRate);
+        buffer.putInt(byteRate);
+        buffer.putShort((short) 2);
+        buffer.putShort((short) 16);
+        buffer.put("data".getBytes());
+        buffer.putInt(dataSize);
+        for (int i = 0; i < numSamples; i++) {
+            buffer.putShort(amplitude);
+        }
+        return buffer.array();
+    }
+
+    private static WhisperTranscriptionResponse.Segment buildSegment(
+            double noSpeechProb, double avgLogprob, double compressionRatio) {
+        WhisperTranscriptionResponse.Segment segment = new WhisperTranscriptionResponse.Segment();
+        ReflectionTestUtils.setField(segment, "noSpeechProb", noSpeechProb);
+        ReflectionTestUtils.setField(segment, "avgLogprob", avgLogprob);
+        ReflectionTestUtils.setField(segment, "compressionRatio", compressionRatio);
+        return segment;
     }
 
     // ========== STT 테스트 ==========
@@ -69,7 +111,7 @@ class VoiceServiceImplTest {
             WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
             ReflectionTestUtils.setField(response, "text", "안녕하세요");
 
-            when(sttClient.transcribe(any(), eq("whisper-1"), eq("ko"), eq("json")))
+            when(sttClient.transcribe(any(), eq("whisper-1"), eq("ko"), eq("verbose_json")))
                     .thenReturn(response);
 
             // When
@@ -188,7 +230,7 @@ class VoiceServiceImplTest {
         @DisplayName("wav 형식 파일도 정상 처리")
         void wavFormat_success() {
             MockMultipartFile wavFile = new MockMultipartFile(
-                    "file", "test.wav", "audio/wav", "fake-wav".getBytes()
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
             );
 
             WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
@@ -199,6 +241,131 @@ class VoiceServiceImplTest {
             String result = voiceService.speechToText(wavFile);
 
             assertThat(result).isEqualTo("테스트");
+        }
+
+        // ===== [STT 환각 방지] 최소 길이/에너지 사전 체크 =====
+
+        @Test
+        @DisplayName("짧고 동시에 조용한 WAV(사실상 빈 오디오)는 Whisper 호출 없이 빈 문자열 반환")
+        void tooShortAndTooQuietWav_skipsSttCall() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 100, (short) 0)
+            );
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEmpty();
+            verify(sttClient, never()).transcribe(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("짧지만 또렷하고 큰 소리인 WAV는 길이만으로 걸러지지 않고 Whisper까지 호출됨")
+        void shortButLoudWav_stillCallsStt() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 100, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "네");
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEqualTo("네");
+            verify(sttClient, times(1)).transcribe(any(), any(), any(), any());
+        }
+
+        // ===== [STT 환각 방지] verbose_json 신뢰도 필터링 =====
+
+        @Test
+        @DisplayName("no_speech_prob가 높고 avg_logprob가 낮으면 환각으로 판단해 빈 문자열 반환")
+        void highNoSpeechProbAndLowLogprob_filteredAsHallucination() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "시청해주셔서 감사합니다");
+            ReflectionTestUtils.setField(response, "segments", List.of(buildSegment(0.9, -2.0, 1.0)));
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("compression_ratio가 높으면(반복 패턴) 환각으로 판단해 빈 문자열 반환")
+        void highCompressionRatio_filteredAsHallucination() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "네네네네네네네네네네");
+            ReflectionTestUtils.setField(response, "segments", List.of(buildSegment(0.1, -0.2, 3.0)));
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("신뢰도 지표가 정상 범위면 필터링되지 않고 텍스트 그대로 반환")
+        void normalConfidence_notFiltered() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "안녕하세요");
+            ReflectionTestUtils.setField(response, "segments", List.of(buildSegment(0.05, -0.3, 1.2)));
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEqualTo("안녕하세요");
+        }
+
+        // ===== [STT 환각 방지] 알려진 환각 문구 백스톱 필터 =====
+
+        @Test
+        @DisplayName("알려진 환각 문구와 정확히 일치하면 빈 문자열 반환")
+        void knownHallucinationPhrase_filtered() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "시청해주셔서 감사합니다.");
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("어르신의 정상적인 짧은 인사(감사합니다)는 백스톱 필터에 걸리지 않음")
+        void legitimateThanksReply_notFiltered() {
+            MockMultipartFile wavFile = new MockMultipartFile(
+                    "file", "test.wav", "audio/wav", buildWavBytes(16000, 1000, (short) 20000)
+            );
+
+            WhisperTranscriptionResponse response = new WhisperTranscriptionResponse();
+            ReflectionTestUtils.setField(response, "text", "감사합니다");
+
+            when(sttClient.transcribe(any(), any(), any(), any())).thenReturn(response);
+
+            String result = voiceService.speechToText(wavFile);
+
+            assertThat(result).isEqualTo("감사합니다");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- 짧은 발화("안녕" 등) 뒤에 STT가 "시청해주셔서 감사합니다" 같은 엉뚱한 텍스트를 뱉는 Whisper 환각(hallucination) 문제 대응. 모델 교체(`whisper-1` → `gpt-4o-transcribe`)는 이번 스코프에서 제외하고, 아래 4가지 방어선만 적용:
  1. **클라이언트**: Silero VAD의 `silenceDurationMs` hangover로 인해 발화 종료 후 붙는 무음 꼬리를, WAV 변환 직전 프레임 단위 에너지(dBFS)를 다시 계산해 트리밍 (`WavConverter.trimTrailingSilence`)
  2. **서버**: 오디오가 300ms 미만 **이고 동시에** -45dBFS 미만이면(AND 조건) Whisper 호출 자체를 스킵 — 짧지만 또렷한 정상 발화("네!" 등)가 길이만으로 걸러지는 회귀를 피하기 위해 OR가 아닌 AND로 설계
  3. **서버**: `response_format`을 `json` → `verbose_json`으로 전환해, Whisper 공식 CLI가 자체 디코딩에서 쓰는 기본 임계값(`no_speech_prob>0.6 && avg_logprob<-1.0`, `compression_ratio>2.4`)과 동일한 기준으로 저신뢰도 결과 필터링
  4. **서버**: 알려진 환각 문구("시청해주셔서 감사합니다" 등) 완전일치 백스톱 필터 (부분 문자열 매칭은 사용 안 함 - "감사합니다" 같은 정상 인사 오탐 방지)
- 위 필터링으로 반환되는 빈 문자열은 기존 무음(`sttEmpty`) 재요청 안내 흐름(`ConversationService`)에 그대로 흡수되므로 해당 서비스는 수정하지 않음.

## Test plan
- [x] `server`: `VoiceServiceImplTest`에 신규 케이스 추가 (짧고 조용한 오디오 스킵, 짧지만 큰 오디오는 정상 호출, 신뢰도 필터링, 백스톱 문구 필터링, 정상 응답 회귀 방지) — `./gradlew test` 통과
- [x] `android`: `WavConverterTest` 신규 (무음 꼬리 트리밍, 패딩 보존, 발화 중간 짧은 무음 보존, 전체 무음 과잉 트리밍 방지) — `./gradlew testLocalDebugUnitTest` 통과
- [x] `server`: `./gradlew build` 통과
- [ ] 실기기/에뮬레이터에서 짧은 발화 시나리오 재현 확인 (리뷰어 검증 필요)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ev2cV41uxMfZwqKk48qyHg