### PR TITLE
fix: 실내 GPS 오차로 집이 외출로 오분류되던 버그 수정

### DIFF
--- a/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/api/UserApi.kt
@@ -4,6 +4,7 @@ import com.example.graduation_project.data.model.*
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT
+import retrofit2.http.Query
 
 interface UserApi {
 
@@ -27,6 +28,12 @@ interface UserApi {
 
     @PUT("/api/users/me/preferences/home-location")
     suspend fun updateHomeLocation(@Body request: HomeLocationUpdateRequest): UserPreferences
+
+    @GET("/api/users/me/preferences/home-location/address")
+    suspend fun previewHomeAddress(
+        @Query("latitude") latitude: Double,
+        @Query("longitude") longitude: Double
+    ): HomeAddressPreview
 
     @PUT("/api/users/me/preferences/family-info")
     suspend fun updateFamilyInfo(@Body request: FamilyInfoUpdateRequest): UserPreferences

--- a/android/app/src/main/java/com/example/graduation_project/data/location/LocationManager.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/location/LocationManager.kt
@@ -9,6 +9,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
@@ -24,6 +25,10 @@ class LocationManager @VisibleForTesting internal constructor(
         private const val TAG = "LocationManager"
         // 집 등록은 사용자가 한 번 누르는 액션이라 정확도를 위해 여유 있게 대기
         private const val LOCATION_TIMEOUT_MS = 15_000L
+
+        // 집 등록용 다중 샘플링 설정 - 실내 GPS 오차(단발 측정 시 100m+ 흔함)를 평균으로 줄인다
+        private const val HOME_REGISTRATION_SAMPLE_COUNT = 3
+        private const val HOME_REGISTRATION_SAMPLE_DELAY_MS = 1_000L
     }
 
     @SuppressLint("MissingPermission")
@@ -53,6 +58,46 @@ class LocationManager @VisibleForTesting internal constructor(
             Log.w(TAG, "getCurrentLocation null (타임아웃 ${LOCATION_TIMEOUT_MS}ms 또는 미가용) → lastLocation 폴백")
         }
         return location ?: getLastKnownLocation()
+    }
+
+    /**
+     * 집 등록 전용: GPS를 여러 번 찍어 평균 낸 위치를 반환한다.
+     *
+     * 단발 측정([getCurrentLocation])은 실내에서 100m 이상 오차가 흔해, 집 좌표를 기준으로
+     * 방문지를 집/외출로 분류할 때(HOME_MATCH_RADIUS_METERS) 오분류를 유발할 수 있다.
+     * 집 등록은 사용자가 버튼을 한 번 누르는 저빈도 액션이므로, 몇 초 더 기다리더라도
+     * 여러 샘플을 평균 내 오차를 줄이는 쪽이 낫다.
+     */
+    suspend fun getAveragedCurrentLocation(
+        sampleCount: Int = HOME_REGISTRATION_SAMPLE_COUNT,
+        sampleDelayMs: Long = HOME_REGISTRATION_SAMPLE_DELAY_MS
+    ): Location? {
+        val samples = mutableListOf<Location>()
+        repeat(sampleCount) { index ->
+            getCurrentLocation()?.let { samples.add(it) }
+            if (index < sampleCount - 1) {
+                delay(sampleDelayMs)
+            }
+        }
+
+        Log.d(TAG, "getAveragedCurrentLocation - 유효 샘플 ${samples.size}/${sampleCount}개")
+        return averageLocations(samples)
+    }
+
+    private fun averageLocations(samples: List<Location>): Location? {
+        if (samples.isEmpty()) return null
+        if (samples.size == 1) return samples[0]
+
+        val avgLatitude = samples.sumOf { it.latitude } / samples.size
+        val avgLongitude = samples.sumOf { it.longitude } / samples.size
+        val avgAccuracy = samples.map { it.accuracy }.average().toFloat()
+
+        return Location("averaged").apply {
+            latitude = avgLatitude
+            longitude = avgLongitude
+            accuracy = avgAccuracy
+            time = System.currentTimeMillis()
+        }
     }
 
     @SuppressLint("MissingPermission")

--- a/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/model/UserModels.kt
@@ -43,6 +43,10 @@ data class LocationUpdateRequest(val location: String?)
 @Serializable
 data class HomeLocationUpdateRequest(val latitude: Double, val longitude: Double)
 
+/** 집 등록 직후 확인용 - 측정 좌표를 역지오코딩한 결과 (저장은 하지 않음) */
+@Serializable
+data class HomeAddressPreview(val placeName: String? = null, val address: String? = null)
+
 @Serializable
 data class FamilyInfoUpdateRequest(val familyInfo: String?)
 

--- a/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/example/graduation_project/data/repository/UserRepository.kt
@@ -27,6 +27,9 @@ class UserRepository(
     suspend fun updateHomeLocation(latitude: Double, longitude: Double): ApiResult<UserPreferences> =
         safeApiCall { userApi.updateHomeLocation(HomeLocationUpdateRequest(latitude, longitude)) }
 
+    suspend fun previewHomeAddress(latitude: Double, longitude: Double): ApiResult<HomeAddressPreview> =
+        safeApiCall { userApi.previewHomeAddress(latitude, longitude) }
+
     suspend fun updateFamilyInfo(familyInfo: String?): ApiResult<UserPreferences> =
         safeApiCall { userApi.updateFamilyInfo(FamilyInfoUpdateRequest(familyInfo)) }
 

--- a/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/example/graduation_project/presentation/settings/SettingsViewModel.kt
@@ -437,9 +437,9 @@ class SettingsViewModel(
         }
         viewModelScope.launch {
             _uiState.update { it.copy(isRegisteringHome = true) }
-            android.util.Log.d("SettingsVM", "집 등록: 현재 위치 요청 시작")
+            android.util.Log.d("SettingsVM", "집 등록: 현재 위치 요청 시작 (평균 측정)")
             val location = com.example.graduation_project.data.location.LocationManager(context)
-                .getCurrentLocation()
+                .getAveragedCurrentLocation()
             if (location == null) {
                 android.util.Log.w("SettingsVM", "집 등록: 위치 null (getCurrentLocation + lastLocation 모두 실패)")
                 _uiState.update {
@@ -452,11 +452,23 @@ class SettingsViewModel(
             }
             android.util.Log.d("SettingsVM", "집 등록: 위치 획득 (${location.latitude}, ${location.longitude}) → 서버 저장")
             when (val result = userRepository.updateHomeLocation(location.latitude, location.longitude)) {
-                is ApiResult.Success -> _uiState.update {
-                    applyPrefs(it, result.data).copy(
-                        isRegisteringHome = false,
-                        savedMessage = "현재 위치를 집으로 등록했습니다"
-                    )
+                is ApiResult.Success -> {
+                    // 등록된 주소를 보여줘서 실내 GPS 오차로 엉뚱한 곳이 등록됐는지 바로 확인할 수 있게 함
+                    // (조회 전용 API라 실패해도 등록 자체는 이미 성공한 것으로 처리)
+                    val addressPreview = userRepository.previewHomeAddress(location.latitude, location.longitude)
+                    val addressText = (addressPreview as? ApiResult.Success)?.data
+                        ?.let { it.placeName ?: it.address }
+
+                    _uiState.update {
+                        applyPrefs(it, result.data).copy(
+                            isRegisteringHome = false,
+                            savedMessage = if (addressText != null) {
+                                "현재 위치를 집으로 등록했습니다: $addressText"
+                            } else {
+                                "현재 위치를 집으로 등록했습니다"
+                            }
+                        )
+                    }
                 }
                 is ApiResult.Error -> {
                     android.util.Log.w("SettingsVM", "집 등록: 서버 저장 실패 - ${result.exception.message}")

--- a/android/app/src/test/java/com/example/graduation_project/data/location/LocationManagerTest.kt
+++ b/android/app/src/test/java/com/example/graduation_project/data/location/LocationManagerTest.kt
@@ -99,7 +99,69 @@ class LocationManagerTest {
             verify(exactly = 1) { mockFusedClient.lastLocation }
         }
 
+    // ===== 4. 집 등록용 다중 샘플 평균 =====
+
+    @Test
+    fun `getAveragedCurrentLocation 성공 시 위도경도 평균 반환`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val sample1 = realLocation(37.5665, 126.9780)
+            val sample2 = realLocation(37.5666, 126.9781)
+            val sample3 = realLocation(37.5664, 126.9779)
+            stubCurrentLocationSequence(sample1, sample2, sample3)
+            stubLastLocation(successResult = null)
+
+            val result = locationManager.getAveragedCurrentLocation(sampleCount = 3, sampleDelayMs = 1_000L)
+
+            assertEquals(37.5665, result?.latitude ?: 0.0, 0.0001)
+            assertEquals(126.9780, result?.longitude ?: 0.0, 0.0001)
+            verify(exactly = 3) { mockFusedClient.getCurrentLocation(any<Int>(), any<CancellationToken>()) }
+        }
+
+    @Test
+    fun `getAveragedCurrentLocation 일부 샘플 실패해도 유효한 샘플만으로 평균`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val sample1 = realLocation(37.5665, 126.9780)
+            val sample3 = realLocation(37.5667, 126.9782)
+            stubCurrentLocationSequence(sample1, null, sample3)
+            stubLastLocation(successResult = null)
+
+            val result = locationManager.getAveragedCurrentLocation(sampleCount = 3, sampleDelayMs = 1_000L)
+
+            assertEquals(37.5666, result?.latitude ?: 0.0, 0.0001)
+        }
+
+    @Test
+    fun `getAveragedCurrentLocation 모든 샘플 실패 시 null 반환`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            stubCurrentLocationSequence(null, null, null)
+            stubLastLocation(successResult = null)
+
+            val result = locationManager.getAveragedCurrentLocation(sampleCount = 3, sampleDelayMs = 1_000L)
+
+            assertNull(result)
+        }
+
     // ===== 헬퍼 =====
+
+    private fun realLocation(lat: Double, lng: Double): Location {
+        val location = mockk<Location>()
+        every { location.latitude } returns lat
+        every { location.longitude } returns lng
+        return location
+    }
+
+    private fun stubCurrentLocationSequence(vararg results: Location?) {
+        val tasks = results.map { result ->
+            val task = mockk<Task<Location>>()
+            every { task.addOnSuccessListener(any<OnSuccessListener<Location>>()) } answers {
+                firstArg<OnSuccessListener<Location>>().onSuccess(result)
+                task
+            }
+            every { task.addOnFailureListener(any()) } returns task
+            task
+        }
+        every { mockFusedClient.getCurrentLocation(any<Int>(), any<CancellationToken>()) } returnsMany tasks
+    }
 
     private fun stubCurrentLocation(successResult: Location?) {
         val task = mockk<Task<Location>>()

--- a/server/src/main/java/com/example/echo/location/service/LocationService.java
+++ b/server/src/main/java/com/example/echo/location/service/LocationService.java
@@ -33,8 +33,11 @@ public class LocationService {
      * 거주지(집) 판정 반경 (미터)
      * - 방문 장소의 좌표가 등록된 집 좌표로부터 이 거리 이내이면 "집"으로 분류한다.
      * - 앱의 체류 판정 반경(50m) + GPS 오차/센트로이드 편차를 고려해 넉넉히 잡는다.
+     * - 150m였을 때 실내 GPS 오차(집 등록 시 단발 측정 오차 + StayPoint centroid 표류가 겹치면
+     *   흔히 100~200m대)로 인해 실제로 집에 있었는데도 "외출"로 오분류되는 버그가 있었음 → 250m로 상향.
+     *   너무 크게 잡으면 반대로 아파트 단지 내 짧은 외출까지 "집"으로 삼켜버릴 수 있어 무한정 키우지는 않는다.
      */
-    private static final double HOME_MATCH_RADIUS_METERS = 150.0;
+    private static final double HOME_MATCH_RADIUS_METERS = 250.0;
 
     /**
      * 원시 위치 데이터를 보강된 위치 데이터로 변환 (집 좌표 없이 - 모두 외출로 취급)

--- a/server/src/main/java/com/example/echo/user/controller/UserController.java
+++ b/server/src/main/java/com/example/echo/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.example.echo.user.controller;
 
 import com.example.echo.common.auth.CurrentUser;
+import com.example.echo.location.dto.GeocodingResult;
+import com.example.echo.location.service.GeocodingService;
 import com.example.echo.user.dto.*;
 import com.example.echo.user.service.UserService;
 import jakarta.validation.Valid;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final GeocodingService geocodingService;
 
     @GetMapping("/preferences")
     public ResponseEntity<UserPreferences> getPreferences(@CurrentUser Long userId) {
@@ -47,6 +50,18 @@ public class UserController {
             @Valid @RequestBody HomeLocationUpdateRequest request) {
         return ResponseEntity.ok(
                 userService.updateHomeLocation(userId, request.getLatitude(), request.getLongitude()));
+    }
+
+    /**
+     * 집 등록 직후 확인용 - 측정된 좌표를 역지오코딩해 사람이 읽을 수 있는 주소로 보여준다.
+     * 저장은 하지 않는다(조회 전용). 실내 GPS 오차로 엉뚱한 곳이 등록됐을 때
+     * 사용자가 바로 알아차릴 수 있게 하기 위함.
+     */
+    @GetMapping("/preferences/home-location/address")
+    public ResponseEntity<GeocodingResult> previewHomeAddress(
+            @RequestParam Double latitude,
+            @RequestParam Double longitude) {
+        return ResponseEntity.ok(geocodingService.reverseGeocode(latitude, longitude));
     }
 
     @PutMapping("/preferences/family-info")

--- a/server/src/test/java/com/example/echo/location/service/LocationServiceHomeClassificationTest.java
+++ b/server/src/test/java/com/example/echo/location/service/LocationServiceHomeClassificationTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.lenient;
 /**
  * 방문 장소의 집/외출 분류(isHome) 검증.
  *
- * 등록된 집 좌표와 방문 좌표의 Haversine 거리가 판정 반경(150m) 이내이면 집으로 분류된다.
+ * 등록된 집 좌표와 방문 좌표의 Haversine 거리가 판정 반경(250m) 이내이면 집으로 분류된다.
  * 체류 30분 미만으로 잡아 날씨 조회(WeatherClient)를 타지 않게 해 mock을 최소화한다.
  */
 @ExtendWith(MockitoExtension.class)
@@ -81,13 +81,26 @@ class LocationServiceHomeClassificationTest {
     @DisplayName("집 좌표에서 먼 방문(다른 동네) → isHome = false")
     void visitFarFromHome_isHomeFalse() {
         stubGeocoding();
-        // 위도 +0.0035 ≈ 약 390m → 150m 밖
+        // 위도 +0.0035 ≈ 약 390m → 250m 밖
         RawLocationData raw = rawWithVisit(HOME_LAT + 0.0035, HOME_LNG + 0.0100);
 
         LocationData result = locationService.enrichLocationData(raw, HOME_LAT, HOME_LNG);
 
         VisitedPlace place = result.getVisitedPlaces().get(0);
         assertThat(place.isHome()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회귀 방지: 실내 GPS 오차 수준(~200m) 방문 → isHome = true (150m 기준이었다면 외출로 오분류됐음)")
+    void visitWithinIndoorGpsErrorMargin_isHomeTrue() {
+        stubGeocoding();
+        // 위도 +0.0018 ≈ 약 200m → 250m 이내지만 이전 기준(150m)이었다면 외출로 오분류됐을 거리
+        RawLocationData raw = rawWithVisit(HOME_LAT + 0.0018, HOME_LNG);
+
+        LocationData result = locationService.enrichLocationData(raw, HOME_LAT, HOME_LNG);
+
+        VisitedPlace place = result.getVisitedPlaces().get(0);
+        assertThat(place.isHome()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary
집에 있었는데도 방문 장소가 "외출"로 분류되어 "OO를 다녀오셨네요?"라고 묻는 버그를 수정했습니다.

**원인**
1. "현재 위치를 집으로 등록"이 GPS를 한 번만 찍어서 저장 — 실내에서는 100m 이상 오차가 흔함
2. `LocationService.HOME_MATCH_RADIUS_METERS`(150m)가 그 오차를 못 버텨냄

**수정**
- `LocationManager.getAveragedCurrentLocation()` 추가 — 집 등록 시에만 GPS를 3회(1초 간격) 측정해 평균 좌표 사용, 랜덤 오차를 줄임
- `HOME_MATCH_RADIUS_METERS`를 150m → 250m로 상향 (실내 GPS 오차를 더 넉넉히 흡수, 너무 크게 잡진 않음 — 아파트 단지 내 짧은 외출까지 삼키지 않도록)
- 집 등록 직후 측정 좌표를 역지오코딩해 사용자에게 주소를 보여주는 조회 전용 API(`GET /preferences/home-location/address`) 추가 — 저장은 그대로 하되, 엉뚱한 곳이 등록됐으면 스낵바 메시지로 바로 알아차리고 재등록(버튼 다시 탭)할 수 있음

## Test plan
- [x] `LocationServiceHomeClassificationTest` — 250m 반경 검증 + 회귀 방지 테스트(150m였다면 오분류됐을 ~200m 방문이 이제 isHome=true) 통과
- [x] `PromptServiceTest` 통과 (반경 변경에 따른 회귀 없음)
- [x] 서버/안드로이드 모두 컴파일 성공
- [ ] `LocationManagerTest`의 새 `getAveragedCurrentLocation` 테스트는 로컬 샌드박스의 사전 존재 이슈(Android Log/Location 스텁 미mock — 기존 테스트도 동일하게 실패)로 로컬에서 실행 검증은 못 했음. Android Studio나 CI에서 확인 필요
- [ ] 실제 기기로 실내에서 집 등록 → 대화 시작해 "집" 정상 판정되는지 확인